### PR TITLE
Improve notebook file locking to work across nodes

### DIFF
--- a/lib/livebook/file_system.ex
+++ b/lib/livebook/file_system.ex
@@ -33,14 +33,14 @@ defprotocol Livebook.FileSystem do
   system.
   """
   @spec resource_identifier(t()) :: term()
-  def resource_identifier(file_ystem)
+  def resource_identifier(file_system)
 
   @doc """
-  Checks if the file system is a resource local to its host.
+  Checks if the file system is a resource local to its node.
 
   A regular file system is local, because it is accessible only
-  to the host its mounted on. On the other hand, external storage
-  is global, because it can be accessed from any host.
+  to the node its mounted on. On the other hand, external storage
+  is global, because it can be accessed from any node.
   """
   @spec local?(t()) :: boolean()
   def local?(file_system)

--- a/lib/livebook/file_system.ex
+++ b/lib/livebook/file_system.ex
@@ -36,11 +36,11 @@ defprotocol Livebook.FileSystem do
   def resource_identifier(file_ystem)
 
   @doc """
-  Checks if the file system is a resource local to its node.
+  Checks if the file system is a resource local to its host.
 
   A regular file system is local, because it is accessible only
-  to the node its mounted on. On the other hand, external storage
-  is global, because it can be accessed from any node.
+  to the host its mounted on. On the other hand, external storage
+  is global, because it can be accessed from any host.
   """
   @spec local?(t()) :: boolean()
   def local?(file_system)

--- a/lib/livebook/file_system.ex
+++ b/lib/livebook/file_system.ex
@@ -29,6 +29,23 @@ defprotocol Livebook.FileSystem do
   @type access :: :read | :write | :read_write | :none
 
   @doc """
+  Returns a term uniquely identifying the resource used as a file
+  system.
+  """
+  @spec resource_identifier(t()) :: term()
+  def resource_identifier(file_ystem)
+
+  @doc """
+  Checks if the file system is a resource local to its node.
+
+  A regular file system is local, because it is accessible only
+  to the node its mounted on. On the other hand, external storage
+  is global, because it can be accessed from any node.
+  """
+  @spec local?(t()) :: boolean()
+  def local?(file_system)
+
+  @doc """
   Returns the default directory path.
 
   To some extent this is similar to current working directory

--- a/lib/livebook/file_system.ex
+++ b/lib/livebook/file_system.ex
@@ -36,14 +36,17 @@ defprotocol Livebook.FileSystem do
   def resource_identifier(file_system)
 
   @doc """
-  Checks if the file system is a resource local to its node.
+  Returns the file system type.
 
-  A regular file system is local, because it is accessible only
-  to the node its mounted on. On the other hand, external storage
-  is global, because it can be accessed from any node.
+  Based on the underlying resource, the type can be either:
+
+    * `:local` - if the resource is local to its node
+
+    * `:global` - if the resource is external and available
+      accessible from any node
   """
-  @spec local?(t()) :: boolean()
-  def local?(file_system)
+  @spec type(t()) :: :local | :global
+  def type(file_system)
 
   @doc """
   Returns the default directory path.

--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -62,7 +62,7 @@ defmodule Livebook.FileSystem.File do
   end
 
   @doc """
-  Checks if the given file is within a file system local to its node.
+  Checks if the given file is within a file system local to its host.
   """
   @spec local?(t()) :: term()
   def local?(file) do

--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -66,7 +66,7 @@ defmodule Livebook.FileSystem.File do
   """
   @spec local?(t()) :: term()
   def local?(file) do
-    FileSystem.local?(file.file_system)
+    FileSystem.type(file.file_system) == :local
   end
 
   @doc """

--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -53,6 +53,23 @@ defmodule Livebook.FileSystem.File do
   end
 
   @doc """
