### PR TITLE
Improve scroll on cell focus/blur

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -409,7 +409,7 @@ function handleDocumentMouseDown(hook, event) {
   const insertMode = editableElementClicked(event, cell);
 
   if (cellId !== hook.state.focusedCellId) {
-    setFocusedCell(hook, cellId, !insertMode);
+    setFocusedCell(hook, cellId, false);
   }
 
   // Depending on whether the click targets editor disable/enable insert mode


### PR DESCRIPTION
Closes #658.

Also, I disabled autoscroll when focusing cell with click (currently we do this only when clicking the editor). The case where it's prominent is interacting with an output of non-focused cell (like a vegalite plot), it's confusing to scroll on click.