### PR TITLE
Handle runtime event broadcast in a separate worker process

### DIFF
--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -142,9 +142,14 @@ defprotocol Livebook.Runtime do
   monitoring that process and return the monitor reference.
   This way the caller is notified when the runtime goes down
   by listening to the :DOWN message.
+
+  ## Options
+
+    * `:runtime_broadcast_to` - the process to which broadcast
+      messages should be sent. Defaults to the owner
   """
-  @spec connect(t()) :: reference()
-  def connect(runtime)
+  @spec connect(t(), keyword()) :: reference()
+  def connect(runtime, opts \\ [])
 
   @doc """
   Disconnects the current owner from runtime.

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -41,8 +41,8 @@ end
 defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
   alias Livebook.Runtime.ErlDist
 
-  def connect(runtime) do
-    ErlDist.RuntimeServer.set_owner(runtime.server_pid, self())
+  def connect(runtime, opts \\ []) do
+    ErlDist.RuntimeServer.attach(runtime.server_pid, self(), opts)
     Process.monitor(runtime.server_pid)
   end
 

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -69,8 +69,8 @@ end
 defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
   alias Livebook.Runtime.ErlDist
 
-  def connect(runtime) do
-    ErlDist.RuntimeServer.set_owner(runtime.server_pid, self())
+  def connect(runtime, opts \\ []) do
+    ErlDist.RuntimeServer.attach(runtime.server_pid, self(), opts)
     Process.monitor(runtime.server_pid)
   end
 

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -42,8 +42,8 @@ end
 defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
   alias Livebook.Runtime.ErlDist
 
-  def connect(runtime) do
-    ErlDist.RuntimeServer.set_owner(runtime.server_pid, self())
+  def connect(runtime, opts \\ []) do
+    ErlDist.RuntimeServer.attach(runtime.server_pid, self(), opts)
     Process.monitor(runtime.server_pid)
   end
 

--- a/lib/livebook/runtime/erl_dist/evaluator_supervisor.ex
+++ b/lib/livebook/runtime/erl_dist/evaluator_supervisor.ex
@@ -20,12 +20,11 @@ defmodule Livebook.Runtime.ErlDist.EvaluatorSupervisor do
   @doc """
   Spawns a new evaluator.
   """
-  @spec start_evaluator(pid(), pid()) :: {:ok, Evaluator.t()} | {:error, any()}
-  def start_evaluator(supervisor, object_tracker) do
-    case DynamicSupervisor.start_child(
-           supervisor,
-           {Evaluator, [formatter: Evaluator.DefaultFormatter, object_tracker: object_tracker]}
-         ) do
+  @spec start_evaluator(pid(), keyword()) :: {:ok, Evaluator.t()} | {:error, any()}
+  def start_evaluator(supervisor, opts) do
+    opts = Keyword.put_new(opts, :formatter, Evaluator.DefaultFormatter)
+
+    case DynamicSupervisor.start_child(supervisor, {Evaluator, opts}) do
       {:ok, _pid, evaluator} -> {:ok, evaluator}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -136,8 +136,8 @@ end
 defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
   alias Livebook.Runtime.ErlDist
 
-  def connect(runtime) do
-    ErlDist.RuntimeServer.set_owner(runtime.server_pid, self())
+  def connect(runtime, opts \\ []) do
+    ErlDist.RuntimeServer.attach(runtime.server_pid, self(), opts)
     Process.monitor(runtime.server_pid)
   end
 

--- a/lib/livebook/session/worker.ex
+++ b/lib/livebook/session/worker.ex
@@ -5,8 +5,8 @@ defmodule Livebook.Session.Worker do
   # when the session state is not necessary.
   #
   # In particular, this process handles broadcast messages
-  # sent from within the runtime and sends them to the actual
-  # subscribers.
+  # sent from within the runtime and distributes them to the
+  # actual subscribers via pubsub.
 
   use GenServer
 

--- a/lib/livebook/session/worker.ex
+++ b/lib/livebook/session/worker.ex
@@ -1,0 +1,28 @@
+defmodule Livebook.Session.Worker do
+  @moduledoc false
+
+  # A dedicated process for offloading the session process,
+  # when the session state is not necessary.
+  #
+  # In particular, this process handles broadcast messages
+  # sent from within the runtime and sends them to the actual
+  # subscribers.
+
+  use GenServer
+
+  def start_link(session_id) do
+    GenServer.start_link(__MODULE__, {session_id})
+  end
+
+  @impl true
+  def init({session_id}) do
+    {:ok, %{session_id: session_id}}
+  end
+
+  @impl true
+  def handle_info({:runtime_broadcast, topic, subtopic, message}, state) do
+    full_topic = Livebook.Session.runtime_messages_topic(state.session_id, topic, subtopic)
+    Phoenix.PubSub.broadcast(Livebook.PubSub, full_topic, message)
+    {:noreply, state}
+  end
+end

--- a/test/livebook/evaluator/io_proxy_test.exs
+++ b/test/livebook/evaluator/io_proxy_test.exs
@@ -5,12 +5,13 @@ defmodule Livebook.Evaluator.IOProxyTest do
   alias Livebook.Evaluator.IOProxy
 
   setup do
-    # {:ok, io} = IOProxy.start_link()
-
     {:ok, object_tracker} = start_supervised(Evaluator.ObjectTracker)
