### PR TITLE
Improve error message when attaching to a remote node with different ERTS version

### DIFF
--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -72,7 +72,7 @@ defmodule Livebook.Runtime.ErlDist do
           else
             raise RuntimeError,
                   "failed to load #{inspect(module)} module into the remote node, reason: #{inspect(reason)}"
-          else
+          end
       end
     end
   end

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -66,7 +66,7 @@ defmodule Livebook.Runtime.ErlDist do
           local_otp = :erlang.system_info(:otp_release)
           remote_otp = :rpc.call(node, :erlang, :system_info, [:otp_release])
 
-          if is_list(remote_otp) and local_otp != remote_otp do
+          if local_otp != remote_otp do
             raise RuntimeError,
                   "failed to load #{inspect(module)} module into the remote node, potentially due to Erlang/OTP version mismatch, reason: #{inspect(reason)} (local #{local_otp} != remote #{remote_otp})"
           else

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -66,13 +66,13 @@ defmodule Livebook.Runtime.ErlDist do
           local_otp = :erlang.system_info(:otp_release)
           remote_otp = :rpc.call(node, :erlang, :system_info, [:otp_release])
 
-          if local_otp == remote_otp do
+          if is_list(remote_otp) and local_otp != remote_otp do
+            raise RuntimeError,
+                  "failed to load #{inspect(module)} module into the remote node, potentially due to Erlang/OTP version mismatch, reason: #{inspect(reason)} (local #{local_otp} != remote #{remote_otp})
+          else
             raise RuntimeError,
                   "failed to load #{inspect(module)} module into the remote node, reason: #{inspect(reason)}"
           else
-            raise RuntimeError,
-                  "failed to load #{inspect(module)} module into the remote node due to Erlang/OTP version mismatch, local #{local_otp} != remote #{remote_otp}"
-          end
       end
     end
   end

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -68,7 +68,7 @@ defmodule Livebook.Runtime.ErlDist do
 
           if is_list(remote_otp) and local_otp != remote_otp do
             raise RuntimeError,
-                  "failed to load #{inspect(module)} module into the remote node, potentially due to Erlang/OTP version mismatch, reason: #{inspect(reason)} (local #{local_otp} != remote #{remote_otp})
+                  "failed to load #{inspect(module)} module into the remote node, potentially due to Erlang/OTP version mismatch, reason: #{inspect(reason)} (local #{local_otp} != remote #{remote_otp})"
           else
             raise RuntimeError,
                   "failed to load #{inspect(module)} module into the remote node, reason: #{inspect(reason)}"


### PR DESCRIPTION
Closes #510.

At this point this seems like a rare issue, but raising a more specific error should avoid some confusion.