### PR TITLE
Fix launcher script

### DIFF
--- a/app_builder/lib/app_builder/macos.ex
+++ b/app_builder/lib/app_builder/macos.ex
@@ -142,8 +142,8 @@ defmodule AppBuilder.MacOS do
     #!/bin/sh
     set -e
     root=$(dirname $(dirname "$0"))
-    $root/Resources/rel/bin/#{release_name} start \
-      1>> ~/Library/Logs/#{app_name}.stdout.log \
+    $root/Resources/rel/bin/#{release_name} start \\
+      1>> ~/Library/Logs/#{app_name}.stdout.log \\
       2>> ~/Library/Logs/#{app_name}.stderr.log
     """
   end


### PR DESCRIPTION
The idea was to leave trailing `\` for bash but it needs to be escaped!
The script worked fine fwiw.
