### PR TITLE
Adjust JS iframe default styles

### DIFF
--- a/assets/js/js_output/iframe.html
+++ b/assets/js/js_output/iframe.html
@@ -3,7 +3,7 @@
   <head>
     <title>Output</title>
     <style>
-      body {
+      html, body {
         margin: 0;
         padding: 0;
         font-family: sans-serif;


### PR DESCRIPTION
When elements have margins not all content is shown within the iframe, this fixes it.