### PR TITLE
Fix focus in large editors

### DIFF
--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -27,10 +27,6 @@
     transform: scaleY(-1);
   }
 
-  .scroll-smooth {
-    scroll-behavior: smooth;
-  }
-
   /* Animations */
 
   .fade-in {

--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -216,15 +216,14 @@ function handleInsertModeChanged(hook, insertMode) {
     hook.state.insertMode = insertMode;
 
     if (hook.state.liveEditor) {
-      // For some reason, when clicking the editor for a brief moment it is
-      // already focused and the cursor is in the previous location, which
-      // makes the browser immediately scroll there. We blur the editor,
-      // then wait for the editor to update the cursor position, finally
-      // we focus the editor and scroll if the cursor is not in the view
-      // (when entering insert mode with "i").
-      hook.state.liveEditor.blur();
+      hook.state.liveEditor.focus();
+
+      // The insert mode may be enabled as a result of clicking the editor,
+      // in which case we want to wait until editor handles the click and
+      // sets new cursor position. To achieve this, we simply put this task
+      // at the end of event loop, ensuring the editor mousedown handler is
+      // executed first
       setTimeout(() => {
-        hook.state.liveEditor.focus();
         scrollIntoView(document.activeElement, {
           scrollMode: "if-needed",
           behavior: "smooth",

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -119,7 +119,7 @@ defmodule LivebookWeb.SessionLive do
           <.runtime_info data_view={@data_view} session={@session} socket={@socket} empty_default_runtime={@empty_default_runtime} />
         </div>
       </div>
-      <div class="flex-grow overflow-y-auto scroll-smooth relative" data-element="notebook">
+      <div class="flex-grow overflow-y-auto relative" data-element="notebook">
         <div data-element="output-iframes" phx-update="ignore" id="output-iframes"></div>
         <div class="w-full max-w-screen-lg px-16 mx-auto py-7" data-element="notebook-content">
           <div class="flex items-center pb-4 mb-6 space-x-4 border-b border-gray-200"

--- a/lib/livebook_web/templates/layout/root.html.heex
+++ b/lib/livebook_web/templates/layout/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
@@ -10,7 +10,7 @@
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}></script>
   </head>
-  <body class="scroll-smooth">
+  <body>
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
This happens in Firefox:

https://user-images.githubusercontent.com/17034772/147596437-b438712e-42b4-4f7d-b2ec-1f53c7aa87be.mp4

Specifically, if the cursor (either focused or not) is outside the viewport, any focusing causes jumps.

This is caused by smooth scrolling that we introduced in #638, so I reverted that. I also reported this in https://github.com/microsoft/monaco-editor/issues/2861, since it could likely be improved on the editor side.