### PR TITLE
Compute cell snapshots when an existing notebook is given

### DIFF
--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -155,7 +155,7 @@ defmodule Livebook.Session.Data do
   """
   @spec new(Notebook.t()) :: t()
   def new(notebook \\ Notebook.new()) do
-    %__MODULE__{
+    data = %__MODULE__{
       notebook: notebook,
       origin: nil,
       file: nil,
@@ -167,6 +167,11 @@ defmodule Livebook.Session.Data do
       clients_map: %{},
       users_map: %{}
     }
+
+    data
+    |> with_actions()
+    |> compute_snapshots()
+    |> elem(0)
   end
 
   defp initial_section_infos(notebook) do
@@ -1235,7 +1240,7 @@ defmodule Livebook.Session.Data do
       number_of_evaluations: 0,
       bound_to_input_ids: MapSet.new(),
       bound_input_readings: [],
-      snapshot: {:initial, :initial},
+      snapshot: {nil, nil},
       evaluation_snapshot: nil
     }
   end
@@ -1411,7 +1416,7 @@ defmodule Livebook.Session.Data do
     |> input_readings_snapshot()
   end
 
-  defp input_readings_snapshot([]), do: :initial
+  defp input_readings_snapshot([]), do: :empty
 
   defp input_readings_snapshot(name_value_pairs) do
     name_value_pairs |> Enum.sort() |> :erlang.phash2()

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -20,15 +20,34 @@ defmodule Livebook.Session.DataTest do
     end
 
     test "called with a notebook, sets default cell and section infos" do
-      cell = Notebook.Cell.new(:elixir)
-      section = %{Notebook.Section.new() | cells: [cell]}
-      notebook = %{Notebook.new() | sections: [section]}
+      notebook = %{
+        Notebook.new()
+        | sections: [
+            %{
+              Notebook.Section.new()
+              | id: "s1",
+                cells: [%{Notebook.Cell.new(:elixir) | id: "c1"}]
+            }
+          ]
+      }
 
-      cell_id = cell.id
-      section_id = section.id
+      assert %{cell_infos: %{"c1" => %{}}, section_infos: %{"s1" => %{}}} = Data.new(notebook)
+    end
 
-      assert %{cell_infos: %{^cell_id => %{}}, section_infos: %{^section_id => %{}}} =
-               Data.new(notebook)
+    test "called with a notebook, computes cell snapshots" do
+      notebook = %{
+        Notebook.new()
+        | sections: [
+            %{
+              Notebook.Section.new()
+              | id: "s1",
+                cells: [%{Notebook.Cell.new(:elixir) | id: "c1"}]
+            }
+          ]
+      }
+
+      assert %{cell_infos: %{"c1" => %{snapshot: snapshot}}} = Data.new(notebook)
+      assert snapshot != {nil, nil}
     end
   end
 


### PR DESCRIPTION
We now start the session with a predefined notebook (inserted section and cell), but we don't compute the initial snapshots. A scenario where it would manifest itself:

* open new notebook (without adding new cells)
* manually connect to runtime
* evaluate the first cell
* the cell becomes stale instead of evaluated