### PR TITLE
Remove configuration env vars on boot

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -152,5 +152,7 @@ defmodule Livebook.Application do
     end
   end
 
-  defp config_env_var?(var), do: String.match?(var, ~r/^(LIVEBOOK|RELEASE)_/)
+  defp config_env_var?("LIVEBOOK_" <> _), do: true
+  defp config_env_var?("RELEASE_" <> _), do: true
+  defp config_env_var?(_), do: false
 end

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -30,6 +30,7 @@ defmodule Livebook.Application do
     opts = [strategy: :one_for_one, name: Livebook.Supervisor]
 
     with {:ok, _} = result <- Supervisor.start_link(children, opts) do
+      clear_env_vars()
       display_startup_info()
       result
     end
@@ -144,4 +145,12 @@ defmodule Livebook.Application do
       IO.puts("[Livebook] Application running at #{LivebookWeb.Endpoint.access_url()}")
     end
   end
+
+  defp clear_env_vars() do
+    for {var, _} <- System.get_env(), config_env_var?(var) do
+      System.delete_env(var)
+    end
+  end
+
+  defp config_env_var?(var), do: String.match?(var, ~r/^(LIVEBOOK|RELEASE)_/)
 end


### PR DESCRIPTION
Closes #644.

@josevalim I thought alternatively we could clear them at the end of `Livebook.config_runtime`, but if someone call this function we are still at configuration stage, so seems better to keep it until the app starts.