### PR TITLE
Rename restart runtime to reconnect

### DIFF
--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -123,7 +123,7 @@ defmodule LivebookWeb.Output do
     <%= if @is_standalone do %>
       <div>
         <button class="button button-gray" phx-click="restart_runtime">
-          Reconnect
+          Reconnect runtime
         </button>
       </div>
     <% else %>

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -123,7 +123,7 @@ defmodule LivebookWeb.Output do
     <%= if @is_standalone do %>
       <div>
         <button class="button button-gray" phx-click="restart_runtime">
-          Restart runtime
+          Reconnect
         </button>
       </div>
     <% else %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6402997/144270933-c8ba2986-34a8-45c9-97d4-2601c6ffc82d.png)
(print screen got from Jose's today stream)

Jose was streaming and got this two different labels for the same action (reconnect the runtime). And he asked to make a PR to fix this. :)