### PR TITLE
Adds a bit of contrast to the comments in the code editor

### DIFF
--- a/assets/css/ansi.css
+++ b/assets/css/ansi.css
@@ -14,7 +14,7 @@ to be consistent with the editor.
   --ansi-color-magenta: #c678dd;
   --ansi-color-cyan: #56b6c2;
   --ansi-color-white: white;
-  --ansi-color-light-black: #737a8c;
+  --ansi-color-light-black: #5c6370;
   --ansi-color-light-red: #f87171;
   --ansi-color-light-green: #34d399;
   --ansi-color-light-yellow: #fde68a;

--- a/assets/css/ansi.css
+++ b/assets/css/ansi.css
@@ -14,7 +14,7 @@ to be consistent with the editor.
   --ansi-color-magenta: #c678dd;
   --ansi-color-cyan: #56b6c2;
   --ansi-color-white: white;
-  --ansi-color-light-black: #5c6370;
+  --ansi-color-light-black: #737a8c;
   --ansi-color-light-red: #f87171;
   --ansi-color-light-green: #34d399;
   --ansi-color-light-yellow: #fde68a;

--- a/assets/js/cell/live_editor/theme.js
+++ b/assets/js/cell/live_editor/theme.js
@@ -4,7 +4,7 @@ const colors = {
   default: "#abb2bf",
   lightRed: "#e06c75",
   blue: "#61afef",
-  gray: "#737A8C",
+  gray: "#737a8c",
   green: "#98c379",
   purple: "#c678dd",
   red: "#be5046",

--- a/assets/js/cell/live_editor/theme.js
+++ b/assets/js/cell/live_editor/theme.js
@@ -4,7 +4,7 @@ const colors = {
   default: "#abb2bf",
   lightRed: "#e06c75",
   blue: "#61afef",
-  gray: "#5c6370",
+  gray: "#737A8C",
   green: "#98c379",
   purple: "#c678dd",
   red: "#be5046",


### PR DESCRIPTION
With the current color, the comments are almost unreadable. A little more contrast while keeping the same shade of gray increases readability without losing the consistency of the theme.

<img width="944" alt="Screen Shot 2022-01-12 at 23 04 00" src="https://user-images.githubusercontent.com/5660941/149257652-0016ffea-131f-4436-8a3a-d0d84063d84e.png">
<img width="936" alt="Screen Shot 2022-01-12 at 23 32 36" src="https://user-images.githubusercontent.com/5660941/149257663-adaf5a47-fae1-448d-898d-5fe2c61227f4.png">

