### PR TITLE
Disable Ecto stats in Phoenix Live Dashboard

### DIFF
--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -62,7 +62,8 @@ defmodule LivebookWeb.Router do
 
     live_dashboard "/dashboard",
       metrics: LivebookWeb.Telemetry,
-      home_app: {"Livebook", :livebook}
+      home_app: {"Livebook", :livebook},
+      ecto_repos: []
   end
 
   # Public URLs without authentication


### PR DESCRIPTION
Livebook does not use Ecto, so disable Ecto stats.
