### PR TITLE
Save static vegalite plot to livemd

### DIFF
--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -154,7 +154,7 @@ defmodule Livebook.LiveMarkdown.Export do
   end
 
   defp render_output({:vega_lite_static, vegalite_data}) do
-    ["```", "vega_lite_static\n", Jason.encode!(vegalite_data), "\n", "```"]
+    ["```", "vega-lite\n", Jason.encode!(vegalite_data), "\n", "```"]
   end
 
   defp render_output(_output), do: :ignored

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -153,11 +153,11 @@ defmodule Livebook.LiveMarkdown.Export do
     [delimiter, "output\n", text, "\n", delimiter]
   end
 
-  defp render_output({:vega_lite_static, vegalite_data}) when vegalite_data == %{},
+  defp render_output({:vega_lite_static, spec}) when spec == %{},
     do: :ignored
 
-  defp render_output({:vega_lite_static, vegalite_data}) do
-    ["```", "vega-lite\n", Jason.encode!(vegalite_data), "\n", "```"]
+  defp render_output({:vega_lite_static, spec}) do
+    ["```", "vega-lite\n", Jason.encode!(spec), "\n", "```"]
   end
 
   defp render_output(_output), do: :ignored

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -153,9 +153,6 @@ defmodule Livebook.LiveMarkdown.Export do
     [delimiter, "output\n", text, "\n", delimiter]
   end
 
-  defp render_output({:vega_lite_static, spec}) when spec == %{},
-    do: :ignored
-
   defp render_output({:vega_lite_static, spec}) do
     ["```", "vega-lite\n", Jason.encode!(spec), "\n", "```"]
   end

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -153,6 +153,10 @@ defmodule Livebook.LiveMarkdown.Export do
     [delimiter, "output\n", text, "\n", delimiter]
   end
 
+  defp render_output({:vega_lite_static, vegalite_data}) do
+    ["```", "vega_lite_static\n", Jason.encode!(vegalite_data), "\n", "```"]
+  end
+
   defp render_output(_output), do: :ignored
 
   defp get_elixir_cell_code(%{source: source, disable_formatting: true}),

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -153,6 +153,9 @@ defmodule Livebook.LiveMarkdown.Export do
     [delimiter, "output\n", text, "\n", delimiter]
   end
 
+  defp render_output({:vega_lite_static, vegalite_data}) when vegalite_data == %{},
+    do: :ignored
+
   defp render_output({:vega_lite_static, vegalite_data}) do
     ["```", "vega-lite\n", Jason.encode!(vegalite_data), "\n", "```"]
   end

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -356,9 +356,6 @@ defmodule Livebook.LiveMarkdown.Import do
       {"reevaluate_automatically", reevaluate_automatically}, attrs ->
         Map.put(attrs, :reevaluate_automatically, reevaluate_automatically)
 
-      {"output_is_vega", output_is_vega}, attrs ->
-        Map.put(attrs, :output_is_vega, output_is_vega)
-
       _entry, attrs ->
         attrs
     end)

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -184,7 +184,7 @@ defmodule Livebook.LiveMarkdown.Import do
          [{"pre", _, [{"code", [{"class", "output"}], [output], %{}}], %{}} | ast],
          outputs
        ) do
-    take_outputs(ast, [output | outputs])
+    take_outputs(ast, [{:text, output} | outputs])
   end
 
   defp take_outputs(
@@ -208,7 +208,6 @@ defmodule Livebook.LiveMarkdown.Import do
   defp build_notebook([{:cell, :elixir, source, outputs} | elems], cells, sections, messages) do
     {metadata, elems} = grab_metadata(elems)
     attrs = cell_metadata_to_attrs(:elixir, metadata)
-    outputs = Enum.map(outputs, fn output -> if is_tuple(output), do: output, else: {:text, output} end )
     cell = %{Notebook.Cell.new(:elixir) | source: source, outputs: outputs} |> Map.merge(attrs)
     build_notebook(elems, [cell | cells], sections, messages)
   end

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -192,7 +192,7 @@ defmodule Livebook.LiveMarkdown.Import do
          outputs
        ) do
     case Jason.decode(output) do
