### PR TITLE
Remove output border from dynamic JS widgets

### DIFF
--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -275,7 +275,10 @@ defmodule LivebookWeb.FileSelectComponent do
           </span>
           <span class={"flex font-medium overflow-hidden whitespace-nowrap #{if(@file_info.is_running, do: "text-green-300", else: "text-gray-500")}"}>
             <%= if @file_info.highlighted != "" do %>
-              <span class={"font-medium overflow-hidden text-ellipsis #{if(@file_info.is_running, do: "text-green-400", else: "text-gray-900")}"}>
+              <span class={
+                "font-medium
+                  #{if(@file_info.unhighlighted == "", do: "overflow-hidden text-ellipsis")}
+                  #{if(@file_info.is_running, do: "text-green-400", else: "text-gray-900")}"}>
                 <%= @file_info.highlighted %>
               </span>
             <% end %>

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -51,12 +51,11 @@ defmodule LivebookWeb.Output do
     end
   end
 
-  defp standalone?({:table_dynamic, _}), do: true
-  defp standalone?({:frame_dynamic, _}), do: true
-  defp standalone?({:js_dynamic, _, _}), do: true
-  defp standalone?({:input, _}), do: true
-  defp standalone?({:control, _}), do: true
-  defp standalone?(_output), do: false
+  defp standalone?(:ignored), do: false
+  defp standalone?(text) when is_binary(text), do: false
+  defp standalone?({:text, _text}), do: false
+  defp standalone?({:error, _message, _type}), do: false
+  defp standalone?(_output), do: true
 
   defp composite?({:frame_dynamic, _}), do: true
   defp composite?(_output), do: false

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -53,6 +53,7 @@ defmodule LivebookWeb.Output do
 
   defp standalone?({:table_dynamic, _}), do: true
   defp standalone?({:frame_dynamic, _}), do: true
+  defp standalone?({:js_dynamic, _, _}), do: true
   defp standalone?({:input, _}), do: true
   defp standalone?({:control, _}), do: true
   defp standalone?(_output), do: false

--- a/test/livebook/unique_task_test.exs
+++ b/test/livebook/unique_task_test.exs
@@ -54,8 +54,8 @@ defmodule Livebook.UniqueTaskTest do
       send(parent, {:result2, result})
     end)
 
-    assert_receive {:ping_from_task, task1_pid}
-    assert_receive {:ping_from_task, task2_pid}
+    assert_receive {:ping_from_task, task1_pid}, 200
+    assert_receive {:ping_from_task, task2_pid}, 200
 
     send(task1_pid, :pong)
     send(task2_pid, :pong)


### PR DESCRIPTION
The widgets could be anything, but with tables in mind we want to remove border from dynamic JS widgets.

This means static charts will have border and dynamic won't, we could also remove the border for static JS widgets, but I'm not sure which way makes more sense. @josevalim wdyt?

(also an unrelated CSS fix)