### PR TITLE
Do not show choose file button if file select component is active

### DIFF
--- a/lib/livebook_web/live/session_live/persistence_live.ex
+++ b/lib/livebook_web/live/session_live/persistence_live.ex
@@ -91,10 +91,12 @@ defmodule LivebookWeb.SessionLive.PersistenceLive do
                 <span class="text-gray-700 whitespace-no-wrap">
                   no file selected
                 </span>
-                <button class="button-base button-gray button-small"
-                  phx-click="open_file_select">
-                  Choose a file
-                </button>
+                <%= unless @draft_file do %>
+                  <button class="button-base button-gray button-small"
+                    phx-click="open_file_select">
+                    Choose a file
+                  </button>
+                <% end %>
               <% end %>
             </div>
           </form>


### PR DESCRIPTION
Currently in the persistence live view, the "Choose file" button is shown when the file select component is active:

![choose-0](https://user-images.githubusercontent.com/67545861/147230373-48c7ba9f-0b0d-4503-9909-a763fc761aa8.png)

This PR changes the persistence live view to not show the "Choose file" button when the file select component is active:

![choose](https://user-images.githubusercontent.com/67545861/147230109-f52872d9-a2a1-4438-a1ff-7b6a73baad79.png)


