### PR TITLE
Remove delete prompt for empty sections

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -665,28 +665,23 @@ defmodule LivebookWeb.SessionLive do
   end
 
   def handle_event("delete_section", %{"section_id" => section_id}, socket) do
-    %{section_views: section_views} = socket.assigns.data_view
-    section_view = Enum.find(section_views, &(&1.id == section_id))
+    {:ok, section} = Notebook.fetch_section(socket.private.data.notebook, section_id)
 
-    if section_view do
-      if section_view.cell_views == [] or Enum.all?(section_view.cell_views, & &1.empty?) do
-        Session.delete_section(socket.assigns.session.pid, section_id, true)
+    if section.cells == [] do
+      Session.delete_section(socket.assigns.session.pid, section_id, true)
 
-        {:noreply, socket}
-      else
-        {:noreply,
-         push_patch(socket,
-           to:
-             Routes.session_path(
-               socket,
-               :delete_section,
-               socket.assigns.session.id,
-               section_view.id
-             )
-         )}
-      end
-    else
       {:noreply, socket}
+    else
+      {:noreply,
+       push_patch(socket,
+         to:
+           Routes.session_path(
+             socket,
+             :delete_section,
+             socket.assigns.session.id,
+             section.id
+           )
+       )}
     end
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -664,6 +664,12 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
+  def handle_event("delete_empty_section", %{"section_id" => section_id}, socket) do
+    Session.delete_section(socket.assigns.session.pid, section_id, true)
+
+    {:noreply, socket}
+  end
+
   def handle_event("queue_cell_evaluation", %{"cell_id" => cell_id}, socket) do
     Session.queue_cell_evaluation(socket.assigns.session.pid, cell_id)
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -667,21 +667,20 @@ defmodule LivebookWeb.SessionLive do
   def handle_event("delete_section", %{"section_id" => section_id}, socket) do
     socket =
       case Notebook.fetch_section(socket.private.data.notebook, section_id) do
+        {:ok, %{cells: []} = section} ->
+          Session.delete_section(socket.assigns.session.pid, section.id, true)
+          socket
+
         {:ok, section} ->
-          if section.cells == [] do
-            Session.delete_section(socket.assigns.session.pid, section_id, true)
-            socket
-          else
-            push_patch(socket,
-              to:
-                Routes.session_path(
-                  socket,
-                  :delete_section,
-                  socket.assigns.session.id,
-                  section.id
-                )
-            )
-          end
+          push_patch(socket,
+            to:
+              Routes.session_path(
+                socket,
+                :delete_section,
+                socket.assigns.session.id,
+                section.id
+              )
+          )
 
         :error ->
           socket

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -77,20 +77,12 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
             {if @section_view.has_children?,
                do: [class: "tooltip left", data_tooltip: "Cannot delete this section because\nother sections branch from it"],
                else: [class: "tooltip top", data_tooltip: "Delete"]}>
-            <%= if @section_view.cell_views == [] or Enum.all?(@section_view.cell_views, & &1.empty?) do %>
-               <button class="icon-button #{if @section_view.has_children?, do: 'disabled'}"
-                 aria-label="delete section"
-                 phx-click="delete_empty_section"
-                 phx-value-section_id={@section_view.id}>
+              <button class="icon-button #{if @section_view.has_children?, do: 'disabled'}"
+                aria-label="delete section"
+                phx-click="delete_section"
+                phx-value-section_id={@section_view.id}>
                 <.remix_icon icon="delete-bin-6-line" class="text-xl" />
-            <% else %>
-              <%= live_patch to: Routes.session_path(@socket, :delete_section, @session_id, @section_view.id),
-                    class: "icon-button #{if @section_view.has_children?, do: "disabled"}",
-                    aria_label: "delete section",
-                    role: "button" do %>
-                <.remix_icon icon="delete-bin-6-line" class="text-xl" />
-              <% end %>
-            <% end %>
+              </button>
           </span>
         </div>
       </div>

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -77,7 +77,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
             {if @section_view.has_children?,
                do: [class: "tooltip left", data_tooltip: "Cannot delete this section because\nother sections branch from it"],
                else: [class: "tooltip top", data_tooltip: "Delete"]}>
-              <button class="icon-button #{if @section_view.has_children?, do: 'disabled'}"
+              <button class={"icon-button #{if @section_view.has_children?, do: "disabled"}"}
                 aria-label="delete section"
                 phx-click="delete_section"
                 phx-value-section_id={@section_view.id}>

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -77,12 +77,12 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
             {if @section_view.has_children?,
                do: [class: "tooltip left", data_tooltip: "Cannot delete this section because\nother sections branch from it"],
                else: [class: "tooltip top", data_tooltip: "Delete"]}>
-              <button class={"icon-button #{if @section_view.has_children?, do: "disabled"}"}
-                aria-label="delete section"
-                phx-click="delete_section"
-                phx-value-section_id={@section_view.id}>
-                <.remix_icon icon="delete-bin-6-line" class="text-xl" />
-              </button>
+            <button class={"icon-button #{if @section_view.has_children?, do: "disabled"}"}
+              aria-label="delete section"
+              phx-click="delete_section"
+              phx-value-section_id={@section_view.id}>
+              <.remix_icon icon="delete-bin-6-line" class="text-xl" />
+            </button>
           </span>
         </div>
       </div>

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -77,11 +77,19 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
             {if @section_view.has_children?,
                do: [class: "tooltip left", data_tooltip: "Cannot delete this section because\nother sections branch from it"],
                else: [class: "tooltip top", data_tooltip: "Delete"]}>
-            <%= live_patch to: Routes.session_path(@socket, :delete_section, @session_id, @section_view.id),
-                  class: "icon-button #{if @section_view.has_children?, do: "disabled"}",
-                  aria_label: "delete section",
-                  role: "button" do %>
-              <.remix_icon icon="delete-bin-6-line" class="text-xl" />
+            <%= if @section_view.cell_views == [] or Enum.all?(@section_view.cell_views, & &1.empty?) do %>
+               <button class="icon-button #{if @section_view.has_children?, do: 'disabled'}"
+                 aria-label="delete section"
+                 phx-click="delete_empty_section"
+                 phx-value-section_id={@section_view.id}>
+                <.remix_icon icon="delete-bin-6-line" class="text-xl" />
+            <% else %>
+              <%= live_patch to: Routes.session_path(@socket, :delete_section, @session_id, @section_view.id),
+                    class: "icon-button #{if @section_view.has_children?, do: "disabled"}",
+                    aria_label: "delete section",
+                    role: "button" do %>
+                <.remix_icon icon="delete-bin-6-line" class="text-xl" />
+              <% end %>
             <% end %>
           </span>
         </div>


### PR DESCRIPTION
If a section has no cell views or only empty cell views, avoid
prompting the user to delete the section and just go ahead and delete
it.

Added a separate hook in SessionLive to avoid invoking the delete prompt 
component. I'm not sure if additional protection should be added to the 
`delete_empty_section` callback to ensure the session is empty. Happy to
make further tweaks if there's a better way to handle this.

See #800