### PR TITLE
Add completion for struct keys

### DIFF
--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -150,7 +150,17 @@ defmodule Livebook.Intellisense do
       label: "#{name}",
       kind: :field,
       detail: "#{inspect(struct)} struct field",
-      documentation: "Default: #{inspect(default)}",
+      documentation:
+        join_with_divider([
+          code(name),
+          """
+          **Default**
+
+          ```
+          #{inspect(default, pretty: true, width: @line_length)}
+          ```
+          """
+        ]),
       insert_text: "#{name}: "
     }
 

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -138,11 +138,11 @@ defmodule Livebook.Intellisense do
 
   defp format_completion_item({:map_field, name, _value}),
     do: %{
-      label: name,
+      label: "#{name}",
       kind: :field,
       detail: "field",
       documentation: nil,
-      insert_text: name
+      insert_text: "#{name}"
     }
 
   defp format_completion_item({:in_struct_field, struct_name, name, default}),

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -145,11 +145,11 @@ defmodule Livebook.Intellisense do
       insert_text: "#{name}"
     }
 
-  defp format_completion_item({:in_struct_field, struct_name, name, default}),
+  defp format_completion_item({:in_struct_field, struct, name, default}),
     do: %{
       label: "#{name}",
       kind: :field,
-      detail: "#{struct_name} struct field",
+      detail: "#{inspect(struct)} struct field",
       documentation: "Default: #{inspect(default)}",
       insert_text: "#{name}: "
     }
@@ -349,10 +349,16 @@ defmodule Livebook.Intellisense do
 
   defp format_details_item({:map_field, name, _value}), do: code(name)
 
-  defp format_details_item({:in_struct_field, _struct_name, name, default}) do
+  defp format_details_item({:in_struct_field, _struct, name, default}) do
     join_with_divider([
       code(name),
-      "Default: #{inspect(default)}"
+      """
+      **Default**
+
+      ```
+      #{inspect(default, pretty: true, width: @line_length)}
+      ```
+      """
     ])
   end
 

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -145,6 +145,15 @@ defmodule Livebook.Intellisense do
       insert_text: name
     }
 
+  defp format_completion_item({:in_struct_field, struct_name, name, default}),
+    do: %{
+      label: "#{name}",
+      kind: :field,
+      detail: "#{struct_name} struct field",
+      documentation: "Default: #{inspect(default)}",
+      insert_text: "#{name}: "
+    }
+
   defp format_completion_item({:module, module, display_name, documentation}) do
     subtype = Docs.get_module_subtype(module)
 
@@ -339,6 +348,13 @@ defmodule Livebook.Intellisense do
   defp format_details_item({:variable, name, _value}), do: code(name)
 
   defp format_details_item({:map_field, name, _value}), do: code(name)
+
+  defp format_details_item({:in_struct_field, _struct_name, name, default}) do
+    join_with_divider([
+      code(name),
+      "Default: #{inspect(default)}"
+    ])
+  end
 
   defp format_details_item({:module, _module, display_name, documentation}) do
     join_with_divider([

--- a/lib/livebook/intellisense/identifier_matcher.ex
+++ b/lib/livebook/intellisense/identifier_matcher.ex
@@ -256,7 +256,7 @@ defmodule Livebook.Intellisense.IdentifierMatcher do
           |> Map.reject(fn {key, _} ->
             key
             |> Atom.to_string()
-            |> String.match?(~r/__.*__/)
+            |> String.starts_with?("_")
           end)
         else
           %{}

--- a/lib/livebook/intellisense/identifier_matcher.ex
+++ b/lib/livebook/intellisense/identifier_matcher.ex
@@ -311,7 +311,7 @@ defmodule Livebook.Intellisense.IdentifierMatcher do
         is_atom(key),
         name = Atom.to_string(key),
         ctx.matcher.(name, hint),
-        do: {:map_field, name, value}
+        do: {:map_field, key, value}
   end
 
   defp match_sigil(hint, ctx) do

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1095,7 +1095,7 @@ defmodule Livebook.IntellisenseTest do
                }
              ] =
                Intellisense.get_completion_items(
-                 "%Livebook.IntellisenseTest.MyStruct{my",
+                 "%ArgumentError{",
                  binding,
                  env
                )

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1053,6 +1053,42 @@ defmodule Livebook.IntellisenseTest do
              ] = Intellisense.get_completion_items("struct.my", binding, env)
     end
 
