### PR TITLE
Add a hex badge to show the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 <h1><img src="https://github.com/livebook-dev/livebook/raw/main/priv/static/images/logo-with-text.png" alt="Livebook" width="400"></h1>
 
-<p>
- <a href="https://hex.pm/packages/livebook">
-   <img alt="Hex.pm" src="https://img.shields.io/hexpm/v/livebook">
- </a>
-</p>
+ [![Hex.pm](https://img.shields.io/hexpm/v/livebook)](https://hex.pm/packages/livebook)
 
 Livebook is a web application for writing interactive and collaborative code notebooks for Elixir, built with [Phoenix LiveView](https://github.com/phoenixframework/phoenix_live_view). It features:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 <h1><img src="https://github.com/livebook-dev/livebook/raw/main/priv/static/images/logo-with-text.png" alt="Livebook" width="400"></h1>
 
+<p>
+ <a href="https://hex.pm/packages/livebook">
+   <img alt="Hex.pm" src="https://img.shields.io/hexpm/v/livebook">
+ </a>
+</p>
+
 Livebook is a web application for writing interactive and collaborative code notebooks for Elixir, built with [Phoenix LiveView](https://github.com/phoenixframework/phoenix_live_view). It features:
 
   * Code notebooks with Markdown support and Elixir cells where code is evaluated on demand.


### PR DESCRIPTION
I was curious about the most recent version of Livebook and saw a version mentioned in the escript section of the readme and wasn't entirely sure if that was outdated (confirmed that it wasn't by looking at the github tags). All of this is made easier with a hex badge showing the most recent public version of the livebook package. Can change the style of the badge if necessary (just went with the default).

![image](https://user-images.githubusercontent.com/865203/131222790-e25b16c9-e802-4616-98af-2868cbd66bb3.png)
