### PR TITLE
Change color for aborted and queued status

### DIFF
--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -336,7 +336,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   defp cell_status(%{cell_view: %{evaluation_status: :queued}} = assigns) do
     ~H"""
-    <.status_indicator circle_class="bg-gray-500" animated_circle_class="bg-gray-400">
+    <.status_indicator circle_class="bg-gray-400" animated_circle_class="bg-gray-300">
       Queued
     </.status_indicator>
     """
@@ -363,7 +363,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   defp cell_status(%{cell_view: %{validity_status: :aborted}} = assigns) do
     ~H"""
-    <.status_indicator circle_class="bg-red-400">
+    <.status_indicator circle_class="bg-gray-500">
       Aborted
     </.status_indicator>
     """


### PR DESCRIPTION
refs #609

Changing the status indicator color for aborted status to a dark gray and modifying the gray of the queued status to be lighter.