### PR TITLE
Hide list bullets in markdown checkboxes

### DIFF
--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -52,6 +52,11 @@
   list-style-type: none;
 }
 
+.markdown .task-list-item input[type="checkbox"] {
+  margin-left: -1.1rem;
+  vertical-align: middle;
+}
+
 .markdown ul > li,
 .markdown ol > li {
   @apply my-1;


### PR DESCRIPTION
Minor change to hide list bullets when using checkboxes a la

```md
- [ ] item 1
- [ ] item 2
```

Would've liked to also look how to have the checkboxes be interactive such that when a user
clicks on the rendered markdown's checkbox, it actually edits the markdown to `- [x] item 1`,
but I don't really have the free time right now.