### PR TITLE
Adds an option to increase the font size of the editor

### DIFF
--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -162,7 +162,7 @@ class LiveEditor {
       renderLineHighlight: "none",
       theme: "custom",
       fontFamily: "JetBrains Mono, Droid Sans Mono, monospace",
-      fontSize: 14,
+      fontSize: settings.editor_font_size,
       tabIndex: -1,
       tabSize: 2,
       autoIndent: true,

--- a/assets/js/editor_settings/index.js
+++ b/assets/js/editor_settings/index.js
@@ -1,4 +1,8 @@
-import { loadLocalSettings, storeLocalSettings } from "../lib/settings";
+import {
+  loadLocalSettings,
+  storeLocalSettings,
+  EDITOR_FONT_SIZE,
+} from "../lib/settings";
 
 /**
  * A hook for the editor settings.
@@ -24,7 +28,7 @@ const EditorSettings = {
     editorAutoCompletionCheckbox.checked = settings.editor_auto_completion;
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
     editorFontSizeCheckbox.checked =
-      settings.editor_font_size === 16 ? true : false;
+      settings.editor_font_size === EDITOR_FONT_SIZE.large ? true : false;
 
     editorAutoCompletionCheckbox.addEventListener("change", (event) => {
       storeLocalSettings({ editor_auto_completion: event.target.checked });
@@ -35,7 +39,11 @@ const EditorSettings = {
     });
 
     editorFontSizeCheckbox.addEventListener("change", (event) => {
-      storeLocalSettings({ editor_font_size: event.target.checked ? 16 : 14 });
+      storeLocalSettings({
+        editor_font_size: event.target.checked
+          ? EDITOR_FONT_SIZE.large
+          : EDITOR_FONT_SIZE.normal,
+      });
     });
   },
 };

--- a/assets/js/editor_settings/index.js
+++ b/assets/js/editor_settings/index.js
@@ -17,9 +17,14 @@ const EditorSettings = {
     const editorAutoSignatureCheckbox = this.el.querySelector(
       `[name="editor_auto_signature"][value="true"]`
     );
+    const editorFontSizeCheckbox = this.el.querySelector(
+      `[name="editor_font_size"][value="true"]`
+    );
 
     editorAutoCompletionCheckbox.checked = settings.editor_auto_completion;
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
+    editorFontSizeCheckbox.checked =
+      settings.editor_font_size === 16 ? true : false;
 
     editorAutoCompletionCheckbox.addEventListener("change", (event) => {
       storeLocalSettings({ editor_auto_completion: event.target.checked });
@@ -27,6 +32,10 @@ const EditorSettings = {
 
     editorAutoSignatureCheckbox.addEventListener("change", (event) => {
       storeLocalSettings({ editor_auto_signature: event.target.checked });
+    });
+
+    editorFontSizeCheckbox.addEventListener("change", (event) => {
+      storeLocalSettings({ editor_font_size: event.target.checked ? 16 : 14 });
     });
   },
 };

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -1,9 +1,14 @@
 const SETTINGS_KEY = "livebook:settings";
 
+export const EDITOR_FONT_SIZE = {
+  normal: 14,
+  large: 16,
+};
+
 const DEFAULT_SETTINGS = {
   editor_auto_completion: true,
   editor_auto_signature: true,
-  editor_font_size: 14,
+  editor_font_size: EDITOR_FONT_SIZE.normal,
 };
 
 /**

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -3,6 +3,7 @@ const SETTINGS_KEY = "livebook:settings";
 const DEFAULT_SETTINGS = {
   editor_auto_completion: true,
   editor_auto_signature: true,
+  editor_font_size: 14,
 };
 
 /**

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -112,7 +112,7 @@ defmodule LivebookWeb.SettingsLive do
                   checked={false} />
                 <.switch_checkbox
                   name="editor_font_size"
-                  label="Increases the font size"
+                  label="Increase font size"
                   checked={false} />
               </div>
             </div>

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -110,6 +110,10 @@ defmodule LivebookWeb.SettingsLive do
                   name="editor_auto_signature"
                   label="Show function signature while typing"
                   checked={false} />
+                <.switch_checkbox
+                  name="editor_font_size"
+                  label="Increases the font size"
+                  checked={false} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Closes #752.

An initial idea to add the option to increase the font size of the editor while keeping the settings simple and easy to use

<img width="955" alt="Screen Shot 2022-01-13 at 01 04 59" src="https://user-images.githubusercontent.com/5660941/149265510-8e948938-1d81-4ba4-92b4-6fb84c4f7caf.png">
<img width="931" alt="Screen Shot 2022-01-13 at 01 05 14" src="https://user-images.githubusercontent.com/5660941/149265515-e68ab953-be99-47d5-902a-edf7ae3f81b6.png">


https://user-images.githubusercontent.com/5660941/149265437-7c692714-e464-4096-aa73-f724772297a5.mov


