### PR TITLE
Use a default naming convention for untitled files

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -72,6 +72,28 @@ defmodule Livebook.Config do
   end
 
   @doc """
+  Returns a path for a new file named with the default untitled file
+  naming convention.
+  """
+  @spec untitled_file_path(FileSystem.t()) :: FileSystem.File.t()
+  def untitled_file_path(file_system) do
+    default_path = FileSystem.default_path(file_system)
+
+    untitled_count =
+      default_path
+      |> then(&FileSystem.list(file_system, &1, false))
+      |> elem(1)
+      |> Enum.filter(&Regex.match?(~r/(?:\/|\\)untitled-\d*\.livemd$/, &1))
+      |> Enum.count()
+
+    FileSystem.resolve_path(
+      file_system,
+      default_path,
+      "#{default_path}untitled-#{untitled_count}.livemd"
+    )
+  end
+
+  @doc """
   Returns the directory where notebooks with no file should be persisted.
   """
   @spec autosave_path() :: String.t() | nil

--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -37,7 +37,7 @@ defmodule Livebook.FileSystem.File do
 
         path
       else
-        default_path
+        Livebook.Config.untitled_file_path(file_system)
       end
 
     %__MODULE__{file_system: file_system, path: path}

--- a/test/livebook/file_system/file_test.exs
+++ b/test/livebook/file_system/file_test.exs
@@ -24,9 +24,13 @@ defmodule Livebook.FileSystem.FileTest do
                    end
     end
 
-    test "uses default file system path if non is given" do
-      file_system = FileSystem.Local.new(default_path: "/dir/")
-      assert %FileSystem.File{path: "/dir/"} = FileSystem.File.new(file_system)
+    test "uses default file system path if not given" do
+      current_dir = elem(File.cwd(), 1) <> "/"
+      file_system = FileSystem.Local.new(default_path: current_dir)
+
+      path = "#{current_dir}untitled-0.livemd"
+
+      assert %FileSystem.File{path: ^path} = FileSystem.File.new(file_system)
     end
   end
 


### PR DESCRIPTION
Updates the `Livebook.Filesystem.File.new` function to use a default naming convention of `untitled-#{n}.livemd`,
where `n` is the number of other untitled files in the default directory.

Closes https://github.com/livebook-dev/livebook/issues/814
