### PR TITLE
Fix long section names alignment

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -305,7 +305,7 @@ defmodule LivebookWeb.SessionLive do
       <div class="flex flex-col mt-4 space-y-4">
         <%= for section_item <- @data_view.sections_items do %>
           <div class="flex items-center">
-            <button class="flex-grow flex items-center text-gray-500 hover:text-gray-900"
+            <button class="flex-grow flex items-center text-gray-500 hover:text-gray-900 text-left"
               data-element="sections-list-item"
               data-section-id={section_item.id}>
               <span class="flex items-center space-x-1">


### PR DESCRIPTION
By default content in `<button>` is centered, so long section names would show up as:

![image](https://user-images.githubusercontent.com/17034772/144616482-3cc7c719-2f0c-4f13-aed4-100e682578bf.png)

instead of:

![image](https://user-images.githubusercontent.com/17034772/144616501-b53481ae-f639-44d3-b98c-97ea3ca069cc.png)
