### PR TITLE
fix typo in keyboard shortcuts modal

### DIFF
--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -51,8 +51,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         desc: "Indent lines"
       },
       %{
-        seq: ["ctrl", "]"],
-        seq_mac: ["⌘", "]"],
+        seq: ["ctrl", "["],
+        seq_mac: ["⌘", "["],
         press_all: true,
         desc: "Outdent lines"
       },

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -45,14 +45,14 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         desc: "Delete lines"
       },
       %{
-        seq: ["ctrl", "]"],
-        seq_mac: ["⌘", "]"],
+        seq: ["ctrl", "["],
+        seq_mac: ["⌘", "["],
         press_all: true,
         desc: "Indent lines"
       },
       %{
-        seq: ["ctrl", "["],
-        seq_mac: ["⌘", "["],
+        seq: ["ctrl", "]"],
+        seq_mac: ["⌘", "]"],
         press_all: true,
         desc: "Outdent lines"
       },


### PR DESCRIPTION
Outdent lines keymap was not matching with actual keyboard shortcut `ctrl + [` so it seems like it is a typo therefore I added this change.

before the change:

![image](https://user-images.githubusercontent.com/69393483/144739327-4231ad9d-3fef-489f-9b3b-729a5987742d.png)

after the change:

![image](https://user-images.githubusercontent.com/69393483/144739186-77676142-d07a-4568-a3ab-3a98b0e58dac.png)
