### PR TITLE
Support file scheme when importing from URL

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -58,7 +58,7 @@ defmodule Livebook.Session do
   @type t :: %__MODULE__{
           id: id(),
           pid: pid(),
-          origin: {:file, FileSystem.File.t()} | {:url, String.t()} | nil,
+          origin: Livebook.ContentLoader.location() | nil,
           notebook_name: String.t(),
           file: FileSystem.File.t() | nil,
           images_dir: FileSystem.File.t(),

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -159,12 +159,13 @@ defmodule LivebookWeb.HomeLive do
   end
 
   def handle_params(%{"url" => url}, _url, %{assigns: %{live_action: :public_import}} = socket) do
-    url
-    |> Livebook.ContentLoader.rewrite_url()
-    |> Livebook.ContentLoader.fetch_content()
+    origin = Livebook.ContentLoader.url_to_location(url)
+
+    origin
+    |> Livebook.ContentLoader.fetch_content_from_location()
     |> case do
       {:ok, content} ->
-        socket = import_content(socket, content, origin: {:url, url})
+        socket = import_content(socket, content, origin: origin)
         {:noreply, socket}
 
       {:error, _message} ->

--- a/lib/livebook_web/live/home_live/import_url_component.ex
+++ b/lib/livebook_web/live/home_live/import_url_component.ex
@@ -1,7 +1,7 @@
 defmodule LivebookWeb.HomeLive.ImportUrlComponent do
   use LivebookWeb, :live_component
 
-  alias Livebook.{ContentLoader, Utils}
+  alias Livebook.Utils
 
   @impl true
   def mount(socket) do
@@ -58,12 +58,13 @@ defmodule LivebookWeb.HomeLive.ImportUrlComponent do
   end
 
   defp do_import(socket, url) do
-    url
-    |> ContentLoader.rewrite_url()
-    |> ContentLoader.fetch_content()
+    origin = Livebook.ContentLoader.url_to_location(url)
+
+    origin
+    |> Livebook.ContentLoader.fetch_content_from_location()
     |> case do
       {:ok, content} ->
-        send(self(), {:import_content, content, [origin: {:url, url}]})
+        send(self(), {:import_content, content, [origin: origin]})
         socket
 
       {:error, message} ->

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -264,6 +264,19 @@ defmodule LivebookWeb.HomeLiveTest do
       assert render(view) =~ "My notebook"
     end
 
+    @tag :tmp_dir
+    test "imports notebook from local file URL", %{conn: conn, tmp_dir: tmp_dir} do
+      notebook_path = Path.join(tmp_dir, "notebook.livemd")
+      File.write!(notebook_path, "# My notebook")
+      notebook_url = "file://" <> notebook_path
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               live(conn, "/import?url=#{URI.encode_www_form(notebook_url)}")
+
+      {:ok, view, _} = live(conn, to)
+      assert render(view) =~ "My notebook"
+    end
+
     test "redirects to the import form on error", %{conn: conn} do
       bypass = Bypass.open()
 


### PR DESCRIPTION
One case where this is relevant is generating `mix docs` locally and testing the "Run in Livebook" badge. Along the way I moved the url/file related stuff into a single module.