### PR TITLE
add function to open notebook urls

### DIFF
--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -391,10 +391,10 @@ defmodule Livebook.Utils do
   Returns a URL (including localhost) to open the given `url` as a notebook
 
       iex> Livebook.Utils.notebook_open_url("https://example.com/foo.livemd")
-      "http://localhost:4002/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"
+      "http://localhost:4002/open?path=https%3A%2F%2Fexample.com%2Ffoo.livemd"
 
       iex> Livebook.Utils.notebook_open_url("https://my_host", "https://example.com/foo.livemd")
-      "https://my_host/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"  
+      "https://my_host/open?path=https%3A%2F%2Fexample.com%2Ffoo.livemd"  
 
   """
   def notebook_open_url(base_url \\ LivebookWeb.Endpoint.access_struct_url(), url) do

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -386,7 +386,7 @@ defmodule Livebook.Utils do
     |> append_query("url=#{URI.encode_www_form(url)}")
     |> URI.to_string()
   end
-  
+
   @doc """
   Returns a URL (including localhost) to open the given `url` as a notebook
 
@@ -404,7 +404,7 @@ defmodule Livebook.Utils do
     |> append_query("path=#{URI.encode_www_form(url)}")
     |> URI.to_string()
   end
-  
+
   # TODO: On Elixir v1.14, use URI.append_query/2
   def append_query(%URI{query: query} = uri, query_to_add) when query in [nil, ""] do
     %{uri | query: query_to_add}

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -389,15 +389,14 @@ defmodule Livebook.Utils do
   
   @doc """
   Returns a URL (including localhost) to open the given `url` as a notebook
-    
-    iex> Livebook.Utils.notebook_open_url("https://example.com/foo.livemd")
-    "http://localhost:4002/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"
 
-    iex> Livebook.Utils.notebook_open_url("https://my_host", "https://example.com/foo.livemd")
-    "https://my_host/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"  
-    
+      iex> Livebook.Utils.notebook_open_url("https://example.com/foo.livemd")
+      "http://localhost:4002/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"
+
+      iex> Livebook.Utils.notebook_open_url("https://my_host", "https://example.com/foo.livemd")
+      "https://my_host/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"  
+
   """
-  
   def notebook_open_url(base_url \\ LivebookWeb.Endpoint.access_struct_url(), url) do
     base_url
     |> URI.parse()

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -386,7 +386,26 @@ defmodule Livebook.Utils do
     |> append_query("url=#{URI.encode_www_form(url)}")
     |> URI.to_string()
   end
+  
+  @doc """
+  Returns a URL (including localhost) to open the given `url` as a notebook
+    
+    iex> Livebook.Utils.notebook_open_url("https://example.com/foo.livemd")
+    "http://localhost:4002/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"
 
+    iex> Livebook.Utils.notebook_open_url("https://my_host", "https://example.com/foo.livemd")
+    "https://my_host/open?url=https%3A%2F%2Fexample.com%2Ffoo.livemd"  
+    
+  """
+  
+  def notebook_open_url(base_url \\ LivebookWeb.Endpoint.access_struct_url(), url) do
+    base_url
+    |> URI.parse()
+    |> Map.replace!(:path, "/open")
+    |> append_query("url=#{URI.encode_www_form(url)}")
+    |> URI.to_string()
+  end
+  
   # TODO: On Elixir v1.14, use URI.append_query/2
   def append_query(%URI{query: query} = uri, query_to_add) when query in [nil, ""] do
     %{uri | query: query_to_add}

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -401,7 +401,7 @@ defmodule Livebook.Utils do
     base_url
     |> URI.parse()
     |> Map.replace!(:path, "/open")
-    |> append_query("url=#{URI.encode_www_form(url)}")
+    |> append_query("path=#{URI.encode_www_form(url)}")
     |> URI.to_string()
   end
   

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -168,7 +168,7 @@ defmodule LivebookCLI.Server do
 
       File.regular?(path) ->
         base_url
-        |> Livebook.Utils.notebook_open_url()
+        |> Livebook.Utils.notebook_open_url(url_or_file_or_dir)
 
       File.dir?(path) ->
         base_url

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -169,6 +169,7 @@ defmodule LivebookCLI.Server do
       File.regular?(path) ->
         base_url
         |> Livebook.Utils.notebook_open_url(url_or_file_or_dir)
+        |> Livebook.Utils.browser_open()
 
       File.dir?(path) ->
         base_url

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -168,9 +168,7 @@ defmodule LivebookCLI.Server do
 
       File.regular?(path) ->
         base_url
-        |> append_path("open")
-        |> update_query(%{"path" => path})
-        |> Livebook.Utils.browser_open()
+        |> Livebook.Utils.notebook_open_url()
 
       File.dir?(path) ->
         base_url


### PR DESCRIPTION
#927 
Created a `notebook_open_url/2` function in Livebook.Utils

An `:open` route was already added in router.ex.

Have not yet made the suggested changes to `open_from_options` (now `open_from_args/2`) in LivebookCLI.Server. Currently `open` is being added to the path and `Livebook.Utils.browser_open/1` is called to open the notebook [here](https://github.com/aar2dee2/livebook/blob/19f4f17e748e821a0ba9e457b0c417fff71a47ab/lib/livebook_cli/server.ex#L171).

Apologies for the delay :)