### PR TITLE
Use monspaced font for all characters in Markdown code blocks

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   theme: {
     fontFamily: {
       sans: ["Inter"],
-      mono: ["JetBrains Mono"],
+      mono: ["JetBrains Mono", "monospace"],
     },
     extend: {
       colors: {


### PR DESCRIPTION
Closes #854.

JetBrains Mono may not cover some characters, in which case we still want to fallback to a monospaced font.