### PR TITLE
Normalize session tmp directory path

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -719,7 +719,8 @@ defmodule Livebook.Session do
   end
 
   defp session_tmp_dir(session_id) do
-    path = Path.join([System.tmp_dir!(), "livebook", "sessions", session_id]) <> "/"
+    tmp_dir = System.tmp_dir!() |> Path.expand()
+    path = Path.join([tmp_dir, "livebook", "sessions", session_id]) <> "/"
     FileSystem.File.local(path)
   end
 


### PR DESCRIPTION
See #599.

`FileSystem.File.new` expects a normalized expanded path, so we need to explicitly convert `C:\\Users\\...` to `c:/Users/...`