### PR TITLE
Hide reconnect runtime button once reconnected

### DIFF
--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -15,6 +15,7 @@ defmodule LivebookWeb.Output do
                     id: "#{@id}-output#{group_idx}_#{idx}",
                     socket: @socket,
                     runtime: @runtime,
+                    cell_validity_status: @cell_validity_status,
                     input_values: @input_values
                   }) %>
             </div>
@@ -117,8 +118,11 @@ defmodule LivebookWeb.Output do
     live_component(LivebookWeb.Output.ControlComponent, id: id, attrs: attrs)
   end
 
-  defp render_output({:error, formatted, :runtime_restart_required}, %{runtime: runtime})
-       when runtime != nil do
+  defp render_output({:error, formatted, :runtime_restart_required}, %{
+         runtime: runtime,
+         cell_validity_status: cell_validity_status
+       })
+       when runtime != nil and cell_validity_status == :evaluated do
     assigns = %{formatted: formatted, is_standalone: Livebook.Runtime.standalone?(runtime)}
 
     ~H"""

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -120,6 +120,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
             id={"cell-#{@cell_view.id}-evaluation#{evaluation_number(@cell_view.evaluation_status, @cell_view.number_of_evaluations)}-outputs"}
             socket={@socket}
             runtime={@runtime}
+            cell_validity_status={@cell_view.validity_status}
             input_values={@cell_view.input_values} />
         </div>
       <% end %>


### PR DESCRIPTION
Closes #725.

I think we should keep all outputs for clarity and just hide the button, so that it's clear the action was applied.

https://user-images.githubusercontent.com/17034772/144597315-eb53da9e-f4ec-45a4-b01e-85682bf69985.mp4

