### PR TITLE
Removing "Evaluate All Below" shortcut functionality

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -335,8 +335,6 @@ function handleDocumentKeyDown(hook, event) {
       queueAllCellsEvaluation(hook);
     } else if (keyBuffer.tryMatch(["e", "s"])) {
       queueFocusedSectionEvaluation(hook);
-    } else if (keyBuffer.tryMatch(["e", "j"])) {
-      queueChildCellsEvaluation(hook);
     } else if (keyBuffer.tryMatch(["s", "s"])) {
       toggleSectionsList(hook);
     } else if (keyBuffer.tryMatch(["s", "u"])) {
@@ -636,14 +634,6 @@ function queueFocusedSectionEvaluation(hook) {
   if (hook.state.focusedSectionId) {
     hook.pushEvent("queue_section_cells_evaluation", {
       section_id: hook.state.focusedSectionId,
-    });
-  }
-}
-
-function queueChildCellsEvaluation(hook) {
-  if (hook.state.focusedCellId) {
-    hook.pushEvent("queue_child_cells_evaluation", {
-      cell_id: hook.state.focusedCellId,
     });
   }
 }

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -579,18 +579,6 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
-  def handle_event("queue_child_cells_evaluation", %{"cell_id" => cell_id}, socket) do
-    with {:ok, cell, _section} <-
-           Notebook.fetch_cell_and_section(socket.private.data.notebook, cell_id) do
-      for {cell, _} <- Notebook.child_cells_with_section(socket.private.data.notebook, cell.id),
-          is_struct(cell, Cell.Elixir) do
-        Session.queue_cell_evaluation(socket.assigns.session.pid, cell.id)
-      end
-    end
-
-    {:noreply, socket}
-  end
-
   def handle_event("queue_bound_cells_evaluation", %{"cell_id" => cell_id}, socket) do
     data = socket.private.data
 

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -96,7 +96,6 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["e", "e"], desc: "Evaluate cell"},
       %{seq: ["e", "s"], desc: "Evaluate section"},
       %{seq: ["e", "a"], desc: "Evaluate all stale/new cells", basic: true},
-      %{seq: ["e", "j"], desc: "Evaluate cells below"},
       %{seq: ["e", "x"], desc: "Cancel cell evaluation"},
       %{seq: ["s", "s"], desc: "Toggle sections panel"},
       %{seq: ["s", "u"], desc: "Toggle users panel"},


### PR DESCRIPTION
refs #612

Removing `e + j` shortcut from the front-end and also removing their correspondent handler from the backend