### PR TITLE
Improve command to show current commit

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 * Elixir & Erlang/OTP versions (elixir --version): 
 * Operating system: 
 * How have you started Livebook (mix phx.server, livebook CLI, Docker, etc): 
-* Livebook version (use `git show` if running with mix): 
+* Livebook version (use `git rev-parse HEAD` if running with mix): 
 * Browsers that reproduce this bug (the more the merrier): 
 * Include what is logged in the browser console: 
 * Include what is logged to the server console:


### PR DESCRIPTION
`git show` will show the changes, not just the commit. 
It may not be clear to users that they only need to include the commit id.