### PR TITLE
Now uses slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 # Stage 1
 # Builds the Livebook release
-FROM hexpm/elixir:1.12.0-erlang-24.0-alpine-3.13.3 AS build
+FROM hexpm/elixir:1.12.3-erlang-24.0.6-debian-buster-20210902-slim AS build
 
-RUN apk add --no-cache build-base git
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        build-essential git && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -32,13 +37,17 @@ RUN mix do compile, release
 # We use the same base image, because we need Erlang, Elixir and Mix
 # during runtime to spawn the Livebook standalone runtimes.
 # Consequently the release doesn't include ERTS as we have it anyway.
-FROM hexpm/elixir:1.12.0-erlang-24.0-alpine-3.13.3
+FROM hexpm/elixir:1.12.3-erlang-24.0.6-debian-buster-20210902-slim
 
-RUN apk add --no-cache \
-    # Runtime dependencies
-    openssl ncurses-libs \
-    # In case someone uses `Mix.install/2` and point to a git repo
-    git
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        # Runtime dependencies
+        build-essential ca-certificates libncurses5-dev \
+        # In case someone uses `Mix.install/2` and point to a git repo
+        git && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Run in the /data directory by default, makes for
 # a good place for the user to mount local volume


### PR DESCRIPTION
Refs #543 
Refs #545 

Size: `428MB`

Layers:

```
IMAGE                                                                     CREATED              CREATED BY                                                                                                                                                                                                                                                                                                                            SIZE      COMMENT
sha256:ec7110e686d95ed93173f2d95f6f86792134cfb136b2b76838826b0156fcc3e1   8 seconds ago        CMD ["/app/bin/livebook" "start"]                                                                                                                                                                                                                                                                                                     0B        buildkit.dockerfile.v0
<missing>                                                                 8 seconds ago        RUN /bin/sh -c find /app -executable -type f -exec chmod +x {} + # buildkit                                                                                                                                                                                                                                                           12.2kB    buildkit.dockerfile.v0
<missing>                                                                 9 seconds ago        COPY /app/_build/prod/rel/livebook /app # buildkit                                                                                                                                                                                                                                                                                    19MB      buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   ENV LIVEBOOK_IP=0.0.0.0                                                                                                                                                                                                                                                                                                               0B        buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   RUN /bin/sh -c mix local.hex --force &&     mix local.rebar --force # buildkit                                                                                                                                                                                                                                                        1.96MB    buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   RUN /bin/sh -c mkdir $HOME && chmod 777 $HOME # buildkit                                                                                                                                                                                                                                                                              0B        buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   ENV HOME=/home/livebook                                                                                                                                                                                                                                                                                                               0B        buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   WORKDIR /data                                                                                                                                                                                                                                                                                                                         0B        buildkit.dockerfile.v0
<missing>                                                                 About a minute ago   RUN /bin/sh -c apt-get update && apt-get upgrade -y &&     apt-get install --no-install-recommends -y         build-essential ca-certificates libncurses5-dev         git &&     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false &&     apt-get clean -y &&     rm -rf /var/lib/apt/lists/* # buildkit   243MB     buildkit.dockerfile.v0
<missing>                                                                 6 days ago           /bin/sh -c #(nop) COPY dir:a90c0dd8981f88851c523d2fcf156a70fe61b1388fed8579f0077e11ed1c62ff in /usr/local                                                                                                                                                                                                                             6.65MB    
<missing>                                                                 6 days ago           /bin/sh -c #(nop)  ENV LANG=C.UTF-8                                                                                                                                                                                                                                                                                                   0B        
<missing>                                                                 6 days ago           /bin/sh -c #(nop) COPY dir:0fd890fc9c6ef234ac7b1ead8ec20a0d52559552b07dd8baf4bf107cdaa902cb in /usr/local                                                                                                                                                                                                                             64.4MB    
<missing>                                                                 7 days ago           /bin/sh -c apt-get update &&   apt-get -y --no-install-recommends install     libodbc1     libssl1.1     libsctp1                                                                                                                                                                                                                     23.9MB    
<missing>                                                                 2 weeks ago          /bin/sh -c #(nop)  CMD ["bash"]                                                                                                                                                                                                                                                                                                       0B        
<missing>                                                                 2 weeks ago          /bin/sh -c #(nop) ADD file:4ff85d9f6aa246746912db62dea02eb71750474bb29611e770516a1fcd217add in /                                                                                                                                                                                                                                      69.3MB 
```