### PR TITLE
Fix cell insertion while editing Markdown cell

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -446,6 +446,11 @@ function handleDocumentMouseDown(hook, event) {
     return;
   }
 
+  // When clicking an insert button, keep focus and insert mode as is
+  if (event.target.closest(`[data-element="insert-buttons"] button`)) {
+    return;
+  }
+
   // Find the focusable element, if one was clicked
   const focusableEl = event.target.closest(`[data-focusable-id]`);
   const focusableId = focusableEl ? focusableEl.dataset.focusableId : null;


### PR DESCRIPTION
When editing Markdown cell, clicking an insert button exits the insert mode, but this happens before mouse up, so the button doesn't get clicked in the end.