### PR TITLE
Clear undo/redo stack upon receiving a concurrent delta

### DIFF
--- a/assets/js/editor/monaco_editor_adapter.js
+++ b/assets/js/editor/monaco_editor_adapter.js
@@ -34,8 +34,17 @@ export default class MonacoEditorAdapter {
   applyDelta(delta) {
     const operations = this.__deltaToEditorOperations(delta);
     this.ignoreChange = true;
-    this.editor.getModel().pushEditOperations([], operations);
+    // Apply the operations without adding them to the undo stack
+    this.editor.getModel().applyEdits(operations);
     this.ignoreChange = false;
+
+    // Clear the undo/redo stack as the operations may no longer be valid
+    // after applying the concurrent change.
+    // Note: there's not public method for getting EditStack for the text model,
+    // so we use the private attribute.
+    // (https://github.com/microsoft/vscode/blob/11ac71b27220a2354b6bb28966ed3ead183cc495/src/vs/editor/common/model/textModel.ts#L287)
+    const editStack = this.editor.getModel()._commandManager;
+    editStack.clear();
   }
 
   __deltaFromEditorChange(event) {


### PR DESCRIPTION
I've been looking into options regarding proper undo/redo within the collaborative editor. There's pretty much no public editor API for transforming the stack and  even with hacky monkeypatching there would be issues. An alternative approach could be to keep our own stack with deltas and intercept the undo/redo commands. However, there are many neat things the editor does, like keeping track of cursor placement, keeping potentially infinite stack by compressing the operations, batching edits so that undo works per-word when typing or when using autocomplete/snippet (tl;dr the undo/redo is well integrated into the editor).

In our use case many people will just use the notebook on their own and for the collaborative case usually work on different cells at the same time (if we had a single collaborative editor then it would be of much importance, but we have a bunch of tiny editors instead). Given all that I think it's ok to just ensure undo doesn't have weird unexpected effects, so I'd go with either:

1. When a concurrent change comes we simply clear the undo/redo stack. This way the user operates normally until someone else makes a change, in which case we clear the stack. This prevents conflicts and in most cases undo works great. The only drawback is that people editing the cell simultaneously kinda loose the ability to revert to a previous point.

2. Other users' changes land on the stack, so undo/redo applies to those changes. For this to work reasonably we would have to commit every such change to the stack, so undo would usually work letter-by-letter. The drawback is that users could still unintentionally disrupt each other's work.

Both of these are easy to implement. I went with 1., please let me know if this behavior sounds ok :>