### PR TITLE
Update the list of Ubuntu packages with necessary Erlang applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ pick the one that best fits your use case.
 You can run Livebook on your own machine. You will need
 [Elixir v1.12](https://elixir-lang.org/install.html) or later.
 Livebook also requires the following Erlang applications: `inets`,
-`os_mon`, `runtime_tools`, and `ssl`. Those applications come with
-most Erlang distributions but certain package managers may split
+`os_mon`, `runtime_tools`, `ssl` and `xmerl`. Those applications come
+with most Erlang distributions but certain package managers may split
 them apart. For example, on Ubuntu, these Erlang applications could
 be installed as follows:
 
 ```shell
-sudo apt install erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl
+sudo apt install erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl erlang-xmerl erlang-dev erlang-parsetools
 ```
 
 #### Escript


### PR DESCRIPTION
Closes #703.

We need `erlang-xmerl` for xmerl and `erlang-dev erlang-parsetools` for compiling `earmark_parser`.

I verified the installation in Docker, ftr:

**Dockerfile**

```dockerfile
FROM ubuntu:20.04

RUN apt update && apt install -y wget gnupg && \
  wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && dpkg -i erlang-solutions_2.0_all.deb && \
  apt update && apt install -y elixir
```

```shell
$ docker build --tag ubuntu_bare_elixir .
$ docker run -it --rm ubuntu_bare_elixir
# Inside the container
apt update
apt install erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl erlang-xmerl erlang-dev erlang-parsetools
mix escript.install hex livebook
/root/.mix/escripts/livebook server
```