### PR TITLE
Update hostname resolution check

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -88,8 +88,12 @@ defmodule Livebook.Application do
           invalid_hostname!("your hostname \"#{hostname}\" does not resolve to an IP address")
 
         {:ok, hostent(h_addrtype: :inet, h_addr_list: addresses)} ->
-          if {127, 0, 0, 1} not in addresses do
-            invalid_hostname!("your hostname \"#{hostname}\" does not resolve to 127.0.0.1")
+          any_loopback? = Enum.any?(addresses, &match?({127, _, _, _}, &1))
+
+          unless any_loopback? do
+            invalid_hostname!(
+              "your hostname \"#{hostname}\" does not resolve to a loopback address (127.0.0.0/8)"
+            )
           end
 
         _ ->


### PR DESCRIPTION
Follow up to #625.

I checked `:inet.gethostbyname/1` yesterday, but I missed that it's `127.0.1.1` rather than `127.0.0.1` for me. That's generally likely on some systems:

```
➜  ~ cat /etc/hosts
127.0.0.1	localhost
127.0.1.1	mockingjay
```

As long as the hostname resolves to loopback, the nodes should communicate just fine.