### PR TITLE
Make output ids unique across evaluations

### DIFF
--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -408,7 +408,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     <div class="flex flex-col rounded-lg border border-gray-200 divide-y divide-gray-200">
       <%= for {output, index} <- @cell_view.outputs |> Enum.reverse() |> Enum.with_index(), output != :ignored do %>
         <div class="p-4 max-w-full overflow-y-auto tiny-scrollbar">
-          <%= render_output(output, %{id: "cell-#{@cell_view.id}-output#{index}", socket: @socket}) %>
+          <%= render_output(output, %{id: "cell-#{@cell_view.id}-evaluation#{@cell_view.number_of_evaluations}-output#{index}", socket: @socket}) %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
I noticed that if the cell output component is removed before evaluation and then immediately the same component is mounted after finished evaluation, then the HTML is not synced correctly.

---

Here's a simplified version of the case which I think leads to the problem:

```html
# Component

<div id="ID" phx-hook="Hook">
  <content>
</div>
```

Now, if the component is removed on one render and then added on another render with the same id, in the DOM we end up with an *empty* div (no `<content>` there), the div has `data-phx-ignore` attribute and the `data-phx-component` is set to the same value as previously.

---

Making sure the id is always unique resolves the issue, so the above behaviour is not particularly problematic, but it may be an edge case that for some reason is not handled as expected.