### PR TITLE
Fix `elixir_and_livebook.livemd` branch parent

### DIFF
--- a/lib/livebook/notebook/explore/elixir_and_livebook.livemd
+++ b/lib/livebook/notebook/explore/elixir_and_livebook.livemd
@@ -122,7 +122,7 @@ parent = self()
 Process.put(:info, "deal carefully with process dictionaries")
 ```
 
-<!-- livebook:{"branch_parent_index":5} -->
+<!-- livebook:{"branch_parent_index":4} -->
 
 ## More on branches #2
 


### PR DESCRIPTION
The section branch `More on branches #2` was pointing at itself, which would cause an error when running the branch due to the missing `parent` variable. I've updated the `branch_parent_index` to point at `More on branches #1`.