### PR TITLE
Make it possible to configure custom plug for all requests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,8 +30,7 @@ config :livebook, :default_runtime, {Livebook.Runtime.ElixirStandalone, []}
 #
 #    [{plug_module :: module(), opts :: keyword()}]
 #
-# The plugs are run at the end of the browser pipeline
-# and have access to the session
+# The plugs are called directly before the Livebook router.
 config :livebook, :plugs, []
 
 # Import environment specific config. This must remain at the bottom

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,14 @@ config :livebook, :authentication_mode, :token
 # configured arguments.
 config :livebook, :default_runtime, {Livebook.Runtime.ElixirStandalone, []}
 
+# A list of custom plugs in the following format:
+#
+#    [{plug_module :: module(), opts :: keyword()}]
+#
+# The plugs are run at the end of the browser pipeline
+# and have access to the session
+config :livebook, :plugs, []
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/livebook_web/endpoint.ex
+++ b/lib/livebook_web/endpoint.ex
@@ -71,6 +71,10 @@ defmodule LivebookWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
+
+  # Run custom plugs from the app configuration
+  plug LivebookWeb.ConfiguredPlug
+
   plug LivebookWeb.Router
 
   def access_url() do

--- a/lib/livebook_web/plugs/configured_plug.ex
+++ b/lib/livebook_web/plugs/configured_plug.ex
@@ -6,12 +6,13 @@ defmodule LivebookWeb.ConfiguredPlug do
   @behaviour Plug
 
   @impl true
-  def init(_opts) do
-    plugs = Application.get_env(:livebook, :plugs, [])
-    %{plugs: plugs}
-  end
+  def init(opts), do: opts
 
   @impl true
-  def call(conn, %{plugs: []}), do: conn
-  def call(conn, %{plugs: plugs}), do: Plug.run(conn, plugs)
+  def call(conn, _opts) do
+    case Application.get_env(:livebook, :plugs, []) do
+      [] -> conn
+      plugs -> Plug.run(conn, plugs)
+    end
+  end
 end

--- a/lib/livebook_web/plugs/configured_plug.ex
+++ b/lib/livebook_web/plugs/configured_plug.ex
@@ -10,7 +10,7 @@ defmodule LivebookWeb.ConfiguredPlug do
 
   @impl true
   def call(conn, _opts) do
-    case Application.get_env(:livebook, :plugs, []) do
+    case Application.fetch_env!(:livebook, :plugs) do
       [] -> conn
       plugs -> Plug.run(conn, plugs)
     end

--- a/lib/livebook_web/plugs/configured_plug.ex
+++ b/lib/livebook_web/plugs/configured_plug.ex
@@ -1,0 +1,17 @@
+defmodule LivebookWeb.ConfiguredPlug do
+  @moduledoc false
+
+  # Runs plugs configured for the :livebook application
+
+  @behaviour Plug
+
+  @impl true
+  def init(_opts) do
+    plugs = Application.get_env(:livebook, :plugs, [])
+    %{plugs: plugs}
+  end
+
+  @impl true
+  def call(conn, %{plugs: []}), do: conn
+  def call(conn, %{plugs: plugs}), do: Plug.run(conn, plugs)
+end

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -9,7 +9,6 @@ defmodule LivebookWeb.Router do
     plug :put_root_layout, {LivebookWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-    plug LivebookWeb.ConfiguredPlug
   end
 
   pipeline :auth do

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -9,6 +9,7 @@ defmodule LivebookWeb.Router do
     plug :put_root_layout, {LivebookWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug LivebookWeb.ConfiguredPlug
   end
 
   pipeline :auth do


### PR DESCRIPTION
For some context, `livebook_nerves` needs a bit of custom request handling to redirect `nerves.local` to `nerves-{device_id}.local`. This enables specifying a custom list of plugs via app config.