### PR TITLE
Do not generate warning logs in livebook when using Task.async

### DIFF
--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -263,6 +263,20 @@ defmodule Livebook.Evaluator do
     {:reply, :ok, state}
   end
 
+  @impl true
+  def handle_info({ref, _result}, state) when is_reference(ref) do
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, _}, state) when is_reference(ref) and is_pid(pid) do
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.error("Livebook.Evaluator #{inspect(self())} received handle_info with unexpected message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
   defp get_context(state, ref) do
     Map.get_lazy(state.contexts, ref, fn -> state.initial_context end)
   end


### PR DESCRIPTION
Using `Task.async` in livebook, some error logs might make people a bit confused:
<img width="952" alt="Screen Shot 2021-08-19 at 00 00 36" src="https://user-images.githubusercontent.com/128147/129977902-0f4e8d26-c72f-4bd3-b600-ca3c5890f6a9.png">

These are because `Task.async` does link the processes and the evaluator doesn't have a corresponding `handle_info/2` callback for them. I was thinking it would be a good improvement to silence on these, so the experience can be more smooth to the user:
<img width="999" alt="Screen Shot 2021-08-18 at 23 41 44" src="https://user-images.githubusercontent.com/128147/129977796-55af9241-8d13-4a00-af3f-c130ec12cbd1.png">

Do you think it's a good idea to go this path?

~~EDIT: thinking we should error instead of warn in the Logger call that was added.~~ 👍

Thanks!