### PR TITLE
Remove vertical margin from nested markdown lists

### DIFF
--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -62,6 +62,11 @@
   @apply my-1;
 }
 
+.markdown li > ul,
+.markdown li > ol {
+  @apply my-0;
+}
+
 .markdown blockquote {
   @apply border-l-4 border-gray-200 pl-4 py-2 my-4 text-gray-500;
 }


### PR DESCRIPTION
Back with more markdown list css changes :sweat_smile: I use livebook as a devlog as I'm working on a phoenix side project and so I use quite a bit of lists. Here's a screenshot of how nested lists currently look like:

![Screenshot from 2021-10-21 23-15-04](https://user-images.githubusercontent.com/1938892/138387870-e76b511c-b895-4b5c-b065-f65aac515dc9.png)

And here's a screenshot after removing the vertical margin:

![Screenshot from 2021-10-21 23-14-43](https://user-images.githubusercontent.com/1938892/138387961-6569b6c8-4fe6-4cc0-a948-377491d91cbd.png)
