### PR TITLE
Increase timeout for connecting via Mix standalone

### DIFF
--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -105,7 +105,9 @@ defmodule Livebook.Runtime.StandaloneInit do
         {:DOWN, ^port_ref, :port, _object, _reason} ->
           {:error, "Elixir process terminated unexpectedly"}
       after
-        10_000 ->
+        # Use a longer timeout to account for longer child node startup,
+        # as may happen when starting with Mix.
+        4_000 ->
           {:error, "connection timed out"}
       end
     end

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -107,7 +107,7 @@ defmodule Livebook.Runtime.StandaloneInit do
       after
         # Use a longer timeout to account for longer child node startup,
         # as may happen when starting with Mix.
-        4_000 ->
+        40_000 ->
           {:error, "connection timed out"}
       end
     end


### PR DESCRIPTION
I have hit this timeout when connecting via mix to a fairly large application. Increasing this fixes it for my use case. 
We could instead make it configurable somehow if that is preferable?

I also had to start the livebook server like this:

```elixir
iex -S mix phx.server
```

rather than

```elixir
MIX_ENV=prod iex -S mix phx.server
```

Otherwise the app I was connecting to was also started in `:prod` mode. I'm not sure if it's possible to allow connected apps to start in `:dev` when using `livebook server` command?