### PR TITLE
Another attempt to detect invalid shortnames

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -87,8 +87,8 @@ defmodule Livebook.Application do
         {:error, :nxdomain} ->
           invalid_hostname!("your hostname \"#{hostname}\" does not resolve to an IP address")
 
-        {:ok, hostent(h_addrtype: :inet, h_addr_list: addresses)} ->
-          unless any_loopback?(addresses) or any_if?(addresses) do
+        {:ok, hostent(h_name: name, h_aliases: aliases)} ->
+          if hostname not in [name | aliases] do
             invalid_hostname!(
               "your hostname \"#{hostname}\" does not resolve to a loopback address (127.0.0.0/8)"
             )
@@ -97,22 +97,6 @@ defmodule Livebook.Application do
         _ ->
           :ok
       end
-    end
-  end
-
-  defp any_loopback?(addresses) do
-    Enum.any?(addresses, &match?({127, _, _, _}, &1))
-  end
-
-  defp any_if?(addresses) do
-    case :inet.getifaddrs() do
-      {:ok, addrs} ->
-        Enum.any?(addrs, fn {_name, flags} ->
-          Enum.any?(flags, fn {key, value} -> key == :addr and value in addresses end)
-        end)
-
-      _ ->
-        false
     end
   end
 


### PR DESCRIPTION
The changes we did in previous commits made the
check unable to find the original case it was
meant to report on, so let's try to lookup name
and aliases instead.