### PR TITLE
Fix urls on Elixir master

### DIFF
--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -94,7 +94,7 @@ defmodule LivebookCLI.Server do
   defp check_endpoint_availability(base_url) do
     Application.ensure_all_started(:inets)
 
-    health_url = append_path(base_url, "health")
+    health_url = append_path(base_url, "/health")
 
     case Livebook.Utils.HTTP.request(:get, health_url) do
       {:ok, status, _headers, body} ->
@@ -127,7 +127,7 @@ defmodule LivebookCLI.Server do
 
     if opts[:open_new] do
       base_url
-      |> append_path("explore/notebooks/new")
+      |> append_path("/explore/notebooks/new")
       |> browser_open()
     end
   end
@@ -225,7 +225,8 @@ defmodule LivebookCLI.Server do
   defp append_path(url, path) do
     url
     |> URI.parse()
-    |> Map.update!(:path, &((&1 || "/") <> path))
+    # TODO: remove `&1 || ""` when we require Elixir 1.13
+    |> Map.update!(:path, &((&1 || "") <> path))
     |> URI.to_string()
   end
 


### PR DESCRIPTION
Before Elixir master, empty path is represented as `nil`:

    ~% asdf shell elixir 1.12.3-otp-24 ; elixir -e 'IO.inspect URI.parse("http://localhost")'
    %URI{
      authority: "localhost",
      fragment: nil,
      host: "localhost",
      path: nil,
      port: 80,
      query: nil,
      scheme: "http",
      userinfo: nil
    }

On Elixir master, it is an empty string:

    ~% asdf shell elixir git ; elixir -e 'IO.inspect URI.parse("http://localhost")'
    %URI{
      authority: "localhost",
      fragment: nil,
      host: "localhost",
      path: "",
      port: 80,
      query: nil,
      scheme: "http",
      userinfo: nil
    }

The new default, the empty string, caused a bug on this line:

    Map.update!(:path, &((&1 || "/") <> path))

because we never prepended the leading `/` and thus we ended up with
path `"health"`, not `"/health"`, which now on Elixir master crashes:

    iex> URI.parse("http://localhost") |> Map.replace!(:path, "health") |> to_string()
    ** (ArgumentError) :path in URI must be empty or an absolute path if URL has a :host, got: %URI{authority: "localhost", fragment: nil, host: "localhost", path: "health", port: 80, query: nil, scheme: "http", userinfo: nil}
        (elixir 1.13.0-dev) lib/uri.ex:863: String.Chars.URI.to_string/1
