### PR TITLE
Improvements to default theme

### DIFF
--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -125,7 +125,7 @@
   @apply p-4 rounded-lg text-sm align-middle font-mono flex-1 overflow-auto;
   /* Match the editor colors */
   background-color: #282c34;
-  color: #abb2bf;
+  color: #c4cad6;
 }
 
 .markdown kbd {

--- a/assets/js/cell/live_editor/theme.js
+++ b/assets/js/cell/live_editor/theme.js
@@ -1,9 +1,11 @@
 // This is a port of the One Dark theme to the Monaco editor.
+// We color graded the comment so it has AA accessibility and
+// then similarly scaled the default font.
 const colors = {
-  default: "#abb2bf",
+  default: "#c4cad6",
   lightRed: "#e06c75",
   blue: "#61afef",
-  gray: "#737a8c",
+  gray: "#8c92a3",
   green: "#98c379",
   purple: "#c678dd",
   red: "#be5046",

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -117,7 +117,7 @@ defmodule LivebookWeb.SettingsLive do
                   checked={false} />
                 <.switch_checkbox
                   name="editor_high_contrast"
-                  label="High contrast editor"
+                  label="Use high contrast theme"
                   checked={false} />
               </div>
             </div>


### PR DESCRIPTION
Make sure code comments have at least AA readability by default and scale the default color accordingly.
