### PR TITLE
Add initial notebook data structure

### DIFF
--- a/lib/live_book/notebook.ex
+++ b/lib/live_book/notebook.ex
@@ -11,18 +11,15 @@ defmodule LiveBook.Notebook do
   A notebook is divided into a set of isolated *sections*.
   """
 
-  defstruct [:metadata, :sections]
+  defstruct [:name, :version, :sections, :metadata]
 
   alias LiveBook.Notebook.Section
 
   @type t :: %__MODULE__{
-          metadata: metadata(),
-          sections: list(Section.t())
-        }
-
-  @type metadata :: %{
           name: String.t(),
-          version: String.t()
+          version: String.t(),
+          sections: list(Section.t()),
+          metadata: %{atom() => term()}
         }
 
   @version "1.0"
@@ -33,11 +30,10 @@ defmodule LiveBook.Notebook do
   @spec new() :: t()
   def new() do
     %__MODULE__{
-      metadata: %{
-        name: "Untitled notebook",
-        version: @version
-      },
-      sections: []
+      name: "Untitled notebook",
+      version: @version,
+      sections: [],
+      metadata: %{}
     }
   end
 end

--- a/lib/live_book/notebook/cell.ex
+++ b/lib/live_book/notebook/cell.ex
@@ -7,7 +7,7 @@ defmodule LiveBook.Notebook.Cell do
   and may potentially produce some output (e.g. during code execution).
   """
 
-  defstruct [:id, :metadata, :type, :source, :outputs]
+  defstruct [:id, :type, :source, :outputs, :metadata]
 
   alias LiveBook.Utils
 
@@ -16,14 +16,12 @@ defmodule LiveBook.Notebook.Cell do
 
   @type t :: %__MODULE__{
           id: cell_id(),
-          metadata: metadata(),
           type: cell_type(),
           source: String.t(),
           # TODO: expand on this
-          outputs: list()
+          outputs: list(),
+          metadata: %{atom() => term()}
         }
-
-  @type metadata :: %{}
 
   @doc """
   Returns an empty cell of the given type.
@@ -32,10 +30,10 @@ defmodule LiveBook.Notebook.Cell do
   def new(type) do
     %__MODULE__{
       id: Utils.random_id(),
-      metadata: %{},
       type: type,
       source: "",
-      outputs: []
+      outputs: [],
+      metadata: %{}
     }
   end
 end

--- a/lib/live_book/notebook/section.ex
+++ b/lib/live_book/notebook/section.ex
@@ -6,7 +6,7 @@ defmodule LiveBook.Notebook.Section do
   in the sense that cells don't interfere with cells in other sections.
   """
 
-  defstruct [:id, :metadata, :cells]
+  defstruct [:id, :name, :cells, :metadata]
 
   alias LiveBook.Notebook.Cell
   alias LiveBook.Utils
@@ -15,12 +15,9 @@ defmodule LiveBook.Notebook.Section do
 
   @type t :: %__MODULE__{
           id: section_id(),
-          metadata: metadata(),
-          cells: list(Cell.t())
-        }
-
-  @type metadata :: %{
-          name: String.t()
+          name: String.t(),
+          cells: list(Cell.t()),
+          metadata: %{atom() => term()}
         }
 
   @doc """
@@ -30,10 +27,9 @@ defmodule LiveBook.Notebook.Section do
   def new() do
     %__MODULE__{
       id: Utils.random_id(),
-      metadata: %{
-        name: "Section"
-      },
-      cells: []
+      name: "Section",
+      cells: [],
+      metadata: %{}
     }
   end
 end


### PR DESCRIPTION
Notes:

1. When prototyping I stored `session_data` on cells (for keeping OT changes; whether the cell has been executed; etc). Conceptually this is ephemeral session data, so thinking about it, it would be cleaner to store such metadata on session-level (e.g. a map from cell id to session data).
2. We can distinguish cell types either by using a `:type` attribute or have a separate structs like `Cell.Elixir`, `Cell.Markdown`. One one hand markdown cells are simple and we will probably store them as annotations as per @jonklein's draft, on the other the cells have many similarities. For now I went with `:type`, but happy to hears opinions on that.
3. The structs have random ids, so we can easily drop them when storing the file and generate new ids upon import.