-    {:ok, _pid, evaluator} = start_supervised({Evaluator, [object_tracker: object_tracker]})
+
+    {:ok, _pid, evaluator} =
+      start_supervised({Evaluator, [send_to: self(), object_tracker: object_tracker]})
+
     io = Process.info(evaluator.pid)[:group_leader]
-    IOProxy.configure(io, self(), :ref)
+    IOProxy.configure(io, :ref)
     %{io: io}
   end
 
@@ -41,30 +42,41 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
   describe "input" do
     test "responds to Livebook input request", %{io: io} do
-      configure_owner_with_input(io, "input1", :value)
+      pid =
+        spawn(fn ->
+          assert livebook_get_input_value(io, "input1") == {:ok, :value}
+        end)
 
-      assert livebook_get_input_value(io, "input1") == {:ok, :value}
+      reply_to_input_request(:ref, "input1", {:ok, :value}, 1)
+
+      await_termination(pid)
     end
 
     test "responds to subsequent requests with the same value", %{io: io} do
-      configure_owner_with_input(io, "input1", :value)
+      pid =
+        spawn(fn ->
+          assert livebook_get_input_value(io, "input1") == {:ok, :value}
+          assert livebook_get_input_value(io, "input1") == {:ok, :value}
+        end)
 
-      assert livebook_get_input_value(io, "input1") == {:ok, :value}
-      assert livebook_get_input_value(io, "input1") == {:ok, :value}
+      reply_to_input_request(:ref, "input1", {:ok, :value}, 1)
+
+      await_termination(pid)
     end
 
     test "clear_input_cache/1 clears all cached input information", %{io: io} do
       pid =
         spawn_link(fn ->
-          reply_to_input_request(:ref, "input1", {:ok, :value1}, 1)
-          reply_to_input_request(:ref, "input1", {:ok, :value2}, 1)
+          IOProxy.configure(io, :ref)
+          assert livebook_get_input_value(io, "input1") == {:ok, :value1}
+          IOProxy.clear_input_cache(io)
+          assert livebook_get_input_value(io, "input1") == {:ok, :value2}
         end)
 
-      IOProxy.configure(io, pid, :ref)
+      reply_to_input_request(:ref, "input1", {:ok, :value1}, 1)
+      reply_to_input_request(:ref, "input1", {:ok, :value2}, 1)
 
-      assert livebook_get_input_value(io, "input1") == {:ok, :value1}
-      IOProxy.clear_input_cache(io)
-      assert livebook_get_input_value(io, "input1") == {:ok, :value2}
+      await_termination(pid)
     end
   end
 
@@ -94,25 +106,25 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
   describe "token requests" do
     test "returns different tokens for subsequent calls", %{io: io} do
-      IOProxy.configure(io, self(), :ref1)
+      IOProxy.configure(io, :ref1)
       token1 = livebook_generate_token(io)
       token2 = livebook_generate_token(io)
       assert token1 != token2
     end
 
     test "returns different tokens for different refs", %{io: io} do
-      IOProxy.configure(io, self(), :ref1)
+      IOProxy.configure(io, :ref1)
       token1 = livebook_generate_token(io)
-      IOProxy.configure(io, self(), :ref2)
+      IOProxy.configure(io, :ref2)
       token2 = livebook_generate_token(io)
       assert token1 != token2
     end
 
     test "returns same tokens for the same ref", %{io: io} do
-      IOProxy.configure(io, self(), :ref)
+      IOProxy.configure(io, :ref)
       token1 = livebook_generate_token(io)
       token2 = livebook_generate_token(io)
-      IOProxy.configure(io, self(), :ref)
+      IOProxy.configure(io, :ref)
       token3 = livebook_generate_token(io)
       token4 = livebook_generate_token(io)
       assert token1 == token3
@@ -121,15 +133,6 @@ defmodule Livebook.Evaluator.IOProxyTest do
   end
 
   # Helpers
-
-  defp configure_owner_with_input(io, input_id, value) do
-    pid =
-      spawn_link(fn ->
-        reply_to_input_request(:ref, input_id, {:ok, value}, 1)
-      end)
-
-    IOProxy.configure(io, pid, :ref)
-  end
 
   defp reply_to_input_request(_ref, _input_id, _reply, 0), do: :ok
 
@@ -158,5 +161,10 @@ defmodule Livebook.Evaluator.IOProxyTest do
     send(io, {:io_request, self(), ref, request})
     assert_receive {:io_reply, ^ref, reply}
     reply
+  end
+
+  defp await_termination(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, _, _}
   end
 end

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -9,7 +9,7 @@ defmodule Livebook.Runtime.NoopRuntime do
   def new(), do: %__MODULE__{}
 
   defimpl Livebook.Runtime do
-    def connect(_), do: make_ref()
+    def connect(_, _), do: make_ref()
     def disconnect(_), do: :ok
     def evaluate_code(_, _, _, _, _ \\ []), do: :ok
     def forget_evaluation(_, _), do: :ok


### PR DESCRIPTION
`Kino.JS.Live` servers send `{:runtime_broadcast, _, _, _}` messages to the session, which then distributed those via pubsub. Those messages may be send arbitrarily often, and handling them doesn't require any of the session state, so to offload the session we spawn a dedicated `Livebook.Session.Worker` process for this kinds of tasks.

We pass the worker pid all the way down to the runtime group leader as `:runtime_broadcast_to`, so then we know where to message directly.