### PR TITLE
Fix race conditions in message scheduling

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -71,11 +71,13 @@ defmodule Livebook.Session do
           data: Data.t(),
           created_at: DateTime.t(),
           runtime_monitor_ref: reference() | nil,
-          autosave_timer_ref: reference() | nil,
+          autosave_timer: timer() | nil,
           save_task_pid: pid() | nil,
           saved_default_file: FileSystem.File.t() | nil,
           memory_usage: memory_usage()
         }
+
+  @type timer :: %{ref: reference(), message_ref: reference()}
 
   @type memory_usage ::
           %{
@@ -472,7 +474,7 @@ defmodule Livebook.Session do
         data: data,
         created_at: DateTime.utc_now(),
         runtime_monitor_ref: nil,
-        autosave_timer_ref: nil,
+        autosave_timer: nil,
         autosave_path: opts[:autosave_path],
         save_task_pid: nil,
         saved_default_file: nil,
@@ -510,10 +512,11 @@ defmodule Livebook.Session do
 
   defp schedule_autosave(state) do
     if interval_s = state.data.notebook.autosave_interval_s do
-      ref = Process.send_after(self(), :autosave, interval_s * 1000)
-      %{state | autosave_timer_ref: ref}
+      message_ref = make_ref()
+      ref = Process.send_after(self(), {:autosave, message_ref}, interval_s * 1000)
+      %{state | autosave_timer: %{ref: ref, message_ref: message_ref}}
     else
-      %{state | autosave_timer_ref: nil}
+      %{state | autosave_timer: nil}
     end
   end
 
@@ -815,8 +818,12 @@ defmodule Livebook.Session do
     {:noreply, handle_operation(state, operation)}
   end
 
-  def handle_info(:autosave, state) do
+  def handle_info({:autosave, ref}, %{autosave_timer: %{message_ref: ref}} = state) do
     {:noreply, state |> maybe_save_notebook_async() |> schedule_autosave()}
+  end
+
+  def handle_info({:autosave, _ref}, state) do
+    {:noreply, state}
   end
 
   def handle_info({:user_change, user}, state) do
@@ -1034,8 +1041,8 @@ defmodule Livebook.Session do
          _prev_state,
          {:set_notebook_attributes, _client_pid, %{autosave_interval_s: _}}
        ) do
-    if ref = state.autosave_timer_ref do
-      Process.cancel_timer(ref)
+    if timer = state.autosave_timer do
+      Process.cancel_timer(timer.ref)
     end
 
     schedule_autosave(state)

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -517,6 +517,18 @@ defmodule Livebook.Session do
     end
   end
 
+  defp unschedule_autosave(%{autosave_timer_ref: nil} = state), do: state
+
+  defp unschedule_autosave(state) do
+    if Process.cancel_timer(state.autosave_timer_ref) == false do
+      receive do
+        :autosave -> :ok
+      end
+    end
+
+    %{state | autosave_timer_ref: nil}
+  end
+
   @impl true
   def handle_call(:describe_self, _from, state) do
     {:reply, self_from_state(state), state}
@@ -1034,15 +1046,9 @@ defmodule Livebook.Session do
          _prev_state,
          {:set_notebook_attributes, _client_pid, %{autosave_interval_s: _}}
        ) do
-    if ref = state.autosave_timer_ref do
-      if Process.cancel_timer(ref) == false do
-        receive do
-          :autosave -> :ok
-        end
-      end
-    end
-
-    schedule_autosave(state)
+    state
+    |> unschedule_autosave()
+    |> schedule_autosave()
   end
 
   defp after_operation(state, prev_state, {:client_join, _client_pid, user}) do


### PR DESCRIPTION
See https://github.com/livebook-dev/livebook/pull/898#discussion_r790136340.

@josevalim I remove the cancelling mentioned in the comment, and I also noticed we have similar problems with two timers that we cancel in `Session`, so I changed those to attach a reference to each message to handle only those that we expect.