### PR TITLE
Automatically scroll output

### DIFF
--- a/assets/js/virtualized_lines/index.js
+++ b/assets/js/virtualized_lines/index.js
@@ -1,5 +1,9 @@
 import HyperList from "hyperlist";
-import { getAttributeOrThrow, parseInteger } from "../lib/attribute";
+import {
+  getAttributeOrThrow,
+  parseBoolean,
+  parseInteger,
+} from "../lib/attribute";
 import { getLineHeight } from "../lib/utils";
 
 /**
@@ -9,6 +13,8 @@ import { getLineHeight } from "../lib/utils";
  * Configuration:
  *
  *   * `data-max-height` - the maximum height of the element, exceeding this height enables scrolling
+ *
+ *   * `data-follow` - whether to automatically scroll to the bottom as new lines appear
  *
  * The element should have two children:
  *
@@ -60,7 +66,19 @@ const VirtualizedLines = {
       this.props.maxHeight,
       this.state.lineHeight
     );
+
+    const scrollTop = Math.round(this.state.contentElement.scrollTop);
+    const maxScrollTop = Math.round(
+      this.state.contentElement.scrollHeight -
+        this.state.contentElement.clientHeight
+    );
+    const isAtTheEnd = scrollTop === maxScrollTop;
+
     this.virtualizedList.refresh(this.state.contentElement, config);
+
+    if (this.props.follow && isAtTheEnd) {
+      this.state.contentElement.scrollTop = this.state.contentElement.scrollHeight;
+    }
   },
 };
 
@@ -81,6 +99,7 @@ function hyperListConfig(templateElement, maxHeight, lineHeight) {
 function getProps(hook) {
   return {
     maxHeight: getAttributeOrThrow(hook.el, "data-max-height", parseInteger),
+    follow: getAttributeOrThrow(hook.el, "data-follow", parseBoolean),
   };
 }
 

--- a/lib/livebook_web/live/cell_component.ex
+++ b/lib/livebook_web/live/cell_component.ex
@@ -204,7 +204,7 @@ defmodule LivebookWeb.CellComponent do
     assigns = %{lines: lines, id: id}
 
     ~L"""
-    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300">
+    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300" data-follow="true">
       <div data-template class="hidden"><%= for line <- @lines do %><div><%= raw line %></div><% end %></div>
       <div data-content phx-update="ignore" class="overflow-auto whitespace-pre text-gray-500 tiny-scrollbar"></div>
     </div>
@@ -216,7 +216,7 @@ defmodule LivebookWeb.CellComponent do
     assigns = %{lines: lines, id: id}
 
     ~L"""
-    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300">
+    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300" data-follow="false">
       <div data-template class="hidden"><%= for line <- @lines do %><div><%= raw line %></div><% end %></div>
       <div data-content phx-update="ignore" class="overflow-auto whitespace-pre text-gray-500 tiny-scrollbar"></div>
     </div>


### PR DESCRIPTION
Related to #104, although it won't fix the batching problem.

https://user-images.githubusercontent.com/17034772/112010467-a00b1b80-8b27-11eb-8403-7adf21a30d25.mp4

Btw. this works fine without the `sleep`, so the linked issue may be that we are sending a bunch of tiny outputs separately and batching may be the only reasonable solution to that.