+    test "completion for struct keys inside struct" do
+      {binding, env} =
+        eval do
+          struct = %Livebook.IntellisenseTest.MyStruct{}
+        end
+
+      assert [
+               %{
+                 label: "my_val",
+                 kind: :field,
+                 detail: "field",
+                 documentation: nil,
+                 insert_text: "my_val"
+               }
+             ] =
+               Intellisense.get_completion_items(
+                 "%Livebook.IntellisenseTest.MyStruct{my",
+                 binding,
+                 env
+               )
+    end
+
+    test "completion for struct keys inside struct removed filled keys" do
+      {binding, env} =
+        eval do
+          struct = %Livebook.IntellisenseTest.MyStruct{}
+        end
+
+      assert [] =
+               Intellisense.get_completion_items(
+                 "%Livebook.IntellisenseTest.MyStruct{my_val: 123, ",
+                 binding,
+                 env
+               )
+    end
+
     test "ignore invalid Elixir module literals" do
       {binding, env} = eval(do: nil)
 

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1060,9 +1060,9 @@ defmodule Livebook.IntellisenseTest do
                %{
                  label: "my_val",
                  kind: :field,
-                 detail: "field",
-                 documentation: nil,
-                 insert_text: "my_val"
+                 detail: "Livebook.IntellisenseTest.MyStruct struct field",
+                 documentation: "Default: nil",
+                 insert_text: "my_val: "
                }
              ] =
                Intellisense.get_completion_items(
@@ -1086,7 +1086,7 @@ defmodule Livebook.IntellisenseTest do
                )
     end
 
-    test "completion for struct keys inside struct ignores `__exception" do
+    test "completion for struct keys inside struct ignores `__exception__`" do
       {binding, env} = eval(do: nil)
 
       completions =

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1054,10 +1054,7 @@ defmodule Livebook.IntellisenseTest do
     end
 
     test "completion for struct keys inside struct" do
-      {binding, env} =
-        eval do
-          struct = %Livebook.IntellisenseTest.MyStruct{}
-        end
+      {binding, env} = eval(do: nil)
 
       assert [
                %{
@@ -1075,7 +1072,7 @@ defmodule Livebook.IntellisenseTest do
                )
     end
 
-    test "completion for struct keys inside struct removed filled keys" do
+    test "completion for struct keys inside struct removes filled keys" do
       {binding, env} =
         eval do
           struct = %Livebook.IntellisenseTest.MyStruct{}
@@ -1084,6 +1081,21 @@ defmodule Livebook.IntellisenseTest do
       assert [] =
                Intellisense.get_completion_items(
                  "%Livebook.IntellisenseTest.MyStruct{my_val: 123, ",
+                 binding,
+                 env
+               )
+    end
+
+    test "completion for struct keys inside struct ignores `__exception" do
+      {binding, env} = eval(do: nil)
+
+      refute [
+               %{
+                 label: "__exception__"
+               }
+             ] =
+               Intellisense.get_completion_items(
+                 "%Livebook.IntellisenseTest.MyStruct{my",
                  binding,
                  env
                )

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1061,7 +1061,7 @@ defmodule Livebook.IntellisenseTest do
                  label: "my_val",
                  kind: :field,
                  detail: "Livebook.IntellisenseTest.MyStruct struct field",
-                 documentation: "Default: nil",
+                 documentation: "```\nmy_val\n```\n\n---\n\n**Default**\n\n```\nnil\n```\n",
                  insert_text: "my_val: "
                }
              ] =

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1089,16 +1089,14 @@ defmodule Livebook.IntellisenseTest do
     test "completion for struct keys inside struct ignores `__exception" do
       {binding, env} = eval(do: nil)
 
-      refute [
-               %{
-                 label: "__exception__"
-               }
-             ] =
-               Intellisense.get_completion_items(
-                 "%ArgumentError{",
-                 binding,
-                 env
-               )
+      completions =
+        Intellisense.get_completion_items(
+          "%ArgumentError{",
+          binding,
+          env
+        )
+
+      refute Enum.find(completions, &match?(%{label: "__exception__"}, &1))
     end
 
     test "ignore invalid Elixir module literals" do


### PR DESCRIPTION
I noticed that autocompletion doesn't work for keys inside a struct.

Before
<img width="977" alt="Screen Shot 2021-12-11 at 7 48 57 AM" src="https://user-images.githubusercontent.com/34720/145677151-1be5761d-d016-441a-bb14-19ec0bb0df2e.png">

After
<img width="959" alt="Screen Shot 2021-12-11 at 7 47 46 AM" src="https://user-images.githubusercontent.com/34720/145677153-6bdaa1ff-723e-4e35-9e96-5000f6b2f3ef.png">

This is pretty much the code from `IEx.Autocomplete`.
