### PR TITLE
Keep editor focus when cell actions are executed

### DIFF
--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -1,4 +1,8 @@
-import { getAttributeOrThrow, parseBoolean } from "../lib/attribute";
+import {
+  getAttributeOrThrow,
+  parseBoolean,
+  parseInteger,
+} from "../lib/attribute";
 import LiveEditor from "./live_editor";
 import Markdown from "./markdown";
 
@@ -52,13 +56,19 @@ const Cell = {
 
       // New cells are initially focused, so check for such case.
 
-      if (isActive(this.props)) {
+      if (isEditorActive(this.props)) {
         this.liveEditor.focus();
       }
 
       if (this.props.isFocused) {
         this.el.scrollIntoView({ behavior: "smooth", block: "center" });
       }
+
+      this.liveEditor.onBlur(() => {
+        if (isEditorActive(this.props)) {
+          this.liveEditor.focus();
+        }
+      });
     });
   },
 
@@ -69,11 +79,11 @@ const Cell = {
     // Note: this.liveEditor is crated once we receive initial data
     // so here we have to make sure it's defined.
 
-    if (!isActive(prevProps) && isActive(this.props)) {
+    if (!isEditorActive(prevProps) && isEditorActive(this.props)) {
       this.liveEditor && this.liveEditor.focus();
     }
 
-    if (isActive(prevProps) && !isActive(this.props)) {
+    if (isEditorActive(prevProps) && !isEditorActive(this.props)) {
       this.liveEditor && this.liveEditor.blur();
     }
 
@@ -96,7 +106,7 @@ function getProps(hook) {
 /**
  * Checks if the cell editor is active and should have focus.
  */
-function isActive(props) {
+function isEditorActive(props) {
   return props.isFocused && props.insertMode;
 }
 

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -13,6 +13,7 @@ class LiveEditor {
     this.type = type;
     this.source = source;
     this._onChange = null;
+    this._onBlur = null;
 
     this.__mountEditor();
 
@@ -28,6 +29,10 @@ class LiveEditor {
       this.source = delta.applyToString(this.source);
       this._onChange && this._onChange(this.source);
     });
+
+    this.editor.onDidBlurEditorWidget(() => {
+      this._onBlur && this._onBlur();
+    });
   }
 
   /**
@@ -35,6 +40,13 @@ class LiveEditor {
    */
   onChange(callback) {
     this._onChange = callback;
+  }
+
+  /**
+   * Registers a callback called whenever the editor loses focus.
+   */
+  onBlur(callback) {
+    this._onBlur = callback;
   }
 
   focus() {

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -90,10 +90,14 @@ const Session = {
 
     // Focus/unfocus a cell when the user clicks somewhere
     // Note: we use mousedown event to more reliably focus editor
-    // (e.g. if the user selects some text within the editor
-    // and mouseup happens outside the editor)
+    // (e.g. if the user starts selecting some text within the editor)
 
     this.handleDocumentMouseDown = (event) => {
+      // If click targets cell actions, keep the focus as is
+      if (event.target.closest("[data-cell-actions]")) {
+        return;
+      }
+
       // Find the parent with cell id info, if there is one
       const cell = event.target.closest("[data-cell-id]");
       const cellId = cell ? cell.dataset.cellId : null;

--- a/lib/live_book_web/live/cell_component.ex
+++ b/lib/live_book_web/live/cell_component.ex
@@ -18,7 +18,7 @@ defmodule LiveBookWeb.CellComponent do
   def render_cell_content(%{cell: %{type: :markdown}} = assigns) do
     ~L"""
     <%= if @focused do %>
-      <div class="flex flex-col items-center space-y-2 absolute z-50 right-0 top-0 -mr-10">
+      <div class="flex flex-col items-center space-y-2 absolute z-50 right-0 top-0 -mr-10" data-cell-actions>
         <%= unless @insert_mode do %>
           <button phx-click="enable_insert_mode" class="text-gray-500 hover:text-current">
             <%= Icons.svg(:pencil, class: "h-6") %>
@@ -53,7 +53,7 @@ defmodule LiveBookWeb.CellComponent do
   def render_cell_content(%{cell: %{type: :elixir}} = assigns) do
     ~L"""
     <%= if @focused do %>
-      <div class="flex flex-col items-center space-y-2 absolute z-50 right-0 top-0 -mr-10">
+      <div class="flex flex-col items-center space-y-2 absolute z-50 right-0 top-0 -mr-10" data-cell-actions>
         <%= if @cell_info.evaluation_status == :ready do %>
           <button phx-click="queue_focused_cell_evaluation" class="text-gray-500 hover:text-current">
             <%= Icons.svg(:play, class: "h-6") %>


### PR DESCRIPTION
Moving a cell using buttons would get out of insert mode, which was quite weird, especially for a Markdown cells that get collapsed.