-      {:ok, data} -> take_outputs(ast, [{:vega_lite_static, data} | outputs])
+      {:ok, spec} -> take_outputs(ast, [{:vega_lite_static, spec} | outputs])
       _ -> take_outputs(ast, outputs)
     end
   end

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -188,7 +188,7 @@ defmodule Livebook.LiveMarkdown.Import do
   end
 
   defp take_outputs(
-         [{"pre", _, [{"code", [{"class", "vega_lite_static"}], [output], %{}}], %{}} | ast],
+         [{"pre", _, [{"code", [{"class", "vega-lite"}], [output], %{}}], %{}} | ast],
          outputs
        ) do
     case Jason.decode(output) do

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -678,7 +678,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       assert expected_document == document
     end
 
-    test "includes non-empty vega_lite_static output" do
+    test "includes vega_lite_static output" do
       notebook = %{
         Notebook.new()
         | name: "My Notebook",

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -726,24 +726,28 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                       |> Vl.encode_field(:x, "in", type: :quantitative)
                       |> Vl.encode_field(:y, "out", type: :quantitative)\
                       """,
-                      outputs: [{:vega_lite_static, %{
-                        "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
-                        "data" => %{
-                          "values" => [
-                            %{"in" => 1, "out" => 1},
-                            %{"in" => 2, "out" => 2},
-                            %{"in" => 3, "out" => 3},
-                            %{"in" => 4, "out" => 4},
-                            %{"in" => 5, "out" => 5}]
-                        },
-                        "encoding" => %{
-                          "x" => %{"field" => "in", "type" => "quantitative"},
-                          "y" => %{"field" => "out", "type" => "quantitative"}
-                        },
-                        "height" => 200,
-                        "mark" => "line",
-                        "width" => 500
-                      }}]
+                      outputs: [
+                        {:vega_lite_static,
+                         %{
+                           "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
+                           "data" => %{
+                             "values" => [
+                               %{"in" => 1, "out" => 1},
+                               %{"in" => 2, "out" => 2},
+                               %{"in" => 3, "out" => 3},
+                               %{"in" => 4, "out" => 4},
+                               %{"in" => 5, "out" => 5}
+                             ]
+                           },
+                           "encoding" => %{
+                             "x" => %{"field" => "in", "type" => "quantitative"},
+                             "y" => %{"field" => "out", "type" => "quantitative"}
+                           },
+                           "height" => 200,
+                           "mark" => "line",
+                           "width" => 500
+                         }}
+                      ]
                   }
                 ]
             }

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -650,7 +650,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: """
                       IO.puts("hey")\
                       """,
-                      outputs: [{:vega_lite_static, %{}}, {:table_dynamic, self()}]
+                      outputs: [{:table_dynamic, self()}]
                   }
                 ]
             }
@@ -664,6 +664,107 @@ defmodule Livebook.LiveMarkdown.ExportTest do
 
       ```elixir
       IO.puts("hey")
+      ```
+      """
+
+      document = Export.notebook_to_markdown(notebook, include_outputs: true)
+
+      assert expected_document == document
+    end
+
+    test "includes empty vega_lite_static output" do
+      notebook = %{
+        Notebook.new()
+        | name: "My Notebook",
+          sections: [
+            %{
+              Notebook.Section.new()
+              | name: "Section 1",
+                cells: [
+                  %{
+                    Notebook.Cell.new(:elixir)
+                    | source: """
+                      IO.puts("hey")\
+                      """,
+                      outputs: [{:vega_lite_static, %{}}]
+                  }
+                ]
+            }
+          ]
+      }
+
+      expected_document = """
+      # My Notebook
+
+      ## Section 1
+
+      ```elixir
+      IO.puts("hey")
+      ```
+      """
+
+      document = Export.notebook_to_markdown(notebook, include_outputs: true)
+
+      assert expected_document == document
+    end
+
+    test "includes non-empty vega_lite_static output" do
+      notebook = %{
+        Notebook.new()
+        | name: "My Notebook",
+          sections: [
+            %{
+              Notebook.Section.new()
+              | name: "Section 1",
+                cells: [
+                  %{
+                    Notebook.Cell.new(:elixir)
+                    | source: """
+                      Vl.new(width: 500, height: 200)
+                      |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+                      |> Vl.mark(:line)
+                      |> Vl.encode_field(:x, "in", type: :quantitative)
+                      |> Vl.encode_field(:y, "out", type: :quantitative)\
+                      """,
+                      outputs: [{:vega_lite_static, %{
+                        "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
+                        "data" => %{
+                          "values" => [
+                            %{"in" => 1, "out" => 1},
+                            %{"in" => 2, "out" => 2},
+                            %{"in" => 3, "out" => 3},
+                            %{"in" => 4, "out" => 4},
+                            %{"in" => 5, "out" => 5}]
+                        },
+                        "encoding" => %{
+                          "x" => %{"field" => "in", "type" => "quantitative"},
+                          "y" => %{"field" => "out", "type" => "quantitative"}
+                        },
+                        "height" => 200,
+                        "mark" => "line",
+                        "width" => 500
+                      }}]
+                  }
+                ]
+            }
+          ]
+      }
+
+      expected_document = """
+      # My Notebook
+
+      ## Section 1
+
+      ```elixir
+      Vl.new(width: 500, height: 200)
+      |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+      |> Vl.mark(:line)
+      |> Vl.encode_field(:x, "in", type: :quantitative)
+      |> Vl.encode_field(:y, "out", type: :quantitative)
+      ```
+
+      ```vega-lite
+      {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"values":[{"in":1,"out":1},{"in":2,"out":2},{"in":3,"out":3},{"in":4,"out":4},{"in":5,"out":5}]},"encoding":{"x":{"field":"in","type":"quantitative"},"y":{"field":"out","type":"quantitative"}},"height":200,"mark":"line","width":500}
       ```
       """
 

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -530,7 +530,13 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: """
                       IO.puts("hey")\
                       """,
-                      outputs: ["hey"]
+                      outputs: [
+                        "hey",
+                        {:vega_lite_static,
+                         %{
+                           "$schema" => "https://vega.github.io/schema/vega-lite/v5.json"
+                         }}
+                      ]
                   }
                 ]
             }
