### PR TITLE
Include wget in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,9 @@ RUN apt-get update && apt-get upgrade -y && \
         # Runtime dependencies
         build-essential ca-certificates libncurses5-dev \
         # In case someone uses `Mix.install/2` and point to a git repo
-        git && \
+        git \
+        # Additional standard tools
+        wget && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Apparently doesn't come by default  in the debian-slim image.