### PR TITLE
Improve "changed" indicator and batch evaluation shortcuts

### DIFF
--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -81,7 +81,13 @@ solely client-side operations.
   @apply opacity-100 pointer-events-auto;
 }
 
-[data-element="cell"] [data-element="change-indicator"]:not([data-js-shown]) {
+[data-element="cell"] [data-element="cell-status"][data-js-changed] {
+  @apply italic;
+}
+
+[data-element="cell"]
+  [data-element="cell-status"]:not([data-js-changed])
+  [data-element="change-indicator"] {
   @apply invisible;
 }
 

--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -69,9 +69,9 @@ const Cell = {
             const cellStatus = this.el.querySelector(
               `[data-element="cell-status"]`
             );
-            const indicator = cellStatus.querySelector(
-              `[data-element="change-indicator"]`
-            );
+            const indicator =
+              cellStatus &&
+              cellStatus.querySelector(`[data-element="change-indicator"]`);
 
             if (indicator) {
               const source = this.state.liveEditor.getSource();

--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -66,7 +66,10 @@ const Cell = {
           this.state.evaluationDigest = evaluation_digest;
 
           const updateChangeIndicator = () => {
-            const indicator = this.el.querySelector(
+            const cellStatus = this.el.querySelector(
+              `[data-element="cell-status"]`
+            );
+            const indicator = cellStatus.querySelector(
               `[data-element="change-indicator"]`
             );
 
@@ -74,7 +77,7 @@ const Cell = {
               const source = this.state.liveEditor.getSource();
               const digest = md5Base64(source);
               const changed = this.state.evaluationDigest !== digest;
-              indicator.toggleAttribute("data-js-shown", changed);
+              cellStatus.toggleAttribute("data-js-changed", changed);
             }
           };
 

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -297,6 +297,7 @@ function handleDocumentKeyDown(hook, event) {
 
   const cmd = isMacOS() ? event.metaKey : event.ctrlKey;
   const alt = event.altKey;
+  const shift = event.shiftKey;
   const key = event.key;
   const keyBuffer = hook.state.keyBuffer;
 
@@ -321,7 +322,10 @@ function handleDocumentKeyDown(hook, event) {
       if (!monacoInputOpen && !completionBoxOpen && !signatureDetailsOpen) {
         escapeInsertMode(hook);
       }
-    } else if (cmd && key === "Enter" && !alt) {
+    } else if (cmd && shift && !alt && key === "Enter") {
+      cancelEvent(event);
+      queueAllCellsEvaluation(hook);
+    } else if (cmd && !alt && key === "Enter") {
       cancelEvent(event);
       if (hook.state.focusedCellType === "elixir") {
         queueFocusedCellEvaluation(hook);
@@ -350,12 +354,18 @@ function handleDocumentKeyDown(hook, event) {
       saveNotebook(hook);
     } else if (keyBuffer.tryMatch(["d", "d"])) {
       deleteFocusedCell(hook);
-    } else if (keyBuffer.tryMatch(["e", "e"]) || (cmd && key === "Enter")) {
+    } else if (
+      keyBuffer.tryMatch(["e", "a"]) ||
+      (cmd && shift && !alt && key === "Enter")
+    ) {
+      queueAllCellsEvaluation(hook);
+    } else if (
+      keyBuffer.tryMatch(["e", "e"]) ||
+      (cmd && !alt && key === "Enter")
+    ) {
       if (hook.state.focusedCellType === "elixir") {
         queueFocusedCellEvaluation(hook);
       }
-    } else if (keyBuffer.tryMatch(["e", "a"])) {
-      queueAllCellsEvaluation(hook);
     } else if (keyBuffer.tryMatch(["e", "s"])) {
       queueFocusedSectionEvaluation(hook);
     } else if (keyBuffer.tryMatch(["s", "s"])) {

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -324,7 +324,7 @@ function handleDocumentKeyDown(hook, event) {
       }
     } else if (cmd && shift && !alt && key === "Enter") {
       cancelEvent(event);
-      queueAllCellsEvaluation(hook);
+      queueFullCellsEvaluation(hook, true);
     } else if (cmd && !alt && key === "Enter") {
       cancelEvent(event);
       if (hook.state.focusedCellType === "elixir") {
@@ -354,11 +354,10 @@ function handleDocumentKeyDown(hook, event) {
       saveNotebook(hook);
     } else if (keyBuffer.tryMatch(["d", "d"])) {
       deleteFocusedCell(hook);
-    } else if (
-      keyBuffer.tryMatch(["e", "a"]) ||
-      (cmd && shift && !alt && key === "Enter")
-    ) {
-      queueAllCellsEvaluation(hook);
+    } else if (cmd && shift && !alt && key === "Enter") {
+      queueFullCellsEvaluation(hook, true);
+    } else if (keyBuffer.tryMatch(["e", "a"])) {
+      queueFullCellsEvaluation(hook, false);
     } else if (
       keyBuffer.tryMatch(["e", "e"]) ||
       (cmd && !alt && key === "Enter")
@@ -677,8 +676,15 @@ function queueFocusedCellEvaluation(hook) {
   }
 }
 
-function queueAllCellsEvaluation(hook) {
-  hook.pushEvent("queue_all_cells_evaluation", {});
+function queueFullCellsEvaluation(hook, includeFocused) {
+  const forcedCellIds =
+    includeFocused && hook.state.focusedId && isCell(hook.state.focusedId)
+      ? [hook.state.focusedId]
+      : [];
+
+  hook.pushEvent("queue_full_evaluation", {
+    forced_cell_ids: forcedCellIds,
+  });
 }
 
 function queueFocusedSectionEvaluation(hook) {
@@ -686,7 +692,7 @@ function queueFocusedSectionEvaluation(hook) {
     const sectionId = getSectionIdByFocusableId(hook.state.focusedId);
 
     if (sectionId) {
-      hook.pushEvent("queue_section_cells_evaluation", {
+      hook.pushEvent("queue_section_evaluation", {
         section_id: sectionId,
       });
     }

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -417,6 +417,23 @@ defmodule Livebook.Notebook do
   end
 
   @doc """
+  Returns the list with the given parent cells and all of
+  their child cells.
+
+  The cells are not ordered in any secific way.
+  """
+  @spec cell_ids_with_children(t(), list(Cell.id())) :: list(Cell.id())
+  def cell_ids_with_children(data, parent_cell_ids) do
+    graph = cell_dependency_graph(data.notebook)
+
+    for parent_id <- parent_cell_ids,
+        leaf_id <- Graph.leaves(graph),
+        cell_id <- Graph.find_path(graph, leaf_id, parent_id),
+        uniq: true,
+        do: cell_id
+  end
+
+  @doc """
   Computes cell dependency graph.
 
   Every cell has one or none parent cells, so the graph

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -148,7 +148,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends notebook attributes update to the server.
+  Sends notebook attributes update to the server.
   """
   @spec set_notebook_attributes(pid(), map()) :: :ok
   def set_notebook_attributes(pid, attrs) do
@@ -156,7 +156,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends section insertion request to the server.
+  Sends section insertion request to the server.
   """
   @spec insert_section(pid(), non_neg_integer()) :: :ok
   def insert_section(pid, index) do
@@ -164,7 +164,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends section insertion request to the server.
+  Sends section insertion request to the server.
   """
   @spec insert_section_into(pid(), Section.id(), non_neg_integer()) :: :ok
   def insert_section_into(pid, section_id, index) do
@@ -172,7 +172,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends parent update request to the server.
+  Sends parent update request to the server.
   """
   @spec set_section_parent(pid(), Section.id(), Section.id()) :: :ok
   def set_section_parent(pid, section_id, parent_id) do
@@ -180,7 +180,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends parent update request to the server.
+  Sends parent update request to the server.
   """
   @spec unset_section_parent(pid(), Section.id()) :: :ok
   def unset_section_parent(pid, section_id) do
@@ -188,7 +188,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell insertion request to the server.
+  Sends cell insertion request to the server.
   """
   @spec insert_cell(pid(), Section.id(), non_neg_integer(), Cell.type()) :: :ok
   def insert_cell(pid, section_id, index, type) do
@@ -196,7 +196,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends section deletion request to the server.
+  Sends section deletion request to the server.
   """
   @spec delete_section(pid(), Section.id(), boolean()) :: :ok
   def delete_section(pid, section_id, delete_cells) do
@@ -204,7 +204,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell deletion request to the server.
+  Sends cell deletion request to the server.
   """
   @spec delete_cell(pid(), Cell.id()) :: :ok
   def delete_cell(pid, cell_id) do
@@ -212,7 +212,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell restoration request to the server.
+  Sends cell restoration request to the server.
   """
   @spec restore_cell(pid(), Cell.id()) :: :ok
   def restore_cell(pid, cell_id) do
@@ -220,7 +220,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell move request to the server.
+  Sends cell move request to the server.
   """
   @spec move_cell(pid(), Cell.id(), integer()) :: :ok
   def move_cell(pid, cell_id, offset) do
@@ -228,7 +228,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends section move request to the server.
+  Sends section move request to the server.
   """
   @spec move_section(pid(), Section.id(), integer()) :: :ok
   def move_section(pid, section_id, offset) do
@@ -236,7 +236,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell evaluation request to the server.
+  Sends cell evaluation request to the server.
   """
   @spec queue_cell_evaluation(pid(), Cell.id()) :: :ok
   def queue_cell_evaluation(pid, cell_id) do
@@ -244,7 +244,34 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends cell evaluation cancellation request to the server.
+  Sends section evaluation request to the server.
+  """
+  @spec queue_section_evaluation(pid(), Section.id()) :: :ok
+  def queue_section_evaluation(pid, section_id) do
+    GenServer.cast(pid, {:queue_section_evaluation, self(), section_id})
+  end
+
+  @doc """
+  Sends input bound cells evaluation request to the server.
+  """
+  @spec queue_bound_cells_evaluation(pid(), Data.input_id()) :: :ok
+  def queue_bound_cells_evaluation(pid, input_id) do
+    GenServer.cast(pid, {:queue_bound_cells_evaluation, self(), input_id})
+  end
+
+  @doc """
+  Sends full evaluation request to the server.
+
+  All outdated (new/stale/changed) cellss, as well as cells given
+  as `forced_cell_ids` are scheduled for evaluation.
+  """
+  @spec queue_full_evaluation(pid(), list(Cell.id())) :: :ok
+  def queue_full_evaluation(pid, forced_cell_ids) do
+    GenServer.cast(pid, {:queue_full_evaluation, self(), forced_cell_ids})
+  end
+
+  @doc """
+  Sends cell evaluation cancellation request to the server.
   """
   @spec cancel_cell_evaluation(pid(), Cell.id()) :: :ok
   def cancel_cell_evaluation(pid, cell_id) do
@@ -252,7 +279,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends erase outputs request to the server.
+  Sends erase outputs request to the server.
   """
   @spec erase_outputs(pid()) :: :ok
   def erase_outputs(pid) do
@@ -260,7 +287,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends notebook name update request to the server.
+  Sends notebook name update request to the server.
   """
   @spec set_notebook_name(pid(), String.t()) :: :ok
   def set_notebook_name(pid, name) do
@@ -268,7 +295,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends section name update request to the server.
+  Sends section name update request to the server.
   """
   @spec set_section_name(pid(), Section.id(), String.t()) :: :ok
   def set_section_name(pid, section_id, name) do
@@ -276,7 +303,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends a cell delta to apply to the server.
+  Sends a cell delta to apply to the server.
   """
   @spec apply_cell_delta(pid(), Cell.id(), Delta.t(), Data.cell_revision()) :: :ok
   def apply_cell_delta(pid, cell_id, delta, revision) do
@@ -284,7 +311,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously informs at what revision the given client is.
+  Informs at what revision the given client is.
 
   This helps to remove old deltas that are no longer necessary.
   """
@@ -294,7 +321,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends a cell attributes update to the server.
+  Sends a cell attributes update to the server.
   """
   @spec set_cell_attributes(pid(), Cell.id(), map()) :: :ok
   def set_cell_attributes(pid, cell_id, attrs) do
@@ -302,15 +329,15 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends a input value update to the server.
+  Sends a input value update to the server.
   """
-  @spec set_input_value(pid(), Session.input_id(), term()) :: :ok
+  @spec set_input_value(pid(), Data.input_id(), term()) :: :ok
   def set_input_value(pid, input_id, value) do
     GenServer.cast(pid, {:set_input_value, self(), input_id, value})
   end
 
   @doc """
-  Asynchronously connects to the given runtime.
+  Connects to the given runtime.
 
   Note that this results in initializing the corresponding remote node
   with modules and processes required for evaluation.
@@ -321,7 +348,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously disconnects from the current runtime.
+  Disconnects from the current runtime.
 
   Note that this results in clearing the evaluation state.
   """
@@ -331,7 +358,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends file location update request to the server.
+  Sends file location update request to the server.
   """
   @spec set_file(pid(), FileSystem.File.t() | nil) :: :ok
   def set_file(pid, file) do
@@ -339,7 +366,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends save request to the server.
+  Sends save request to the server.
 
   If there's a file set and the notebook changed since the last save,
   it will be persisted to said file.
@@ -360,7 +387,7 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends a close request to the server.
+  Sends a close request to the server.
 
   This results in saving the file and broadcasting
   a :closed message to the session topic.
@@ -533,7 +560,35 @@ defmodule Livebook.Session do
   end
 
   def handle_cast({:queue_cell_evaluation, client_pid, cell_id}, state) do
-    operation = {:queue_cell_evaluation, client_pid, cell_id}
+    operation = {:queue_cells_evaluation, client_pid, [cell_id]}
+    {:noreply, handle_operation(state, operation)}
+  end
+
+  def handle_cast({:queue_section_evaluation, client_pid, section_id}, state) do
+    case Notebook.fetch_section(state.data.notebook, section_id) do
+      {:ok, section} ->
+        cell_ids = for cell <- section.cells, is_struct(cell, Cell.Elixir), do: cell.id
+        operation = {:queue_cells_evaluation, client_pid, cell_ids}
+        {:noreply, handle_operation(state, operation)}
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_cast({:queue_bound_cells_evaluation, client_pid, input_id}, state) do
+    cell_ids =
+      for {bound_cell, _} <- Data.bound_cells_with_section(state.data, input_id),
+          do: bound_cell.id
+
+    operation = {:queue_cells_evaluation, client_pid, cell_ids}
+    {:noreply, handle_operation(state, operation)}
+  end
+
+  def handle_cast({:queue_full_evaluation, client_pid, forced_cell_ids}, state) do
+    cell_ids = Data.cell_ids_for_full_evaluation(state.data, forced_cell_ids)
+
+    operation = {:queue_cells_evaluation, client_pid, cell_ids}
     {:noreply, handle_operation(state, operation)}
   end
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -262,7 +262,7 @@ defmodule Livebook.Session do
   @doc """
   Sends full evaluation request to the server.
 
-  All outdated (new/stale/changed) cellss, as well as cells given
+  All outdated (new/stale/changed) cells, as well as cells given
   as `forced_cell_ids` are scheduled for evaluation.
   """
   @spec queue_full_evaluation(pid(), list(Cell.id())) :: :ok

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -309,7 +309,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     ~H"""
     <div class={"#{if(@tooltip, do: "tooltip")} bottom distant-medium"} data-tooltip={@tooltip}>
       <div class="flex items-center space-x-1">
-        <div class="flex text-xs text-gray-400">
+        <div class="flex text-xs text-gray-400" data-element="cell-status">
           <%= render_slot(@inner_block) %>
           <%= if @change_indicator do %>
             <span data-element="change-indicator">*</span>

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -118,6 +118,13 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         basic: true
       },
       %{
+        seq: ["ctrl", "shift", "↵"],
+        seq_mac: ["⌘", "⇧", "↵"],
+        press_all: true,
+        desc: "Evaluate all stale/new cells in either mode",
+        basic: true
+      },
+      %{
         seq: ["ctrl", "s"],
         seq_mac: ["⌘", "s"],
         press_all: true,

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -101,7 +101,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["d", "d"], desc: "Delete cell", basic: true},
       %{seq: ["e", "e"], desc: "Evaluate cell"},
       %{seq: ["e", "s"], desc: "Evaluate section"},
-      %{seq: ["e", "a"], desc: "Evaluate all stale/new cells", basic: true},
+      %{seq: ["e", "a"], desc: "Evaluate all outdated cells", basic: true},
       %{seq: ["e", "x"], desc: "Cancel cell evaluation"},
       %{seq: ["s", "s"], desc: "Toggle sections panel"},
       %{seq: ["s", "u"], desc: "Toggle users panel"},
@@ -121,7 +121,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         seq: ["ctrl", "shift", "↵"],
         seq_mac: ["⌘", "⇧", "↵"],
         press_all: true,
-        desc: "Evaluate all stale/new cells in either mode",
+        desc: "Evaluate current and all outdated cells",
         basic: true
       },
       %{

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -219,11 +219,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -250,10 +248,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
       operation = {:set_section_parent, self(), "s2", "s1"}
@@ -337,11 +333,9 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -369,10 +363,8 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
       operation = {:unset_section_parent, self(), "s2"}
@@ -527,9 +519,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c2"},
           # Evaluate both cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
@@ -553,11 +544,9 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -585,11 +574,9 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -632,8 +619,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:delete_cell, self(), "c1"}
@@ -680,8 +666,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:delete_cell, self(), "c2"}
@@ -700,9 +685,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           # Evaluate both cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
@@ -723,9 +707,8 @@ defmodule Livebook.Session.DataTest do
           {:set_cell_attributes, self(), "c2", %{reevaluate_automatically: true}},
           # Evaluate both cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
@@ -745,7 +728,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           # Evaluate the elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c2"},
+          {:queue_cells_evaluation, self(), ["c2"]},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
@@ -869,13 +852,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 3, :elixir, "c4"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -910,13 +890,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 3, :elixir, "c4"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -975,11 +952,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -1000,7 +975,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :markdown, "c2"},
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -1023,8 +998,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:move_cell, self(), "c2", -1}
@@ -1047,9 +1021,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -1077,13 +1050,10 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -1116,15 +1086,11 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s4", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4", "c5"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c5"},
           {:add_cell_evaluation_response, self(), "c5", @eval_resp, @eval_meta}
         ])
 
@@ -1154,11 +1120,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -1199,13 +1163,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 1, :elixir, "c4"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -1244,13 +1205,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 1, :elixir, "c4"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -1289,11 +1247,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c3"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -1315,7 +1271,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :markdown, "c2"},
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -1339,8 +1295,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c2"},
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:move_section, self(), "s2", -1}
@@ -1367,9 +1322,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s4", 0, :markdown, "c4"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -1398,13 +1352,10 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s2", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta}
         ])
 
@@ -1452,10 +1403,16 @@ defmodule Livebook.Session.DataTest do
     end
   end
 
-  describe "apply_operation/2 given :queue_cell_evaluation" do
+  describe "apply_operation/2 given :queue_cells_evaluation" do
+    test "returns an error given an empty list of cells" do
+      data = Data.new()
+      operation = {:queue_cells_evaluation, self(), []}
+      assert :error = Data.apply_operation(data, operation)
+    end
+
     test "returns an error given invalid cell id" do
       data = Data.new()
-      operation = {:queue_cell_evaluation, self(), "nonexistent"}
+      operation = {:queue_cells_evaluation, self(), ["nonexistent"]}
       assert :error = Data.apply_operation(data, operation)
     end
 
@@ -1466,7 +1423,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :markdown, "c1"}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c1"}
+      operation = {:queue_cells_evaluation, self(), ["c1"]}
       assert :error = Data.apply_operation(data, operation)
     end
 
@@ -1476,10 +1433,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c1"}
+      operation = {:queue_cells_evaluation, self(), ["c1"]}
       assert :error = Data.apply_operation(data, operation)
     end
 
@@ -1490,7 +1447,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c1"}
+      operation = {:queue_cells_evaluation, self(), ["c1"]}
 
       assert {:ok,
               %{
@@ -1505,10 +1462,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c2"}
+      operation = {:queue_cells_evaluation, self(), ["c2"]}
 
       assert {:ok,
               %{
@@ -1530,7 +1487,7 @@ defmodule Livebook.Session.DataTest do
           {:set_runtime, self(), NoopRuntime.new()}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c1"}
+      operation = {:queue_cells_evaluation, self(), ["c1"]}
 
       assert {:ok,
               %{
@@ -1547,7 +1504,7 @@ defmodule Livebook.Session.DataTest do
           {:set_runtime, self(), NoopRuntime.new()}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c1"}
+      operation = {:queue_cells_evaluation, self(), ["c1"]}
 
       assert {:ok, _data, [{:start_evaluation, %{id: "c1"}, %{id: "s1"}}]} =
                Data.apply_operation(data, operation)
@@ -1560,10 +1517,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c2"}
+      operation = {:queue_cells_evaluation, self(), ["c2"]}
 
       assert {:ok,
               %{
@@ -1580,10 +1537,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 1, "s2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c2"}
+      operation = {:queue_cells_evaluation, self(), ["c2"]}
 
       assert {:ok,
               %{
@@ -1606,12 +1563,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 1, :elixir, "c4"},
           # Evaluate first 2 cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
           # Evaluate the first cell, so the second becomes stale
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -1627,7 +1583,7 @@ defmodule Livebook.Session.DataTest do
       # Queuing cell 4 should also queue cell 3 and cell 2,
       # so that they all become evaluated.
 
-      operation = {:queue_cell_evaluation, self(), "c4"}
+      operation = {:queue_cells_evaluation, self(), ["c4"]}
 
       assert {:ok,
               %{
@@ -1656,7 +1612,7 @@ defmodule Livebook.Session.DataTest do
           {:set_runtime, self(), NoopRuntime.new()}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c3"}
+      operation = {:queue_cells_evaluation, self(), ["c3"]}
 
       # Cell 3 depends directly on cell 1, so cell 2 shouldn't be queued
 
@@ -1686,12 +1642,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c3"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c3"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c2"}
+      operation = {:queue_cells_evaluation, self(), ["c2"]}
 
       assert {:ok,
               %{
@@ -1715,11 +1670,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c2"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c2"}
+      operation = {:queue_cells_evaluation, self(), ["c2"]}
 
       assert {:ok,
               %{
@@ -1742,14 +1697,12 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c4"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"}
+          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c3"}
+      operation = {:queue_cells_evaluation, self(), ["c3"]}
 
       assert {:ok,
               %{
@@ -1775,12 +1728,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c3"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
-      operation = {:queue_cell_evaluation, self(), "c3"}
+      operation = {:queue_cells_evaluation, self(), ["c3"]}
 
       assert {:ok,
               %{
@@ -1797,7 +1749,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:evaluation_started, self(), "c1", "digest"}
@@ -1821,7 +1773,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_output, self(), "c1", "Hello!"}
@@ -1844,7 +1796,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_output, self(), "c1", "Hola"}
         ])
 
@@ -1868,7 +1820,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_output, self(), "c1", "Hola"}
         ])
 
@@ -1892,7 +1844,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -1916,7 +1868,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:set_notebook_attributes, self(), %{persist_outputs: true}},
           {:mark_as_not_dirty, self()}
         ])
@@ -1934,7 +1886,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation =
@@ -1958,7 +1910,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -1978,10 +1930,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
           # Evaluate the first cell
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
           # Start evaluating the second cell
-          {:queue_cell_evaluation, self(), "c2"},
+          {:queue_cells_evaluation, self(), ["c2"]},
           # Remove the first cell, marking the second as stale
           {:delete_cell, self(), "c1"}
         ])
@@ -2001,8 +1953,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -2024,8 +1975,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 1, "s2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -2052,14 +2002,12 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           # Evaluate all cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
           # Queue the first cell again
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -2088,16 +2036,13 @@ defmodule Livebook.Session.DataTest do
           {:set_section_parent, self(), "s4", "s1"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c4", @eval_resp, @eval_meta},
           # Queue the second cell again
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c2"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
@@ -2125,14 +2070,12 @@ defmodule Livebook.Session.DataTest do
           {:set_cell_attributes, self(), "c3", %{reevaluate_automatically: true}},
           # Evaluate all cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
           # Queue the first cell again
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -2155,7 +2098,7 @@ defmodule Livebook.Session.DataTest do
           {:set_cell_attributes, self(), "c2", %{reevaluate_automatically: true}},
           # Evaluate all cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -2178,12 +2121,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
           # Make the Elixir cell evaluating
-          {:queue_cell_evaluation, self(), "c2"},
+          {:queue_cells_evaluation, self(), ["c2"]},
           # Bind the input (effectively read the current value)
           {:bind_input, self(), "c2", "i1"},
           # Change the input value, while the cell is evaluating
@@ -2206,7 +2148,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation =
@@ -2228,7 +2170,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:set_notebook_attributes, self(), %{persist_outputs: true}},
           {:mark_as_not_dirty, self()}
         ])
@@ -2247,7 +2189,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       operation = {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta}
@@ -2263,10 +2205,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:set_input_value, self(), "i1", "value"},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       # Output the same input again
@@ -2283,10 +2225,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:set_input_value, self(), "i1", "value"},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       # This time w don't output the input
@@ -2306,12 +2248,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:add_cell_evaluation_response, self(), "c2", {:input, input}, @eval_meta},
           {:set_input_value, self(), "i1", "value"},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       # This time w don't output the input
@@ -2333,11 +2274,11 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c1"},
           {:insert_cell, self(), "s3", 0, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:set_input_value, self(), "i1", "value"},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1"]},
+          {:queue_cells_evaluation, self(), ["c2"]}
         ])
 
       # This time w don't output the input
@@ -2380,9 +2321,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c2"]}
         ])
 
       operation = {:bind_input, self(), "c2", "i1"}
@@ -2407,9 +2348,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -2438,11 +2377,9 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 1, :elixir, "c3"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
       operation = {:reflect_main_evaluation_failure, self()}
@@ -2475,11 +2412,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c4"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"},
-          {:queue_cell_evaluation, self(), "c4"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta}
         ])
 
@@ -2515,7 +2449,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -2532,10 +2466,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 1, "s2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c2"}
@@ -2561,8 +2493,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c1"}
@@ -2583,11 +2514,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s3", 0, :elixir, "c4"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"},
-          {:queue_cell_evaluation, self(), "c4"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c2"}
@@ -2615,8 +2543,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"}
+          {:queue_cells_evaluation, self(), ["c1", "c2"]}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c2"}
@@ -2636,9 +2563,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c2"}
@@ -2662,10 +2587,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           {:set_section_parent, self(), "s2", "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"}
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
       operation = {:erase_outputs, self()}
@@ -2692,9 +2615,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :markdown, "c2"},
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c3"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c3"},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
         ])
 
@@ -3166,11 +3088,10 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c2"},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
         ])
 
@@ -3203,7 +3124,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta}
         ])
 
@@ -3224,10 +3145,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           {:insert_cell, self(), "s1", 3, :elixir, "c4"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"},
-          {:queue_cell_evaluation, self(), "c3"},
-          {:queue_cell_evaluation, self(), "c4"},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3", "c4"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
           {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
@@ -3266,14 +3184,12 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
-          {:queue_cell_evaluation, self(), "c2"},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
           # Second section with evaluating and queued cells
           {:insert_section, self(), 1, "s2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           {:insert_cell, self(), "s2", 1, :elixir, "c4"},
-          {:queue_cell_evaluation, self(), "c3"},
-          {:queue_cell_evaluation, self(), "c4"}
+          {:queue_cells_evaluation, self(), ["c3", "c4"]}
         ])
 
       runtime = NoopRuntime.new()
@@ -3299,7 +3215,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
-          {:queue_cell_evaluation, self(), "c1"}
+          {:queue_cells_evaluation, self(), ["c1"]}
         ])
 
       runtime = NoopRuntime.new()
@@ -3372,13 +3288,100 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 2, :elixir, "c3"},
           {:insert_cell, self(), "s1", 4, :elixir, "c4"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", {:input, input}, @eval_meta},
           {:bind_input, self(), "c2", "i1"},
           {:bind_input, self(), "c4", "i1"}
         ])
 
       assert [{%{id: "c2"}, _}, {%{id: "c4"}, _}] = Data.bound_cells_with_section(data, "i1")
+    end
+  end
+
+  @empty_digest :erlang.md5("")
+
+  describe "cell_ids_for_full_evaluation/2" do
+    test "includes changed cells with children" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:insert_cell, self(), "s1", 2, :elixir, "c3"},
+          {:set_runtime, self(), NoopRuntime.new()},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:evaluation_started, self(), "c1", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c2", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c3", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
+          # Modify cell 2
+          {:client_join, self(), User.new()},
+          {:apply_cell_delta, self(), "c2", Delta.new() |> Delta.insert("cats"), 1}
+        ])
+
+      assert Data.cell_ids_for_full_evaluation(data, []) |> Enum.sort() == ["c2", "c3"]
+    end
+
+    test "includes fresh cells with children" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c3"},
+          {:set_runtime, self(), NoopRuntime.new()},
+          {:queue_cells_evaluation, self(), ["c1", "c3"]},
+          {:evaluation_started, self(), "c1", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c3", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta},
+          # Insert a fresh cell between cell 1 and cell 3
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"}
+        ])
+
+      assert Data.cell_ids_for_full_evaluation(data, []) |> Enum.sort() == ["c2", "c3"]
+    end
+
+    test "includes stale cells" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:set_runtime, self(), NoopRuntime.new()},
+          {:queue_cells_evaluation, self(), ["c1", "c2"]},
+          {:evaluation_started, self(), "c1", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c2", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
+          # Reevaluate cell 2
+          {:queue_cells_evaluation, self(), ["c1"]},
+          {:evaluation_started, self(), "c1", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
+        ])
+
+      assert Data.cell_ids_for_full_evaluation(data, []) |> Enum.sort() == ["c2"]
+    end
+
+    test "includes forced cells with children" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:insert_cell, self(), "s1", 2, :elixir, "c3"},
+          {:set_runtime, self(), NoopRuntime.new()},
+          {:queue_cells_evaluation, self(), ["c1", "c2", "c3"]},
+          {:evaluation_started, self(), "c1", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c2", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c2", @eval_resp, @eval_meta},
+          {:evaluation_started, self(), "c3", @empty_digest},
+          {:add_cell_evaluation_response, self(), "c3", @eval_resp, @eval_meta}
+        ])
+
+      assert Data.cell_ids_for_full_evaluation(data, ["c2"]) |> Enum.sort() == ["c2", "c3"]
     end
   end
 end

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -90,7 +90,7 @@ defmodule Livebook.SessionTest do
 
       Session.queue_cell_evaluation(session.pid, cell_id)
 
-      assert_receive {:operation, {:queue_cell_evaluation, ^pid, ^cell_id}}
+      assert_receive {:operation, {:queue_cells_evaluation, ^pid, [^cell_id]}}
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id, _,


### PR DESCRIPTION
Closes #758, closes #759.

![image](https://user-images.githubusercontent.com/17034772/145053742-a9f8375c-1c09-48a4-a8a0-c65e4da0b052.png)

As for the shortcut, `ea` evaluates all outdated cells, while Ctrl+Shift+Enter **additionally** evaluates the focused cell.

I changed the Data operation from `{:queue_cell_evaluation, _, cell_id}` to `{:queue_cells_evaluation, _, cell_ids}`, consequently we don't unnecessarily send a bunch of messages when evaluating more cells at once.