### PR TITLE
Keep editor background on rerender

### DIFF
--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -45,7 +45,7 @@ const Cell = {
         editorContainer.appendChild(editorElement);
         // Adjust the background color based on local settings
         const settings = loadLocalSettings();
-        editorContainer.parentElement.style.backgroundColor =
+        editorContainer.style.backgroundColor =
           THEME_BACKGROUND_COLOR[settings.editor_theme];
         // Setup the editor instance.
         this.state.liveEditor = new LiveEditor(

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -212,13 +212,12 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   defp editor(assigns) do
     ~H"""
-    <div class="py-3 rounded-lg bg-editor relative">
-      <div
-        id={"editor-container-#{@cell_view.id}"}
-        data-element="editor-container"
-        phx-update="ignore">
-        <div class="px-8">
-          <.content_placeholder bg_class="bg-gray-500" empty={@cell_view.empty?} />
+    <div class="relative">
+      <div id={"editor-#{@cell_view.id}"} phx-update="ignore">
+        <div class="py-3 rounded-lg bg-editor" data-element="editor-container">
+          <div class="px-8">
+            <.content_placeholder bg_class="bg-gray-500" empty={@cell_view.empty?} />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Follow up to #868. We override background color with JS, but LiveView discards the inline style on next render. I simply moved the elements around, such that the background is already in `phx-update="ignore"` :)