### PR TITLE
Fix image uploads in Markdown cells

### DIFF
--- a/lib/livebook_web/live/session_live/cell_upload_component.ex
+++ b/lib/livebook_web/live/session_live/cell_upload_component.ex
@@ -82,9 +82,12 @@ defmodule LivebookWeb.SessionLive.CellUploadComponent do
       filename = name <> ext
       destination_file = FileSystem.File.resolve(images_dir, filename)
 
-      with :ok <- FileSystem.File.copy(upload_file, destination_file) do
-        {:ok, filename}
-      end
+      result =
+        with :ok <- FileSystem.File.copy(upload_file, destination_file) do
+          {:ok, filename}
+        end
+
+      {:ok, result}
     end)
     |> case do
       [{:ok, filename}] ->

--- a/lib/livebook_web/live/session_live/cell_upload_component.ex
+++ b/lib/livebook_web/live/session_live/cell_upload_component.ex
@@ -91,7 +91,7 @@ defmodule LivebookWeb.SessionLive.CellUploadComponent do
     end)
     |> case do
       [{:ok, filename}] ->
-        src_path = "images/#{filename}"
+        src_path = "images/#{URI.encode(filename, &URI.char_unreserved?/1)}"
 
         {:noreply,
          socket


### PR DESCRIPTION
We updated to LV 0.17.6 just recently, and the behaviour of `consume_uploaded_entries` changed, which broke uploads. This fixes it. Also fixes #910.