### PR TITLE
Fix error on back after closing session

### DIFF
--- a/lib/livebook_web/live/home_live/close_session_component.ex
+++ b/lib/livebook_web/live/home_live/close_session_component.ex
@@ -30,6 +30,6 @@ defmodule LivebookWeb.HomeLive.CloseSessionComponent do
   @impl true
   def handle_event("close", %{}, socket) do
     Livebook.Session.close(socket.assigns.session.pid)
-    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+    {:noreply, push_patch(socket, to: socket.assigns.return_to, replace: true)}
   end
 end

--- a/lib/livebook_web/live/session_live/delete_section_component.ex
+++ b/lib/livebook_web/live/session_live/delete_section_component.ex
@@ -44,6 +44,6 @@ defmodule LivebookWeb.SessionLive.DeleteSectionComponent do
       delete_cells?
     )
 
-    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+    {:noreply, push_patch(socket, to: socket.assigns.return_to, replace: true)}
   end
 end


### PR DESCRIPTION
Clicking the browsers back button after closing a session resulted in an error, since it was trying to close an already closed notebook.
I added `replace: true` to the `push_patch`, so the link for closing the notebook would be replaced in the history.