@@ -651,42 +657,6 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                       IO.puts("hey")\
                       """,
                       outputs: [{:table_dynamic, self()}]
-                  }
-                ]
-            }
-          ]
-      }
-
-      expected_document = """
-      # My Notebook
-
-      ## Section 1
-
-      ```elixir
-      IO.puts("hey")
-      ```
-      """
-
-      document = Export.notebook_to_markdown(notebook, include_outputs: true)
-
-      assert expected_document == document
-    end
-
-    test "includes empty vega_lite_static output" do
-      notebook = %{
-        Notebook.new()
-        | name: "My Notebook",
-          sections: [
-            %{
-              Notebook.Section.new()
-              | name: "Section 1",
-                cells: [
-                  %{
-                    Notebook.Cell.new(:elixir)
-                    | source: """
-                      IO.puts("hey")\
-                      """,
-                      outputs: [{:vega_lite_static, %{}}]
                   }
                 ]
             }

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -652,11 +652,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     ## Section 1
 
     ```elixir
-    Vl.new(width: 500, height: 200)
-    |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
-    |> Vl.mark(:line)
-    |> Vl.encode_field(:x, "in", type: :quantitative)
-    |> Vl.encode_field(:y, "out", type: :quantitative)
+    :ok
     ```
 
     ```vega-lite
@@ -674,11 +670,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  cells: [
                    %Cell.Elixir{
                      source: """
