### PR TITLE
Fix root directory listing on S3 when empty

### DIFF
--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -70,7 +70,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     delimiter = if recursive, do: nil, else: "/"
 
     with {:ok, %{keys: keys}} <- list_objects(file_system, prefix: dir_key, delimiter: delimiter) do
-      if keys == [] do
+      if keys == [] and dir_key != "" do
         FileSystem.Utils.posix_error(:enoent)
       else
         paths = keys |> List.delete(dir_key) |> Enum.map(&("/" <> &1))


### PR DESCRIPTION
Listing "/" on S3 should return an empty list instead of erroring that dir doesn't exist. Currently this prevents from mounting an empty bucket as well.