### PR TITLE
Extend ANSI code parser to handle multiple arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for configuring file systems using env variables ([#498](https://github.com/livebook-dev/livebook/pull/498))
 - Added a keyboard shortcut for triggering on-hover docs ([#508](https://github.com/livebook-dev/livebook/pull/508))
 - Added `--open-new` CLI flag to `livebook server` ([#529](https://github.com/livebook-dev/livebook/pull/529))
+- Nx introductory notebook ([#528](https://github.com/livebook-dev/livebook/pull/528))
 
 ### Changed
 
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved the evaluator process to not consume user-submitted messages from inbox ([#502](https://github.com/livebook-dev/livebook/pull/502))
 - Improved sections panel UI to better handle numerous sections or long section names ([#534](https://github.com/livebook-dev/livebook/pull/534) and [#537](https://github.com/livebook-dev/livebook/pull/537))
 - Fixed branching section evaluation when the parent section is empty ([#560](https://github.com/livebook-dev/livebook/pull/560)
+- Fixed ANSI support to handle multi-code escape sequences ([#569](https://github.com/livebook-dev/livebook/pull/569)
 
 ## [v0.2.3](https://github.com/livebook-dev/livebook/tree/v0.2.3) (2021-08-12)
 

--- a/test/livebook/utils/ansi_test.exs
+++ b/test/livebook/utils/ansi_test.exs
@@ -57,12 +57,24 @@ defmodule Livebook.Utils.ANSITest do
       assert ANSI.parse_ansi_string("\e[H\e[1Acat") == [{[], "cat"}]
     end
 
-    test "returns the whole string if on ANSI code detected" do
+    test "returns the whole string if no ANSI code is detected" do
       assert ANSI.parse_ansi_string("\e[300mcat") == [{[], "\e[300mcat"}]
+      assert ANSI.parse_ansi_string("\ehmmcat") == [{[], "\ehmmcat"}]
     end
 
     test "ignores RFC 1468 switch to ASCII" do
       assert ANSI.parse_ansi_string("\e(Bcat") == [{[], "cat"}]
+    end
+
+    test "supports multiple codes separated by semicolon" do
+      assert ANSI.parse_ansi_string("\e[0;34mcat") == [{[foreground_color: :blue], "cat"}]
+
+      assert ANSI.parse_ansi_string("\e[34;41mcat\e[0m") ==
+               [{[background_color: :red, foreground_color: :blue], "cat"}]
+
+      # 8-bit rgb color followed by background color
+      assert ANSI.parse_ansi_string("\e[38;5;67;41mcat\e[0m") ==
+               [{[background_color: :red, foreground_color: {:rgb6, 1, 2, 3}], "cat"}]
     end
   end
 end


### PR DESCRIPTION
Closes #567.

Apparently ANSI codes can be combined with semicolon like `\e{code1};{code2}m`, so I updated the parser to handle this.