### PR TITLE
fix handleDocumentFocus error

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -427,7 +427,7 @@ function handleDocumentMouseDown(hook, event) {
   }
 
   // Find the focusable element, if one was clicked
-  const focusableEl = event.target.closest(`[data-focusable-id]`);
+  const focusableEl = event.target.closest ? event.target.closest(`[data-focusable-id]`) : false;
   const focusableId = focusableEl ? focusableEl.dataset.focusableId : null;
   const insertMode = editableElementClicked(event, focusableEl);
 
@@ -461,7 +461,7 @@ function editableElementClicked(event, element) {
  * Focuses a focusable element if the user "tab"s anywhere into it.
  */
 function handleDocumentFocus(hook, event) {
-  const focusableEl = event.target.closest(`[data-focusable-id]`);
+  const focusableEl = event.target.closest ? event.target.closest(`[data-focusable-id]`) : false;
 
   if (focusableEl) {
     const focusableId = focusableEl.dataset.focusableId;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -463,7 +463,8 @@ function editableElementClicked(event, element) {
  * Focuses a focusable element if the user "tab"s anywhere into it.
  */
 function handleDocumentFocus(hook, event) {
-  const focusableEl = event.target.closest && event.target.closest(`[data-focusable-id]`);
+  const focusableEl =
+    event.target.closest && event.target.closest(`[data-focusable-id]`);
 
   if (focusableEl) {
     const focusableId = focusableEl.dataset.focusableId;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -463,9 +463,7 @@ function editableElementClicked(event, element) {
  * Focuses a focusable element if the user "tab"s anywhere into it.
  */
 function handleDocumentFocus(hook, event) {
-  const focusableEl = event.target.closest
-    ? event.target.closest(`[data-focusable-id]`)
-    : false;
+  const focusableEl = event.target.closest && event.target.closest(`[data-focusable-id]`);
 
   if (focusableEl) {
     const focusableId = focusableEl.dataset.focusableId;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -427,7 +427,9 @@ function handleDocumentMouseDown(hook, event) {
   }
 
   // Find the focusable element, if one was clicked
-  const focusableEl = event.target.closest ? event.target.closest(`[data-focusable-id]`) : false;
+  const focusableEl = event.target.closest
+    ? event.target.closest(`[data-focusable-id]`)
+    : false;
   const focusableId = focusableEl ? focusableEl.dataset.focusableId : null;
   const insertMode = editableElementClicked(event, focusableEl);
 
@@ -461,7 +463,9 @@ function editableElementClicked(event, element) {
  * Focuses a focusable element if the user "tab"s anywhere into it.
  */
 function handleDocumentFocus(hook, event) {
-  const focusableEl = event.target.closest ? event.target.closest(`[data-focusable-id]`) : false;
+  const focusableEl = event.target.closest
+    ? event.target.closest(`[data-focusable-id]`)
+    : false;
 
   if (focusableEl) {
     const focusableId = focusableEl.dataset.focusableId;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -427,9 +427,7 @@ function handleDocumentMouseDown(hook, event) {
   }
 
   // Find the focusable element, if one was clicked
-  const focusableEl = event.target.closest
-    ? event.target.closest(`[data-focusable-id]`)
-    : false;
+  const focusableEl = event.target.closest(`[data-focusable-id]`);
   const focusableId = focusableEl ? focusableEl.dataset.focusableId : null;
   const insertMode = editableElementClicked(event, focusableEl);
 


### PR DESCRIPTION
Fix error #776
```
Correction Uncaught TypeError: t.target.closest is not a function
```

To simulate the problem, just place the focus in another location, for example:
Change tabs and then return to editor.
