### PR TITLE
Update the vim modeline comment to not error

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ file gets rendered on GitHub, so all you need to do is add a magic comment in ev
 such notebook:
 
 ```
-<!-- vim: syntax=markdown -->
+<!-- vim: set syntax=markdown: -->
 
 # My notebook
 

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -471,7 +471,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       | name: "My Notebook",
         persist_outputs: true,
         leading_comments: [
-          ["vim: syntax=markdown"],
+          ["vim: set syntax=markdown:"],
           ["nowhitespace"],
           ["  Multi", "  line"]
         ],
@@ -492,7 +492,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
     }
 
     expected_document = """
-    <!-- vim: syntax=markdown -->
+    <!-- vim: set syntax=markdown: -->
 
     <!-- nowhitespace -->
 

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -475,7 +475,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
 
   test "imports comments preceding the notebook title" do
     markdown = """
-    <!-- vim: syntax=markdown -->
+    <!-- vim: set syntax=markdown: -->
 
     <!--nowhitespace-->
 
@@ -499,7 +499,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
              name: "My Notebook",
              persist_outputs: true,
              leading_comments: [
-               ["vim: syntax=markdown"],
+               ["vim: set syntax=markdown:"],
                ["nowhitespace"],
                ["  Multi", "  line"]
              ],
@@ -522,7 +522,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     markdown = """
     <!-- livebook:{"persist_outputs":true} -->
 
-    <!-- vim: syntax=markdown -->
+    <!-- vim: set syntax=markdown: -->
 
     # My Notebook
 


### PR DESCRIPTION
The currently suggested vim modeline formatting string to allow .livemd files to render as markdown on GitHub works, but confuses vim itself.

```
<!-- vim: syntax=markdown -->
```

When opening a .livemd file with the suggested modeline in vim it errors when it tries to parse `-->` as a modeline option.

e.g.

```
"2021/day2.livemd" 81L, 1616B
Error detected while processing modelines:
line    1:
E518: Unknown option: -->
```

The fix is to replace the suggested vim modeline

```
<!-- vim: syntax=markdown -->
```

With a modeline declaration format that indicates when the modeline options are complete, allowing vim to ignore the rest of the line.

```
<!-- vim: set syntax=markdown: -->
```

Reference
- vim issue: https://github.com/vim/vim/issues/1648
- especially this comment: https://github.com/vim/vim/issues/1648#issuecomment-296386153

Fixes #773