+  Returns a term uniquely identifying the file together
+  with its file system.
+  """
+  @spec resource_identifier(t()) :: term()
+  def resource_identifier(file) do
+    {FileSystem.resource_identifier(file.file_system), file.path}
+  end
+
+  @doc """
+  Checks if the given file is within a file system local to its node.
+  """
+  @spec local?(t()) :: term()
+  def local?(file) do
+    FileSystem.local?(file.file_system)
+  end
+
+  @doc """
   Returns a new file resulting from resolving `subject`
   against `file`.
 

--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -62,7 +62,7 @@ defmodule Livebook.FileSystem.File do
   end
 
   @doc """
-  Checks if the given file is within a file system local to its host.
+  Checks if the given file is within a file system local to its node.
   """
   @spec local?(t()) :: term()
   def local?(file) do

--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -3,12 +3,12 @@ defmodule Livebook.FileSystem.Local do
 
   # File system backed by local disk.
 
-  defstruct [:node, :default_path]
+  defstruct [:host_id, :default_path]
 
   alias Livebook.FileSystem
 
   @type t :: %__MODULE__{
-          node: node(),
+          host_id: term(),
           default_path: FileSystem.path()
         }
 
@@ -29,7 +29,13 @@ defmodule Livebook.FileSystem.Local do
 
     FileSystem.Utils.assert_dir_path!(default_path)
 
-    %__MODULE__{node: node(), default_path: default_path}
+    %__MODULE__{host_id: local_host_id(), default_path: default_path}
+  end
+
+  @doc false
+  def local_host_id() do
+    {:ok, hostname} = :inet.gethostname()
+    hostname
   end
 end
 
@@ -37,7 +43,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
   alias Livebook.FileSystem
 
   def resource_identifier(file_system) do
-    file_system.node
+    file_system.host_id
   end
 
   def local?(_file_system) do
@@ -219,10 +225,10 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
   end
 
   defp ensure_local(file_system) do
-    if file_system.node == node() do
+    if file_system.host_id == FileSystem.Local.local_host_id() do
       :ok
     else
-      {:error, "this local file system points to a different host"}
+      {:error, "this local file system belongs to a different host"}
     end
   end
 end

--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -44,8 +44,8 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
     {:local_file_system, node(file_system.origin_pid)}
   end
 
-  def local?(_file_system) do
-    true
+  def type(_file_system) do
+    :local
   end
 
   def default_path(file_system) do

--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -3,11 +3,12 @@ defmodule Livebook.FileSystem.Local do
 
   # File system backed by local disk.
 
-  defstruct [:default_path]
+  defstruct [:node, :default_path]
 
   alias Livebook.FileSystem
 
   @type t :: %__MODULE__{
+          node: node(),
           default_path: FileSystem.path()
         }
 
@@ -28,12 +29,20 @@ defmodule Livebook.FileSystem.Local do
 
     FileSystem.Utils.assert_dir_path!(default_path)
 
-    %__MODULE__{default_path: default_path}
+    %__MODULE__{node: node(), default_path: default_path}
   end
 end
 
 defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
   alias Livebook.FileSystem
+
+  def resource_identifier(file_system) do
+    file_system.node
+  end
+
+  def local?(_file_system) do
+    true
+  end
 
   def default_path(file_system) do
     file_system.default_path

--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -51,148 +51,178 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
   def list(file_system, path, recursive) do
     FileSystem.Utils.assert_dir_path!(path)
 
