### PR TITLE
Allow application/octet-stream content type for import

### DIFF
--- a/lib/livebook/content_loader.ex
+++ b/lib/livebook/content_loader.ex
@@ -64,8 +64,11 @@ defmodule Livebook.ContentLoader do
       {:ok, 200, headers, body} ->
         valid_content? =
           case HTTP.fetch_content_type(headers) do
-            {:ok, content_type} -> content_type in ["text/plain", "text/markdown"]
-            :error -> false
+            {:ok, content_type} ->
+              content_type in ["text/plain", "text/markdown", "application/octet-stream"]
+
+            :error ->
+              false
           end
 
         if valid_content? do


### PR DESCRIPTION
With the "Run in Livebook" badge it's more likely we import notebooks from self-hosted locations and docs. If the web server returns content type based on file extensions, it's likely it defaults to `application/octet-stream` for unknown `.livemd` files, so we want to support this a well.