### PR TITLE
Sanitize HTML rendered from Markdown

### DIFF
--- a/assets/js/cell/markdown.js
+++ b/assets/js/cell/markdown.js
@@ -1,5 +1,6 @@
 import marked from "marked";
 import morphdom from "morphdom";
+import DOMPurify from 'dompurify';
 
 /**
  * Renders markdown content in the given container.
@@ -28,9 +29,10 @@ class Markdown {
 
   __getHtml() {
     const html = marked(this.content);
+    const sanitizedHtml = DOMPurify.sanitize(html);
 
-    if (html) {
-      return html;
+    if (sanitizedHtml) {
+      return sanitizedHtml;
     } else {
       return `
         <div class="text-gray-300">

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -4109,6 +4109,11 @@
         }
       }
     },
+    "dompurify": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,6 +9,7 @@
     "test": "jest --watch"
   },
   "dependencies": {
+    "dompurify": "^2.2.6",
     "marked": "^1.2.8",
     "monaco-editor": "^0.21.2",
     "morphdom": "^2.6.1",


### PR DESCRIPTION
Fixes #37.

Whenever rendering Markdown we now sanitize the resulting HTML using [DOMPurify](https://github.com/cure53/DOMPurify), so any unsafe attributes are removed.