### PR TITLE
Skip XML.decode!(body) if body is empty

### DIFF
--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -403,11 +403,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
       {:ok, content_type} when content_type in ["text/xml", "application/xml"] ->
         {:ok, status, headers, XML.decode!(body)}
 
-      # Google Cloud Storage XML API returns this type of response.
-      {:ok, "text/html"} when body == "" ->
-        {:ok, status, headers, body}
-
-      :error ->
+      _ ->
         {:ok, status, headers, body}
     end
   end

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -398,10 +398,14 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     host |> String.split(".") |> Enum.reverse() |> Enum.at(2, "auto")
   end
 
-  defp encode({:ok, status, headers, body}) when body != "" do
+  defp encode({:ok, status, headers, body}) do
     case HTTP.fetch_content_type(headers) do
       {:ok, content_type} when content_type in ["text/xml", "application/xml"] ->
         {:ok, status, headers, XML.decode!(body)}
+
+      # Google Cloud Storage XML API returns this type of response.
+      {:ok, "text/html"} when body == "" ->
+        {:ok, status, headers, body}
 
       :error ->
         {:ok, status, headers, body}

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -398,7 +398,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     host |> String.split(".") |> Enum.reverse() |> Enum.at(2, "auto")
   end
 
-  defp encode({:ok, status, headers, body}) do
+  defp encode({:ok, status, headers, body}) when body != "" do
     case HTTP.fetch_content_type(headers) do
       {:ok, content_type} when content_type in ["text/xml", "application/xml"] ->
         {:ok, status, headers, XML.decode!(body)}

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -204,7 +204,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
 
     query = %{"list-type" => "2", "prefix" => prefix, "delimiter" => delimiter}
 
-    case request(file_system, :get, "/", query: query) |> encode() do
+    case request(file_system, :get, "/", query: query) |> decode() do
       {:ok, 200, _headers, %{"ListBucketResult" => result}} ->
         bucket = result["Name"]
         file_keys = result |> xml_get_list("Contents") |> Enum.map(& &1["Key"])
@@ -228,7 +228,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
 
     query = %{"list-type" => "2", "max-keys" => "0"}
 
-    case request(file_system, :get, "/", query: query) |> encode() do
+    case request(file_system, :get, "/", query: query) |> decode() do
       {:ok, 200, _headers, %{"ListBucketResult" => %{"Name" => bucket}}} ->
         {:ok, bucket}
 
@@ -246,7 +246,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
   end
 
   defp put_object(file_system, key, content) do
-    case request(file_system, :put, "/" <> encode_key(key), body: content) |> encode() do
+    case request(file_system, :put, "/" <> encode_key(key), body: content) |> decode() do
       {:ok, 200, _headers, _body} -> :ok
       other -> request_response_to_error(other)
     end
@@ -272,7 +272,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     headers = [{"x-amz-copy-source", copy_source}]
 
     case request(file_system, :put, "/" <> encode_key(destination_key), headers: headers)
-         |> encode() do
+         |> decode() do
       {:ok, 200, _headers, _body} -> :ok
       {:ok, 404, _headers, _body} -> FileSystem.Utils.posix_error(:enoent)
       other -> request_response_to_error(other)
@@ -280,7 +280,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
   end
 
   defp delete_object(file_system, key) do
-    case request(file_system, :delete, "/" <> encode_key(key)) |> encode() do
+    case request(file_system, :delete, "/" <> encode_key(key)) |> decode() do
       {:ok, 204, _headers, _body} -> :ok
       {:ok, 404, _headers, _body} -> :ok
       other -> request_response_to_error(other)
@@ -300,7 +300,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     headers = [{"Content-MD5", body_md5}]
 
     case request(file_system, :post, "/", query: %{"delete" => ""}, headers: headers, body: body)
-         |> encode() do
+         |> decode() do
       {:ok, 200, _headers, %{"Error" => errors}} -> {:error, format_errors(errors)}
       {:ok, 200, _headers, _body} -> :ok
       other -> request_response_to_error(other)
@@ -398,7 +398,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     host |> String.split(".") |> Enum.reverse() |> Enum.at(2, "auto")
   end
 
-  defp encode({:ok, status, headers, body}) do
+  defp decode({:ok, status, headers, body}) do
     case HTTP.fetch_content_type(headers) do
       {:ok, content_type} when content_type in ["text/xml", "application/xml"] ->
         {:ok, status, headers, XML.decode!(body)}
@@ -412,7 +412,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.S3 do
     end
   end
 
-  defp encode(other), do: other
+  defp decode(other), do: other
 
   defp xml_get_list(xml_map, key) do
     case xml_map do

--- a/test/livebook/file_system/s3_test.exs
+++ b/test/livebook/file_system/s3_test.exs
@@ -256,7 +256,7 @@ defmodule Livebook.FileSystem.S3Test do
     end
 
     # Google Cloud Storage XML API returns this type of response.
-    test "writes contents even if content type is text/html and body is empty", %{bypass: bypass} do
+    test "returns success when the status is 200 even if the content type is text/html", %{bypass: bypass} do
       content = "content"
 
       Bypass.expect_once(bypass, "PUT", "/mybucket/dir/file.txt", fn conn ->

--- a/test/livebook/file_system/s3_test.exs
+++ b/test/livebook/file_system/s3_test.exs
@@ -256,7 +256,9 @@ defmodule Livebook.FileSystem.S3Test do
     end
 
     # Google Cloud Storage XML API returns this type of response.
-    test "returns success when the status is 200 even if the content type is text/html", %{bypass: bypass} do
+    test "returns success when the status is 200 even if the content type is text/html", %{
+      bypass: bypass
+    } do
       content = "content"
 
       Bypass.expect_once(bypass, "PUT", "/mybucket/dir/file.txt", fn conn ->


### PR DESCRIPTION
Google Cloud Storage has [almost S3 compatible XML API](https://cloud.google.com/storage/docs/interoperability).
So I tried to use it as a file system.
But some responses have `content-type: text/html; charset=UTF-8` and empty body, which leads to XML decode error.

```
17:17:35.640 [error] 3917- fatal: :expected_element_start_tag

17:17:35.651 [error] Task #PID<0.707.0> started from #PID<0.694.0> terminating
** (stop) {:fatal, {:expected_element_start_tag, {:file, :file_name_unknown}, {:line, 1}, {:col, 1}}}
    (xmerl 1.3.28) xmerl_scan.erl:4127: :xmerl_scan.fatal/2
    (xmerl 1.3.28) xmerl_scan.erl:575: :xmerl_scan.scan_document/2
    (xmerl 1.3.28) xmerl_scan.erl:294: :xmerl_scan.string/2
    (livebook 0.5.2) lib/livebook/file_system/s3/xml.ex:35: Livebook.FileSystem.S3.XML.decode!/1
    (livebook 0.5.2) lib/livebook/file_system/s3.ex:406: Livebook.FileSystem.Livebook.FileSystem.S3.encode/1
    (livebook 0.5.2) lib/livebook/file_system/s3.ex:251: Livebook.FileSystem.Livebook.FileSystem.S3.put_object/3
    (livebook 0.5.2) lib/livebook/session.ex:1185: anonymous fn/4 in Livebook.Session.maybe_save_notebook_async/1
    (elixir 1.13.2) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
Function: #Function<11.64266708/0 in Livebook.Session.maybe_save_notebook_async/1>
    Args: []
```

This tweak prevents the error and enables the backend to work fine with Google Cloud Storage.