### PR TITLE
Show an error message when loading the JS module fails

### DIFF
--- a/assets/js/js_output/index.js
+++ b/assets/js/js_output/index.js
@@ -295,8 +295,8 @@ function bindIframeSize(iframe, iframePlaceholder) {
 // (1): https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#document_source_security
 // (2): https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 
-const IFRAME_SHA256 = "9cYdQb4mocxzFoj1EryzubL1n7P+lQTeEdWAkeV4E0I=";
-const IFRAME_URL = "https://livebook.space/iframe/v1.html";
+const IFRAME_SHA256 = "+uJyGu0Ey7uVV7WwRwg7GyjwCkMNRBnyNc25iGFpYXc=";
+const IFRAME_URL = "https://livebook.space/iframe/v2.html";
 
 function initializeIframeSource(iframe) {
   return verifyIframeSource().then(() => {


### PR DESCRIPTION
Closes #954.

Also see https://github.com/livebook-dev/livebook.space/pull/1.

![image](https://user-images.githubusercontent.com/17034772/152394122-3b2109b3-684f-44ab-8eba-d60c0c67f5a6.png)

Also, other errors are now shown in the same way:

![image](https://user-images.githubusercontent.com/17034772/152394225-6986d07d-1012-42d7-ad18-e5ce3da0d28c.png)
