### PR TITLE
Fastlane JS channel events

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1313,9 +1313,11 @@ defmodule Livebook.Session do
   @doc """
   Subscribes the caller to runtime messages under the given topic.
   """
-  @spec subscribe_to_runtime_events(id(), String.t(), String.t()) :: :ok | {:error, term()}
-  def subscribe_to_runtime_events(session_id, topic, subtopic) do
-    Phoenix.PubSub.subscribe(Livebook.PubSub, runtime_messages_topic(session_id, topic, subtopic))
+  @spec subscribe_to_runtime_events(id(), String.t(), String.t(), term()) ::
+          :ok | {:error, term()}
+  def subscribe_to_runtime_events(session_id, topic, subtopic, metadata) do
+    full_topic = runtime_messages_topic(session_id, topic, subtopic)
+    Phoenix.PubSub.subscribe(Livebook.PubSub, full_topic, metadata: metadata)
   end
 
   @doc """

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1312,29 +1312,72 @@ defmodule Livebook.Session do
 
   @doc """
   Subscribes the caller to runtime messages under the given topic.
+
+  Broadcasted events are encoded using `encoder`, if successful,
+  the message is sent directly to `receiver_pid`, otherwise an
+  `{:encoding_error, error, message}` is sent to the caller.
   """
-  @spec subscribe_to_runtime_events(id(), String.t(), String.t(), term()) ::
-          :ok | {:error, term()}
-  def subscribe_to_runtime_events(session_id, topic, subtopic, metadata) do
+  @spec subscribe_to_runtime_events(
+          id(),
+          String.t(),
+          String.t(),
+          (term() -> {:ok, term()} | {:error, term()}),
+          pid()
+        ) :: :ok | {:error, term()}
+  def subscribe_to_runtime_events(session_id, topic, subtopic, encoder, receiver_pid) do
     full_topic = runtime_messages_topic(session_id, topic, subtopic)
-    Phoenix.PubSub.subscribe(Livebook.PubSub, full_topic, metadata: metadata)
+    Phoenix.PubSub.subscribe(Livebook.PubSub, full_topic, metadata: {encoder, receiver_pid})
   end
 
   @doc """
   Unsubscribes the caller from runtime messages subscribed earlier
-  with `subscribe_to_runtime_events/3`.
+  with `subscribe_to_runtime_events/5`.
   """
   @spec unsubscribe_from_runtime_events(id(), String.t(), String.t()) :: :ok | {:error, term()}
   def unsubscribe_from_runtime_events(session_id, topic, subtopic) do
-    Phoenix.PubSub.unsubscribe(
-      Livebook.PubSub,
-      runtime_messages_topic(session_id, topic, subtopic)
-    )
+    full_topic = runtime_messages_topic(session_id, topic, subtopic)
+    Phoenix.PubSub.unsubscribe(Livebook.PubSub, full_topic)
   end
 
   @doc false
-  def runtime_messages_topic(session_id, topic, subtopic) do
+  def broadcast_runtime_event(session_id, topic, subtopic, message) do
+    full_topic = runtime_messages_topic(session_id, topic, subtopic)
+    Phoenix.PubSub.broadcast(Livebook.PubSub, full_topic, message, __MODULE__)
+  end
+
+  defp runtime_messages_topic(session_id, topic, subtopic) do
     "sessions:#{session_id}:runtime_messages:#{topic}:#{subtopic}"
+  end
+
+  @doc false
+  # Custom dispatcher for broadcasting runtime events
+  def dispatch(subscribers, from, message) do
+    Enum.reduce(subscribers, %{}, fn
+      {pid, _}, cache when pid == from ->
+        cache
+
+      {pid, {encoder, receiver_pid}}, cache ->
+        case cache do
+          %{^encoder => encoded_message} ->
+            send(receiver_pid, encoded_message)
+            cache
+
+          %{} ->
+            case encoder.(message) do
+              {:ok, encoded_message} ->
+                send(receiver_pid, encoded_message)
+                Map.put(cache, encoder, encoded_message)
+
+              {:error, error} ->
+                send(pid, {:encoding_error, error, message})
+                cache
+            end
+        end
+
+      {pid, _}, cache ->
+        send(pid, message)
+        cache
+    end)
   end
 
   @doc """

--- a/lib/livebook/session/worker.ex
+++ b/lib/livebook/session/worker.ex
@@ -22,7 +22,7 @@ defmodule Livebook.Session.Worker do
   @impl true
   def handle_info({:runtime_broadcast, topic, subtopic, message}, state) do
     full_topic = Livebook.Session.runtime_messages_topic(state.session_id, topic, subtopic)
-    Phoenix.PubSub.broadcast(Livebook.PubSub, full_topic, message)
+    Phoenix.PubSub.broadcast(Livebook.PubSub, full_topic, message, LivebookWeb.JSOutputChannel)
     {:noreply, state}
   end
 end

--- a/lib/livebook/session/worker.ex
+++ b/lib/livebook/session/worker.ex
@@ -21,8 +21,7 @@ defmodule Livebook.Session.Worker do
 
   @impl true
   def handle_info({:runtime_broadcast, topic, subtopic, message}, state) do
-    full_topic = Livebook.Session.runtime_messages_topic(state.session_id, topic, subtopic)
-    Phoenix.PubSub.broadcast(Livebook.PubSub, full_topic, message, LivebookWeb.JSOutputChannel)
+    Livebook.Session.broadcast_runtime_event(state.session_id, topic, subtopic, message)
     {:noreply, state}
   end
 end

--- a/test/livebook_web/channels/js_output_channel_test.exs
+++ b/test/livebook_web/channels/js_output_channel_test.exs
@@ -23,12 +23,6 @@ defmodule LivebookWeb.JSOutputChannelTest do
     assert_push "init:1", %{"root" => [nil, [1, 2, 3]]}
   end
 
-  test "sends events received from widget server to the client", %{socket: socket} do
-    send(socket.channel_pid, {:event, "ping", [1, 2, 3], %{ref: "1"}})
-
-    assert_push "event:1", %{"root" => [["ping"], [1, 2, 3]]}
-  end
-
   test "sends client events to the corresponding widget server", %{socket: socket} do
     push(socket, "connect", %{"session_token" => session_token(), "ref" => "1"})
 
@@ -49,14 +43,6 @@ defmodule LivebookWeb.JSOutputChannelTest do
       send(from, {:connect_reply, payload, %{ref: "1"}})
 
       assert_push "init:1", {:binary, <<24::size(32), "[null,{\"message\":\"hey\"}]", 1, 2, 3>>}
-    end
-
-    test "from server to client", %{socket: socket} do
-      payload = {:binary, %{message: "hey"}, <<1, 2, 3>>}
-      send(socket.channel_pid, {:event, "ping", payload, %{ref: "1"}})
-
-      assert_push "event:1",
-                  {:binary, <<28::size(32), "[[\"ping\"],{\"message\":\"hey\"}]", 1, 2, 3>>}
     end
 
     test "form client to server", %{socket: socket} do


### PR DESCRIPTION
Follow up to #992. Introduces fastlaning to the runtime broadcast events. Specifically, when consuming those events in the `js_output` channel we encode the payload once and send directly to the transport process, entirely skipping the channel.