### PR TITLE
Expand System.tmp_dir!() path by default

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -138,7 +138,7 @@ defmodule Livebook.Config do
       if writable_directory?(cache_path) do
         cache_path
       else
-        System.tmp_dir!() |> Path.join("livebook")
+        System.tmp_dir!() |> Path.expand() |> Path.join("livebook")
       end
 
     notebooks_path = Path.join(path, "notebooks")


### PR DESCRIPTION
Since System.tmp_dir!/0 on Windows returns the path with backslashes instead of
frontslash it is piped to Path.expand/1 to normalize it to frontslashes.

This fixes autosave errors on windows.