### PR TITLE
Set page name when notebook is renamed

### DIFF
--- a/lib/livebook_web/live/explore_live.ex
+++ b/lib/livebook_web/live/explore_live.ex
@@ -14,7 +14,8 @@ defmodule LivebookWeb.ExploreLive do
     {:ok,
      assign(socket,
        lead_notebook_info: lead_notebook_info,
-       notebook_infos: notebook_infos
+       notebook_infos: notebook_infos,
+       page_title: "Livebook - Explore"
      )}
   end
 

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -21,7 +21,8 @@ defmodule LivebookWeb.HomeLive do
        file: Livebook.Config.default_dir(),
        file_info: %{exists: true, access: :read_write},
        sessions: sessions,
-       notebook_infos: notebook_infos
+       notebook_infos: notebook_infos,
+       page_title: "Livebook"
      )}
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -38,6 +38,7 @@ defmodule LivebookWeb.SessionLive do
            self: self(),
            data_view: data_to_view(data),
            autofocus_cell_id: autofocus_cell_id(data.notebook),
+           page_title: get_page_title(data.notebook.name),
            empty_default_runtime: Livebook.Config.default_runtime() |> elem(0) |> struct()
          )
          |> assign_private(data: data)
@@ -1083,6 +1084,10 @@ defmodule LivebookWeb.SessionLive do
     push_event(socket, "clients_updated", %{clients: updated_clients})
   end
 
+  defp after_operation(socket, _prev_socket, {:set_notebook_name, _client_pid, name}) do
+    assign(socket, page_title: get_page_title(name))
+  end
+
   defp after_operation(socket, _prev_socket, {:insert_section, client_pid, _index, section_id}) do
     if client_pid == self() do
       push_event(socket, "section_inserted", %{section_id: section_id})
@@ -1424,5 +1429,9 @@ defmodule LivebookWeb.SessionLive do
   # have impact on dirtiness, so we need to always mirror it
   defp update_dirty_status(data_view, data) do
     put_in(data_view.dirty, data.dirty)
+  end
+
+  defp get_page_title(notebook_name) do
+    "Livebook - #{notebook_name}"
   end
 end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -620,7 +620,7 @@ defmodule LivebookWeb.SessionLive do
     name = normalize_name(name)
     Session.set_notebook_name(socket.assigns.session.pid, name)
 
-    {:noreply, assign(socket, page_title: name)}
+    {:noreply, socket}
   end
 
   def handle_event("set_section_name", %{"metadata" => section_id, "value" => name}, socket) do

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -619,7 +619,7 @@ defmodule LivebookWeb.SessionLive do
     name = normalize_name(name)
     Session.set_notebook_name(socket.assigns.session.pid, name)
 
-    {:noreply, socket}
+    {:noreply, assign(socket, page_title: name)}
   end
 
   def handle_event("set_section_name", %{"metadata" => section_id, "value" => name}, socket) do

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -13,7 +13,8 @@ defmodule LivebookWeb.SettingsLive do
     {:ok,
      assign(socket,
        file_systems: file_systems,
-       file_systems_env: file_systems_env
+       file_systems_env: file_systems_env,
+       page_title: "Livebook - Settings"
      )}
   end
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -28,6 +28,17 @@ defmodule LivebookWeb.SessionLiveTest do
       assert render(view) =~ "My notebook"
     end
 
+    test "renders an updated notebook name in title", %{conn: conn, session: session} do
+      {:ok, view, _} = live(conn, "/sessions/#{session.id}")
+
+      assert page_title(view) =~ "Untitled notebook"
+
+      Session.set_notebook_name(session.pid, "My notebook")
+      wait_for_session_update(session.pid)
+
+      assert page_title(view) =~ "My notebook"
+    end
+
     test "renders a newly inserted section", %{conn: conn, session: session} do
       {:ok, view, _} = live(conn, "/sessions/#{session.id}")
 


### PR DESCRIPTION
#835 Short pr to solve this issue. On new notebook we still have Livebook in the title, I did not wanted to name the tab `Untitled` or renaming the default notebook
![image](https://user-images.githubusercontent.com/904179/148292683-bf75439c-f918-4cda-b784-9f5137910a47.png)
