### PR TITLE
Optimise inspect coloring

### DIFF
--- a/lib/livebook/evaluator/string_formatter.ex
+++ b/lib/livebook/evaluator/string_formatter.ex
@@ -17,17 +17,21 @@ defmodule Livebook.Evaluator.StringFormatter do
   end
 
   defp syntax_colors() do
+    # Note: we intentionally don't specify colors
+    # for `:binary`, `:list`, `:map` and `:tuple`
+    # and rely on these using the default text color.
+    # This way we avoid a bunch of HTML tags for coloring commas, etc.
     [
       atom: :blue,
-      binary: :light_black,
+      # binary: :light_black,
       boolean: :magenta,
-      list: :light_black,
-      map: :light_black,
+      # list: :light_black,
+      # map: :light_black,
       number: :blue,
       nil: :magenta,
       regex: :red,
       string: :green,
-      tuple: :light_black,
+      # tuple: :light_black,
       reset: :reset
     ]
   end


### PR DESCRIPTION
I noticed that long inspect results would significantly slow down the browser client. I figured the problem lies in the number of HTML tags the inspected result has and I suspect it's morphdom parsing and diffing the elements. Here's an example of problematic inspect:

![image](https://user-images.githubusercontent.com/17034772/109888760-58117b00-7c84-11eb-99ee-02654e574527.png)

As you can see most of the text actually has the default color, but all the commas were wrapped in a *light black* color that we use for lists. Instead of using *light black* we can just use no color at all and the result is the same, but we avoid wrapping every comma in its HTML element. This improves the performance and for this specific example works seamlessly.

This does not entirely fix the problem for cases where the output has a lot of separated colored text, because then we just have to wrap every piece in an HTML tag, for example:

![image](https://user-images.githubusercontent.com/17034772/109889392-95c2d380-7c85-11eb-9b68-2b7e8cf822ff.png)

I don't think decreasing inspect `limit` makes sense, because for a simple list we can definitely show `50` elements. Also the problem is not specific to the length itself, but to the number of colored pieces of text.