-    case File.ls(path) do
-      {:ok, filenames} ->
-        paths =
-          Enum.map(filenames, fn name ->
-            path = Path.join(path, name)
-            if File.dir?(path), do: path <> "/", else: path
+    with :ok <- ensure_local(file_system) do
+      case File.ls(path) do
+        {:ok, filenames} ->
+          paths =
+            Enum.map(filenames, fn name ->
+              path = Path.join(path, name)
+              if File.dir?(path), do: path <> "/", else: path
+            end)
+
+          to_traverse =
+            if recursive do
+              Enum.filter(paths, &FileSystem.Utils.dir_path?/1)
+            else
+              []
+            end
+
+          Enum.reduce(to_traverse, {:ok, paths}, fn path, result ->
+            with {:ok, current_paths} <- result,
+                 {:ok, new_paths} <- list(file_system, path, recursive) do
+              {:ok, current_paths ++ new_paths}
+            end
           end)
 
-        to_traverse =
-          if recursive do
-            Enum.filter(paths, &FileSystem.Utils.dir_path?/1)
-          else
-            []
-          end
-
-        Enum.reduce(to_traverse, {:ok, paths}, fn path, result ->
-          with {:ok, current_paths} <- result,
-               {:ok, new_paths} <- list(file_system, path, recursive) do
-            {:ok, current_paths ++ new_paths}
-          end
-        end)
-
-      {:error, error} ->
-        FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def read(_file_system, path) do
-    FileSystem.Utils.assert_regular_path!(path)
-
-    case File.read(path) do
-      {:ok, binary} -> {:ok, binary}
-      {:error, error} -> FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def write(_file_system, path, content) do
-    FileSystem.Utils.assert_regular_path!(path)
-
-    dir = Path.dirname(path)
-
-    with :ok <- File.mkdir_p(dir),
-         :ok <- File.write(path, content) do
-      :ok
-    else
-      {:error, error} -> FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def access(_file_system, path) do
-    case File.stat(path) do
-      {:ok, stat} -> {:ok, stat.access}
-      {:error, error} -> FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def create_dir(_file_system, path) do
-    FileSystem.Utils.assert_dir_path!(path)
-
-    case File.mkdir_p(path) do
-      :ok -> :ok
-      {:error, error} -> FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def remove(_file_system, path) do
-    case File.rm_rf(path) do
-      {:ok, _paths} -> :ok
-      {:error, error, _paths} -> FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def copy(_file_system, source_path, destination_path) do
-    FileSystem.Utils.assert_same_type!(source_path, destination_path)
-
-    containing_dir = Path.dirname(destination_path)
-
-    case File.mkdir_p(containing_dir) do
-      :ok ->
-        case File.cp_r(source_path, destination_path) do
-          {:ok, _paths} -> :ok
-          {:error, error, _path} -> FileSystem.Utils.posix_error(error)
-        end
-
-      {:error, error} ->
-        FileSystem.Utils.posix_error(error)
-    end
-  end
-
-  def rename(_file_system, source_path, destination_path) do
-    FileSystem.Utils.assert_same_type!(source_path, destination_path)
-
-    if File.exists?(destination_path) do
-      FileSystem.Utils.posix_error(:eexist)
-    else
-      containing_dir = Path.dirname(destination_path)
-
-      with :ok <- File.mkdir_p(containing_dir),
-           :ok <- File.rename(source_path, destination_path) do
-        :ok
-      else
         {:error, error} ->
           FileSystem.Utils.posix_error(error)
       end
     end
   end
 
-  def etag_for(_file_system, path) do
-    case File.stat(path) do
-      {:ok, stat} ->
-        %{size: size, mtime: mtime} = stat
-        hash = {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)
-        etag = <<?", hash::binary, ?">>
-        {:ok, etag}
+  def read(file_system, path) do
+    FileSystem.Utils.assert_regular_path!(path)
 
-      {:error, error} ->
-        FileSystem.Utils.posix_error(error)
+    with :ok <- ensure_local(file_system) do
+      case File.read(path) do
+        {:ok, binary} -> {:ok, binary}
+        {:error, error} -> FileSystem.Utils.posix_error(error)
+      end
     end
   end
 
-  def exists?(_file_system, path) do
-    if FileSystem.Utils.dir_path?(path) do
-      {:ok, File.dir?(path)}
-    else
-      {:ok, File.exists?(path)}
+  def write(file_system, path, content) do
+    FileSystem.Utils.assert_regular_path!(path)
+
+    dir = Path.dirname(path)
+
+    with :ok <- ensure_local(file_system) do
+      with :ok <- File.mkdir_p(dir),
+           :ok <- File.write(path, content) do
+        :ok
+      else
+        {:error, error} -> FileSystem.Utils.posix_error(error)
+      end
     end
   end
 
-  def resolve_path(_file_system, dir_path, subject) do
+  def access(file_system, path) do
+    with :ok <- ensure_local(file_system) do
+      case File.stat(path) do
+        {:ok, stat} -> {:ok, stat.access}
+        {:error, error} -> FileSystem.Utils.posix_error(error)
+      end
+    end
+  end
+
+  def create_dir(file_system, path) do
+    FileSystem.Utils.assert_dir_path!(path)
+
+    with :ok <- ensure_local(file_system) do
+      case File.mkdir_p(path) do
+        :ok -> :ok
+        {:error, error} -> FileSystem.Utils.posix_error(error)
+      end
+    end
+  end
+
+  def remove(file_system, path) do
+    with :ok <- ensure_local(file_system) do
+      case File.rm_rf(path) do
+        {:ok, _paths} -> :ok
+        {:error, error, _paths} -> FileSystem.Utils.posix_error(error)
+      end
+    end
+  end
+
+  def copy(file_system, source_path, destination_path) do
+    FileSystem.Utils.assert_same_type!(source_path, destination_path)
+
+    containing_dir = Path.dirname(destination_path)
+
+    with :ok <- ensure_local(file_system) do
+      case File.mkdir_p(containing_dir) do
+        :ok ->
+          case File.cp_r(source_path, destination_path) do
+            {:ok, _paths} -> :ok
+            {:error, error, _path} -> FileSystem.Utils.posix_error(error)
+          end
+
+        {:error, error} ->
+          FileSystem.Utils.posix_error(error)
+      end
+    end
+  end
+
+  def rename(file_system, source_path, destination_path) do
+    FileSystem.Utils.assert_same_type!(source_path, destination_path)
+
+    with :ok <- ensure_local(file_system) do
+      if File.exists?(destination_path) do
+        FileSystem.Utils.posix_error(:eexist)
+      else
+        containing_dir = Path.dirname(destination_path)
+
+        with :ok <- File.mkdir_p(containing_dir),
+             :ok <- File.rename(source_path, destination_path) do
+          :ok
+        else
+          {:error, error} ->
+            FileSystem.Utils.posix_error(error)
+        end
+      end
+    end
+  end
+
+  def etag_for(file_system, path) do
+    with :ok <- ensure_local(file_system) do
+      case File.stat(path) do
+        {:ok, stat} ->
+          %{size: size, mtime: mtime} = stat
+          hash = {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)
+          etag = <<?", hash::binary, ?">>
+          {:ok, etag}
+
+        {:error, error} ->
+          FileSystem.Utils.posix_error(error)
+      end
+    end
+  end
+
+  def exists?(file_system, path) do
+    with :ok <- ensure_local(file_system) do
+      if FileSystem.Utils.dir_path?(path) do
+        {:ok, File.dir?(path)}
+      else
+        {:ok, File.exists?(path)}
+      end
+    end
+  end
+
+  def resolve_path(file_system, dir_path, subject) do
     FileSystem.Utils.assert_dir_path!(dir_path)
 
-    if subject == "" do
-      dir_path
-    else
-      dir? = FileSystem.Utils.dir_path?(subject) or Path.basename(subject) in [".", ".."]
-      expanded_path = Path.expand(subject, dir_path)
-
-      if dir? do
-        FileSystem.Utils.ensure_dir_path(expanded_path)
+    with :ok <- ensure_local(file_system) do
+      if subject == "" do
+        dir_path
       else
-        expanded_path
+        dir? = FileSystem.Utils.dir_path?(subject) or Path.basename(subject) in [".", ".."]
+        expanded_path = Path.expand(subject, dir_path)
+
+        if dir? do
+          FileSystem.Utils.ensure_dir_path(expanded_path)
+        else
+          expanded_path
+        end
       end
+    end
+  end
+
+  defp ensure_local(file_system) do
+    if file_system.node == node() do
+      :ok
+    else
+      {:error, "this local file system points to a different host"}
     end
   end
 end

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -60,7 +60,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
   alias Livebook.FileSystem.S3.XML
 
   def resource_identifier(file_system) do
-    file_system.bucket_url
+    {:s3, file_system.bucket_url}
   end
 
   def local?(_file_system) do

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -59,6 +59,14 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
   alias Livebook.Utils.HTTP
   alias Livebook.FileSystem.S3.XML
 
+  def resource_identifier(file_system) do
+    file_system.bucket_url
+  end
+
+  def local?(_file_system) do
+    false
+  end
+
   def default_path(_file_system) do
     "/"
   end

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -63,8 +63,8 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     {:s3, file_system.bucket_url}
   end
 
-  def local?(_file_system) do
-    false
+  def type(_file_system) do
+    :global
   end
 
   def default_path(_file_system) do

--- a/lib/livebook/session/file_guard.ex
+++ b/lib/livebook/session/file_guard.ex
@@ -12,7 +12,7 @@ defmodule Livebook.Session.FileGuard do
   alias Livebook.FileSystem
 
   @type state :: %{
-          file_with_owner_ref: %{FileSystem.File.t() => reference()}
+          files: %{term() => {FileSystem.File.t(), owner_pid :: pid(), reference()}}
         }
 
   @name __MODULE__
@@ -47,32 +47,55 @@ defmodule Livebook.Session.FileGuard do
 
   @impl true
   def init(_opts) do
-    {:ok, %{file_with_owner_ref: %{}}}
+    {:ok, %{files: %{}}}
   end
 
   @impl true
   def handle_call({:lock, file, owner_pid}, _from, state) do
-    if Map.has_key?(state.file_with_owner_ref, file) do
+    file_id = FileSystem.File.resource_identifier(file)
+
+    if Map.has_key?(state.files, file_id) or lock_globally(file, file_id, owner_pid) == false do
       {:reply, {:error, :already_in_use}, state}
     else
       monitor_ref = Process.monitor(owner_pid)
-      state = put_in(state.file_with_owner_ref[file], monitor_ref)
+      state = put_in(state.files[file_id], {file, owner_pid, monitor_ref})
       {:reply, :ok, state}
     end
   end
 
   @impl true
   def handle_cast({:unlock, file}, state) do
-    {maybe_ref, state} = pop_in(state.file_with_owner_ref[file])
-    maybe_ref && Process.demonitor(maybe_ref, [:flush])
+    file_id = FileSystem.File.resource_identifier(file)
+
+    {maybe_file, state} = pop_in(state.files[file_id])
+
+    with {file, owner_pid, monitor_ref} <- maybe_file do
+      unlock_globally(file, file_id, owner_pid)
+      Process.demonitor(monitor_ref, [:flush])
+    end
 
     {:noreply, state}
   end
 
   @impl true
   def handle_info({:DOWN, ref, :process, _, _}, state) do
-    {file, ^ref} = Enum.find(state.file_with_owner_ref, &(elem(&1, 1) == ref))
-    {_, state} = pop_in(state.file_with_owner_ref[file])
+    state =
+      state.files
+      |> Enum.filter(fn {_file_id, {_file, _owner_pid, monitor_ref}} -> monitor_ref == ref end)
+      |> Enum.reduce(state, fn {file_id, {file, owner_pid, _monitor_ref}}, state ->
+        unlock_globally(file, file_id, owner_pid)
+        {_, state} = pop_in(state.files[file_id])
+        state
+      end)
+
     {:noreply, state}
+  end
+
+  defp lock_globally(file, file_id, owner_pid) do
+    FileSystem.File.local?(file) or :global.set_lock({file_id, owner_pid})
+  end
+
+  defp unlock_globally(file, file_id, owner_pid) do
+    FileSystem.File.local?(file) or :global.del_lock({file_id, owner_pid})
   end
 end

--- a/test/livebook/file_system/local_test.exs
+++ b/test/livebook/file_system/local_test.exs
@@ -510,12 +510,4 @@ defmodule Livebook.FileSystem.LocalTest do
                FileSystem.resolve_path(file_system, "/dir/", "///nested///other/..///file.txt")
     end
   end
-
-  test "file operations an error when the file system is on a different host" do
-    file_system = %{Local.new() | host_id: "definitely another host"}
-    dir_path = "/"
-
-    assert {:error, "this local file system belongs to a different host"} =
-             FileSystem.list(file_system, dir_path, false)
-  end
 end

--- a/test/livebook/file_system/local_test.exs
+++ b/test/livebook/file_system/local_test.exs
@@ -510,4 +510,12 @@ defmodule Livebook.FileSystem.LocalTest do
                FileSystem.resolve_path(file_system, "/dir/", "///nested///other/..///file.txt")
     end
   end
+
+  test "file operations an error when the file system is on a different host" do
+    file_system = %{Local.new() | host_id: "definitely another host"}
+    dir_path = "/"
+
+    assert {:error, "this local file system belongs to a different host"} =
+             FileSystem.list(file_system, dir_path, false)
+  end
 end

--- a/test/livebook/session/file_guard_test.exs
+++ b/test/livebook/session/file_guard_test.exs
@@ -2,21 +2,40 @@ defmodule Livebook.Session.FileGuardTest do
   use ExUnit.Case, async: false
 
   alias Livebook.Session.FileGuard
+  alias Livebook.FileSystem
 
-  test "lock/2 returns an error if the given path is already locked" do
-    assert :ok = FileGuard.lock("/some/path", self())
-    assert {:error, :already_in_use} = FileGuard.lock("/some/path", self())
+  test "lock/2 returns an error if the given file is already locked" do
+    file = FileSystem.File.local("/some/path")
+
+    assert :ok = FileGuard.lock(file, self())
+    assert {:error, :already_in_use} = FileGuard.lock(file, self())
   end
 
-  test "unlock/1 unlocks the given path" do
-    assert :ok = FileGuard.lock("/some/path", self())
-    :ok = FileGuard.unlock("/some/path")
-    assert :ok = FileGuard.lock("/some/path", self())
+  test "lock/2 is agnostic to irrelevant file system configuration" do
+    fs1 = FileSystem.Local.new(default_path: "/path/1/")
+    fs2 = FileSystem.Local.new(default_path: "/path/2/")
+
+    # The file system has different configuration, but it's the same resource
+    file1 = FileSystem.File.new(fs1, "/some/path")
+    file2 = FileSystem.File.new(fs2, "/some/path")
+
+    assert :ok = FileGuard.lock(file1, self())
+    assert {:error, :already_in_use} = FileGuard.lock(file2, self())
   end
 
-  test "path is automatically unloacked when the owner process termiantes" do
+  test "unlock/1 unlocks the given file" do
+    file = FileSystem.File.local("/some/path")
+
+    assert :ok = FileGuard.lock(file, self())
+    :ok = FileGuard.unlock(file)
+    assert :ok = FileGuard.lock(file, self())
+  end
+
+  test "file is automatically unloacked when the owner process termiantes" do
+    file = FileSystem.File.local("/some/path")
+
     owner = spawn(fn -> :ok end)
-    :ok = FileGuard.lock("/some/path", owner)
-    assert :ok = FileGuard.lock("/some/path", self())
+    :ok = FileGuard.lock(file, owner)
+    assert :ok = FileGuard.lock(file, self())
   end
 end


### PR DESCRIPTION
Closes #542.

I updated `Livebook.Session.FileGuard` to use global lock for file systems that are not local.

On a related note, imagine two users within the same session whose LVs are on different nodes. If one user picks a local file for saving and the other user opens the persistence modal, the persistence path is in place, but instead of listing the directory we now show a message that its a file system on a different host.