-                     Vl.new(width: 500, height: 200)
-                     |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
-                     |> Vl.mark(:line)
-                     |> Vl.encode_field(:x, \"in\", type: :quantitative)
-                     |> Vl.encode_field(:y, \"out\", type: :quantitative)\
+                     :ok\
                      """,
                      outputs: []
                    }

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -582,6 +582,111 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     assert %Notebook{name: "My Notebook", autosave_interval_s: 10} = notebook
   end
 
+  test "imports notebook with valid vega-lite output" do
+    markdown = """
+    # My Notebook
+
+    ## Section 1
+
+    ```elixir
+    Vl.new(width: 500, height: 200)
+    |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+    |> Vl.mark(:line)
+    |> Vl.encode_field(:x, "in", type: :quantitative)
+    |> Vl.encode_field(:y, "out", type: :quantitative)
+    ```
+
+    ```vega-lite
+    {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"values":[{"in":1,"out":1},{"in":2,"out":2},{"in":3,"out":3},{"in":4,"out":4},{"in":5,"out":5}]},"encoding":{"x":{"field":"in","type":"quantitative"},"y":{"field":"out","type":"quantitative"}},"height":200,"mark":"line","width":500}
+    ```
+    """
+
+    {notebook, []} = Import.notebook_from_markdown(markdown)
+
+    assert %Notebook{
+      name: "My Notebook",
+      sections: [
+        %Notebook.Section{
+          name: "Section 1",
+          cells: [
+            %Cell.Elixir{
+              source: """
+              Vl.new(width: 500, height: 200)
+              |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+              |> Vl.mark(:line)
+              |> Vl.encode_field(:x, \"in\", type: :quantitative)
+              |> Vl.encode_field(:y, \"out\", type: :quantitative)\
+              """,
+              outputs: [
+                vega_lite_static: %{
+                  "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
+                  "data" => %{
+                    "values" => [
+                      %{"in" => 1, "out" => 1},
+                      %{"in" => 2, "out" => 2},
+                      %{"in" => 3, "out" => 3},
+                      %{"in" => 4, "out" => 4},
+                      %{"in" => 5, "out" => 5}]
+                  },
+                  "encoding" => %{
+                    "x" => %{"field" => "in", "type" => "quantitative"},
+                    "y" => %{"field" => "out", "type" => "quantitative"}
+                  },
+                  "height" => 200,
+                  "mark" => "line",
+                  "width" => 500
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    } = notebook
+  end
+
+  test "imports notebook with invalid vega-lite output" do
+    markdown = """
+    # My Notebook
+
+    ## Section 1
+
+    ```elixir
+    Vl.new(width: 500, height: 200)
+    |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+    |> Vl.mark(:line)
+    |> Vl.encode_field(:x, "in", type: :quantitative)
+    |> Vl.encode_field(:y, "out", type: :quantitative)
+    ```
+
+    ```vega-lite
+    "$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"values":[{"in":1,"out":1},{"in":2,"out":2},{"in":3,"out":3},{"in":4,"out":4},{"in":5,"out":5}]},"encoding":{"x":{"field":"in","type":"quantitative"},"y":{"field":"out","type":"quantitative"}},"height":200,"mark":"line","width":500}
+    ```
+    """
+
+    {notebook, []} = Import.notebook_from_markdown(markdown)
+
+    assert %Notebook{
+      name: "My Notebook",
+      sections: [
+        %Notebook.Section{
+          name: "Section 1",
+          cells: [
+            %Cell.Elixir{
+              source: """
+              Vl.new(width: 500, height: 200)
+              |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+              |> Vl.mark(:line)
+              |> Vl.encode_field(:x, \"in\", type: :quantitative)
+              |> Vl.encode_field(:y, \"out\", type: :quantitative)\
+              """,
+              outputs: []
+            }
+          ]
+        }
+      ]
+    } = notebook
+  end
+
   test "skips invalid input type and returns a message" do
     markdown = """
     # My Notebook

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -660,7 +660,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     ```
 
     ```vega-lite
-    "$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"values":[{"in":1,"out":1},{"in":2,"out":2},{"in":3,"out":3},{"in":4,"out":4},{"in":5,"out":5}]},"encoding":{"x":{"field":"in","type":"quantitative"},"y":{"field":"out","type":"quantitative"}},"height":200,"mark":"line","width":500}
+    not_a_json
     ```
     """
 

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -604,44 +604,45 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     {notebook, []} = Import.notebook_from_markdown(markdown)
 
     assert %Notebook{
-      name: "My Notebook",
-      sections: [
-        %Notebook.Section{
-          name: "Section 1",
-          cells: [
-            %Cell.Elixir{
-              source: """
-              Vl.new(width: 500, height: 200)
-              |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
-              |> Vl.mark(:line)
-              |> Vl.encode_field(:x, \"in\", type: :quantitative)
-              |> Vl.encode_field(:y, \"out\", type: :quantitative)\
-              """,
-              outputs: [
-                vega_lite_static: %{
-                  "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
-                  "data" => %{
-                    "values" => [
-                      %{"in" => 1, "out" => 1},
-                      %{"in" => 2, "out" => 2},
-                      %{"in" => 3, "out" => 3},
-                      %{"in" => 4, "out" => 4},
-                      %{"in" => 5, "out" => 5}]
-                  },
-                  "encoding" => %{
-                    "x" => %{"field" => "in", "type" => "quantitative"},
-                    "y" => %{"field" => "out", "type" => "quantitative"}
-                  },
-                  "height" => 200,
-                  "mark" => "line",
-                  "width" => 500
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    } = notebook
+             name: "My Notebook",
+             sections: [
+               %Notebook.Section{
+                 name: "Section 1",
+                 cells: [
+                   %Cell.Elixir{
+                     source: """
+                     Vl.new(width: 500, height: 200)
+                     |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+                     |> Vl.mark(:line)
+                     |> Vl.encode_field(:x, \"in\", type: :quantitative)
+                     |> Vl.encode_field(:y, \"out\", type: :quantitative)\
+                     """,
+                     outputs: [
+                       vega_lite_static: %{
+                         "$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
+                         "data" => %{
+                           "values" => [
+                             %{"in" => 1, "out" => 1},
+                             %{"in" => 2, "out" => 2},
+                             %{"in" => 3, "out" => 3},
+                             %{"in" => 4, "out" => 4},
+                             %{"in" => 5, "out" => 5}
+                           ]
+                         },
+                         "encoding" => %{
+                           "x" => %{"field" => "in", "type" => "quantitative"},
+                           "y" => %{"field" => "out", "type" => "quantitative"}
+                         },
+                         "height" => 200,
+                         "mark" => "line",
+                         "width" => 500
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ]
+           } = notebook
   end
 
   test "imports notebook with invalid vega-lite output" do
@@ -666,25 +667,25 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     {notebook, []} = Import.notebook_from_markdown(markdown)
 
     assert %Notebook{
-      name: "My Notebook",
-      sections: [
-        %Notebook.Section{
-          name: "Section 1",
-          cells: [
-            %Cell.Elixir{
-              source: """
-              Vl.new(width: 500, height: 200)
-              |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
-              |> Vl.mark(:line)
-              |> Vl.encode_field(:x, \"in\", type: :quantitative)
-              |> Vl.encode_field(:y, \"out\", type: :quantitative)\
-              """,
-              outputs: []
-            }
-          ]
-        }
-      ]
-    } = notebook
+             name: "My Notebook",
+             sections: [
+               %Notebook.Section{
+                 name: "Section 1",
+                 cells: [
+                   %Cell.Elixir{
+                     source: """
+                     Vl.new(width: 500, height: 200)
+                     |> Vl.data_from_series(in: [1, 2, 3, 4, 5], out: [1, 2, 3, 4, 5])
+                     |> Vl.mark(:line)
+                     |> Vl.encode_field(:x, \"in\", type: :quantitative)
+                     |> Vl.encode_field(:y, \"out\", type: :quantitative)\
+                     """,
+                     outputs: []
+                   }
+                 ]
+               }
+             ]
+           } = notebook
   end
 
   test "skips invalid input type and returns a message" do


### PR DESCRIPTION
Hi, I added support for saving static VegaLite plot to the livemd file.

Currently, it saves the VegaLite JSON data and automatically plots it when a user opens the livebook.

This feature can be quite useful in the following situations

- When users only want to view the livebook.
- The livebook is shared as read-only.
- When it takes too much time to rerun the code to get the plot.

Furthermore, if there are more users sharing livebooks on GitHub (or other platforms), then perhaps GitHub will add support for the livemd file, and the embedded plots can be rendered by vegalite.js.