### PR TITLE
Show deprecated and since doc metadata on mouse over

### DIFF
--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -445,7 +445,7 @@ defmodule Livebook.Intellisense do
   end
 
   defp format_meta(:deprecated, %{deprecated: deprecated}) do
-    "This function is deprecated. " <> deprecated
+    "**Deprecated**. " <> deprecated
   end
 
   defp format_meta(:since, %{since: since}) do

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -121,7 +121,8 @@ defmodule Livebook.Intellisense do
   defp include_in_completion?({:module, _module, _display_name, :hidden}), do: false
 
   defp include_in_completion?(
-         {:function, _module, _name, _arity, _type, _display_name, :hidden, _signatures, _specs}
+         {:function, _module, _name, _arity, _type, _display_name, :hidden, _signatures, _specs,
+          _meta}
        ),
        do: false
 
@@ -188,7 +189,8 @@ defmodule Livebook.Intellisense do
   end
 
   defp format_completion_item(
-         {:function, module, name, arity, type, display_name, documentation, signatures, specs}
+         {:function, module, name, arity, type, display_name, documentation, signatures, specs,
+          _meta}
        ),
        do: %{
          label: "#{display_name}/#{arity}",
@@ -380,10 +382,13 @@ defmodule Livebook.Intellisense do
   end
 
   defp format_details_item(
-         {:function, module, name, _arity, _type, _display_name, documentation, signatures, specs}
+         {:function, module, name, _arity, _type, _display_name, documentation, signatures, specs,
+          meta}
        ) do
     join_with_divider([
       format_signatures(signatures, module) |> code(),
+      format_meta(:since, meta),
+      format_meta(:deprecated, meta),
       format_specs(specs, name, @extended_line_length) |> code(),
       format_documentation(documentation, :all)
     ])
@@ -438,6 +443,16 @@ defmodule Livebook.Intellisense do
       signatures_string
     end
   end
+
+  defp format_meta(:deprecated, %{deprecated: deprecated}) do
+    "This function is deprecated. " <> deprecated
+  end
+
+  defp format_meta(:since, %{since: since}) do
+    "Since " <> since
+  end
+
+  defp format_meta(_, _), do: nil
 
   defp format_specs([], _name, _line_length), do: nil
 

--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -10,7 +10,8 @@ defmodule Livebook.Intellisense.Docs do
           arity: non_neg_integer(),
           documentation: documentation(),
           signatures: list(signature()),
-          specs: list(spec())
+          specs: list(spec()),
+          meta: meta()
         }
 
   @type member_kind :: :function | :macro | :type
@@ -18,6 +19,8 @@ defmodule Livebook.Intellisense.Docs do
   @type documentation :: {format :: String.t(), content :: String.t()} | :hidden | nil
 
   @type signature :: String.t()
+
+  @type meta :: map()
 
   @typedoc """
   A single spec annotation in the Erlang Abstract Format.
@@ -88,7 +91,8 @@ defmodule Livebook.Intellisense.Docs do
               arity: arity,
               documentation: documentation(doc, format),
               signatures: signatures,
-              specs: Map.get(specs, {name, base_arity}, [])
+              specs: Map.get(specs, {name, base_arity}, []),
+              meta: meta
             }
 
       _ ->

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1217,6 +1217,20 @@ defmodule Livebook.IntellisenseTest do
       assert content =~ "## Examples"
     end
 
+    test "returns deprecated docs" do
+      {binding, env} = eval(do: nil)
+
+      assert %{contents: [content | _]} = Intellisense.get_details("Enum.chunk", 6, binding, env)
+      assert content =~ "Use Enum.chunk_every/2 instead"
+    end
+
+    test "returns since docs" do
+      {binding, env} = eval(do: nil)
+
+      assert %{contents: [content]} = Intellisense.get_details("then", 2, binding, env)
+      assert content =~ "Since 1.12.0"
+    end
+
     @tag :erl_docs
     test "returns full Erlang docs" do
       {binding, env} = eval(do: nil)


### PR DESCRIPTION
related issue #726 

- deprecated
<img src="https://user-images.githubusercontent.com/6327995/148938598-f5799d61-dfc4-4162-a106-f56431c0d52e.png" width="400px" />

- since
<img src="https://user-images.githubusercontent.com/6327995/148938741-267da573-82e5-43e8-b474-8ce3e32f90a1.png" width="400px" />

