### PR TITLE
Remove --open-new option when starting liveserver

### DIFF
--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -48,8 +48,6 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def disconnect(runtime) do
     ErlDist.RuntimeServer.stop(runtime.server_pid)
-    _ = Node.disconnect(runtime.node)
-    :ok
   end
 
   def evaluate_code(runtime, code, locator, prev_locator, opts \\ []) do

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -48,6 +48,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def disconnect(runtime) do
     ErlDist.RuntimeServer.stop(runtime.server_pid)
+    Node.disconnect(runtime.node)
   end
 
   def evaluate_code(runtime, code, locator, prev_locator, opts \\ []) do

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -48,7 +48,10 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def disconnect(runtime) do
     ErlDist.RuntimeServer.stop(runtime.server_pid)
-    Node.disconnect(runtime.node)
+    
+    if Node.disconnect(runtime.node) do
+      :ok
+    end
   end
 
   def evaluate_code(runtime, code, locator, prev_locator, opts \\ []) do

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -48,10 +48,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def disconnect(runtime) do
     ErlDist.RuntimeServer.stop(runtime.server_pid)
-
-    if Node.disconnect(runtime.node) do
-      :ok
-    end
+    _ = Node.disconnect(runtime.node)
+    :ok
   end
 
   def evaluate_code(runtime, code, locator, prev_locator, opts \\ []) do

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -48,7 +48,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def disconnect(runtime) do
     ErlDist.RuntimeServer.stop(runtime.server_pid)
-    
+
     if Node.disconnect(runtime.node) do
       :ok
     end

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -15,12 +15,20 @@ defmodule LivebookCLI.Server do
   @impl true
   def usage() do
     """
-    Usage: livebook server [url] [options]
+    Usage: livebook server [open-command] [--options]
 
-    An optional url can be given as argument. If one is given,
-    a browser window will open importing the given url as a notebook:
+    An optional open-command can be given as argument. It will open
+    up a browser window according these rules:
 
-        livebook server https://example.com/my-notebook.livemd
+      * If the open-command is "new", the browser window will point
+        to a new notebook
+
+      * If the open-command is a URL, the notebook at the given URL
+        will be imported
+
+    The open-command runs after the server is started. If a server is
+    already running, the browser window will point to the server
+    currently running.
 
     ## Available options
 
@@ -50,6 +58,20 @@ defmodule LivebookCLI.Server do
     ## Environment variables
 
     #{@environment_variables}
+
+    ## Examples
+
+    Starts a server:
+
+        livebook server
+
+    Starts a server and opens up a browser at a new notebook:
+
+        livebook server new
+
+    Starts a server and imports the notebook at the given URL:
+
+        livebook server https://example.com/my-notebook.livemd
 
     """
   end

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -41,7 +41,6 @@ defmodule LivebookCLI.Server do
       --no-token           Disable token authentication, enabled by default
                            If LIVEBOOK_PASSWORD is set, it takes precedence over token auth
       --open               Open browser window pointing to the application
-      --open-new           Open browser window pointing to a new notebook
       -p, --port           The port to start the web application on, defaults to 8080
       --root-path          The root path to use for file selection
       --sname              Set a short name for the app distributed node
@@ -125,12 +124,12 @@ defmodule LivebookCLI.Server do
     if opts[:open] do
       Livebook.Utils.browser_open(base_url)
     end
+  end
 
-    if opts[:open_new] do
-      base_url
-      |> append_path("/explore/notebooks/new")
-      |> Livebook.Utils.browser_open()
-    end
+  defp open_from_options(base_url, _opts, ["new"]) do
+    base_url
+    |> append_path("/explore/notebooks/new")
+    |> Livebook.Utils.browser_open()
   end
 
   defp open_from_options(base_url, _opts, [url]) do
@@ -152,7 +151,6 @@ defmodule LivebookCLI.Server do
     ip: :string,
     name: :string,
     open: :boolean,
-    open_new: :boolean,
     port: :integer,
     root_path: :string,
     sname: :string,


### PR DESCRIPTION
Refers to #950 (specifically point 1 of [this comment](https://github.com/livebook-dev/livebook/issues/950#issuecomment-1025180323))


Note. (Git history seems a bit messed, while it's already rebased)