### PR TITLE
Remove unnecessary scrollbar in Mix runtime modal

### DIFF
--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -86,7 +86,7 @@ defmodule LivebookWeb.FileSelectComponent do
               autocomplete="off" />
           </form>
         </div>
-        <span class="tooltip top" data-tooltip="New directory">
+        <span class={"tooltip #{if(@inner_block, do: "top", else: "left")}"} data-tooltip="New directory">
           <button class="icon-button"
             tabindex="-1"
             aria-label="new directory"


### PR DESCRIPTION
Currently we get this scrollbar:

![image](https://user-images.githubusercontent.com/17034772/150321411-ce026649-eb8f-47c1-8beb-8792c6419f62.png)

That's because of the "New directory" tooltip on the + icon.