### PR TITLE
Controls how lines should wrap of the editor

### DIFF
--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -53,23 +53,6 @@ class LiveEditor {
       this._onCursorSelectionChange &&
         this._onCursorSelectionChange(event.selection);
     });
-
-    this.editor.addAction({
-      contextMenuGroupId: "word-wrapping",
-      id: "enable-word-wrapping",
-      label: "Enable word wrapping",
-      precondition: "config.editor.wordWrap == off",
-      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
-      run: (editor) => editor.updateOptions({ wordWrap: "on" }),
-    });
-    this.editor.addAction({
-      contextMenuGroupId: "word-wrapping",
-      id: "disable-word-wrapping",
-      label: "Disable word wrapping",
-      precondition: "config.editor.wordWrap == on",
-      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
-      run: (editor) => editor.updateOptions({ wordWrap: "off" }),
-    });
   }
 
   /**
@@ -195,6 +178,23 @@ class LiveEditor {
       // of the line we would get "defmodule" as a word completion.
       wordBasedSuggestions: this.type !== "elixir",
       parameterHints: this.type === "elixir" && settings.editor_auto_signature,
+    });
+
+    this.editor.addAction({
+      contextMenuGroupId: "word-wrapping",
+      id: "enable-word-wrapping",
+      label: "Enable word wrapping",
+      precondition: "config.editor.wordWrap == off",
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+      run: (editor) => editor.updateOptions({ wordWrap: "on" }),
+    });
+    this.editor.addAction({
+      contextMenuGroupId: "word-wrapping",
+      id: "disable-word-wrapping",
+      label: "Disable word wrapping",
+      precondition: "config.editor.wordWrap == on",
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+      run: (editor) => editor.updateOptions({ wordWrap: "off" }),
     });
 
     // Automatically adjust the editor size to fit the container.

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -55,16 +55,20 @@ class LiveEditor {
     });
 
     this.editor.addAction({
-      contextMenuGroupId: "toggle-word-wrapping",
-      id: "toggle-word-wrapping",
-      label: "Toggle word wrapping",
-      run: (editor) => {
-        const wordWrap =
-          editor.getOption(monaco.editor.EditorOption.wordWrap) === "on"
-            ? "off"
-            : "on";
-        editor.updateOptions({ wordWrap });
-      },
+      contextMenuGroupId: "word-wrapping",
+      id: "enable-word-wrapping",
+      label: "Enable word wrapping",
+      precondition: "config.editor.wordWrap == off",
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+      run: (editor) => editor.updateOptions({ wordWrap: "on" }),
+    });
+    this.editor.addAction({
+      contextMenuGroupId: "word-wrapping",
+      id: "disable-word-wrapping",
+      label: "Disable word wrapping",
+      precondition: "config.editor.wordWrap == on",
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+      run: (editor) => editor.updateOptions({ wordWrap: "off" }),
     });
   }
 

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -53,6 +53,19 @@ class LiveEditor {
       this._onCursorSelectionChange &&
         this._onCursorSelectionChange(event.selection);
     });
+
+    this.editor.addAction({
+      contextMenuGroupId: "toggle-word-wrapping",
+      id: "toggle-word-wrapping",
+      label: "Toggle word wrapping",
+      run: (editor) => {
+        const wordWrap =
+          editor.getOption(monaco.editor.EditorOption.wordWrap) === "on"
+            ? "off"
+            : "on";
+        editor.updateOptions({ wordWrap });
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
solve #848 

<img src="https://user-images.githubusercontent.com/6327995/151722768-171e22d5-d88e-4ea0-851a-6ac72ac9623d.png" width="450px" />

Some variable names from `vscode`

![image](https://user-images.githubusercontent.com/6327995/151722701-87656034-a24a-4efe-bee7-5044f6b43f87.png)
