### PR TITLE
Group public routes under a common prefix

### DIFF
--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -124,7 +124,7 @@ defmodule LivebookCLI.Server do
   defp check_endpoint_availability(base_url) do
     Application.ensure_all_started(:inets)
 
-    health_url = append_path(base_url, "/health")
+    health_url = append_path(base_url, "/public/health")
 
     case Livebook.Utils.HTTP.request(:get, health_url) do
       {:ok, status, _headers, body} ->

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -20,7 +20,19 @@ defmodule LivebookWeb.Router do
     plug :put_secure_browser_headers
   end
 
-  scope "/", LivebookWeb do
+  # The /public namespace includes routes with no authentication.
+  # When exposing Livebook through an authentication proxy, this
+  # namespace should be configured as publicly available, in order
+  # for all features to work as expected.
+
+  scope "/public", LivebookWeb do
+    pipe_through :browser
+
+    get "/health", HealthController, :index
+  end
+
+  # The following routes are public, but should be treated as opaque
+  scope "/public", LivebookWeb do
     pipe_through [:js_output_assets]
 
     get "/sessions/assets/:hash/*file_parts", SessionController, :show_cached_asset
@@ -76,13 +88,6 @@ defmodule LivebookWeb.Router do
       metrics: LivebookWeb.Telemetry,
       home_app: {"Livebook", :livebook},
       ecto_repos: []
-  end
-
-  # Public URLs without authentication
-  scope "/", LivebookWeb do
-    pipe_through :browser
-
-    get "/health", HealthController, :index
   end
 
   scope "/authenticate", LivebookWeb do


### PR DESCRIPTION
We now prefix all auth-less routes with `/public`, so it's easier to pass those requests through when using an authentication proxy. See the discussion in #954.