### PR TITLE
Preserve Markdown modifiers in headings

### DIFF
--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -202,21 +202,25 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     assert ["Downgrading all headings, because 2 instances of heading 1 were found"] == messages
   end
 
-  test "ignores markdown modifiers in notebok/section names" do
+  test "preserves markdown modifiers in notebok/section names" do
     markdown = """
     # My *Notebook*
 
     ## [Section 1](https://example.com)
+
+    ## ---
+
+    ## # Section
     """
 
     {notebook, []} = Import.notebook_from_markdown(markdown)
 
     assert %Notebook{
-             name: "My Notebook",
+             name: "My *Notebook*",
              sections: [
-               %Notebook.Section{
-                 name: "Section 1"
-               }
+               %Notebook.Section{name: "[Section 1](https://example.com)"},
+               %Notebook.Section{name: "---"},
+               %Notebook.Section{name: "# Section"}
              ]
            } = notebook
   end


### PR DESCRIPTION
Currently a section named `---` is correctly exported as `## ---`, but on import we parse the name and the extracted text is an empty string.

Initially I thought about fixing this for block modifiers, but then I realised we shouldn't convert inline modifiers either. If the users sets section name to `My *section*`, it gets exported just like that, and on import we should preserve all of it, so it's the same as before export.