### PR TITLE
Speed up tests

### DIFF
--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -217,7 +217,7 @@ defmodule LivebookWeb.FileSelectComponent do
             </button>
           <% end %>
         <% end %>
-        <%= live_patch to: Routes.settings_path(@socket, :page),
+        <%= live_redirect to: Routes.settings_path(@socket, :page),
               class: "menu-item text-gray-500 border-t border-gray-200",
               role: "menuitem" do %>
           <.remix_icon icon="settings-3-line" />

--- a/lib/livebook_web/live/page_helpers.ex
+++ b/lib/livebook_web/live/page_helpers.ex
@@ -15,7 +15,7 @@ defmodule LivebookWeb.PageHelpers do
   def title(assigns) do
     ~H"""
     <div class="relative">
-      <%= live_patch to: Routes.home_path(@socket, :page),
+      <%= live_redirect to: Routes.home_path(@socket, :page),
             class: "hidden md:block absolute top-[50%] left-[-12px] transform -translate-y-1/2 -translate-x-full" do %>
         <.remix_icon icon="arrow-left-line" class="text-2xl align-middle" />
       <% end %>

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -168,7 +168,7 @@ defmodule LivebookWeb.SessionLive do
                   <.remix_icon icon="dashboard-2-line" />
                   <span class="font-medium">See on Dashboard</span>
                 </a>
-                <%= live_patch to: Routes.home_path(@socket, :close_session, @session.id),
+                <%= live_redirect to: Routes.home_path(@socket, :close_session, @session.id),
                       class: "menu-item text-red-600",
                       role: "menuitem" do %>
                   <.remix_icon icon="close-circle-line" />

--- a/lib/livebook_web/live/sidebar_helpers.ex
+++ b/lib/livebook_web/live/sidebar_helpers.ex
@@ -23,7 +23,7 @@ defmodule LivebookWeb.SidebarHelpers do
   def logo_item(assigns) do
     ~H"""
     <span>
-      <%= live_patch to: Routes.home_path(@socket, :page), aria_label: "go to homepage" do %>
+      <%= live_redirect to: Routes.home_path(@socket, :page), aria_label: "go to homepage" do %>
         <img src="/images/logo.png" height="40" width="40" alt="" />
       <% end %>
     </span>

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -632,8 +632,8 @@ defmodule Livebook.SessionTest do
   end
 
   defp start_session(opts \\ []) do
-    session_id = Utils.random_id()
-    {:ok, pid} = Session.start_link(Keyword.merge([id: session_id], opts))
+    opts = Keyword.merge([id: Utils.random_id()], opts)
+    pid = start_supervised!({Session, opts}, id: opts[:id])
     Session.get_by_pid(pid)
   end
 

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -120,6 +120,8 @@ defmodule LivebookWeb.HomeLiveTest do
 
       assert render(view) =~ session1.id
       assert render(view) =~ session2.id
+
+      Session.close([session1.pid, session2.pid])
     end
 
     test "updates UI whenever a session is added or deleted", %{conn: conn} do
@@ -151,6 +153,8 @@ defmodule LivebookWeb.HomeLiveTest do
                Routes.session_path(conn, :download_source, session.id, "livemd",
                  include_outputs: false
                )
+
+      Session.close(session.pid)
     end
 
     test "allows forking existing session", %{conn: conn} do
@@ -168,6 +172,8 @@ defmodule LivebookWeb.HomeLiveTest do
 
       {:ok, view, _} = live(conn, to)
       assert render(view) =~ "My notebook - fork"
+
+      Session.close(session.pid)
     end
 
     test "allows closing session after confirmation", %{conn: conn} do
@@ -186,6 +192,8 @@ defmodule LivebookWeb.HomeLiveTest do
       |> render_click()
 
       refute render(view) =~ session.id
+
+      Session.close(session.pid)
     end
 
     test "close all selected sessions using bulk action", %{conn: conn} do
@@ -215,6 +223,8 @@ defmodule LivebookWeb.HomeLiveTest do
       refute render(view) =~ session1.id
       refute render(view) =~ session2.id
       refute render(view) =~ session3.id
+
+      Session.close([session1.pid, session2.pid, session3.pid])
     end
   end
 


### PR DESCRIPTION
I noticed the tests run fairly slow for me, so I did some investigation and it looks like the the bottleneck is `home_live_test.exs`, but only when running after `session_live_test.exs`. One relevant factor is that the session tests create a bunch of sections that are never closed, and then they are all rendered on the homepage, which accumulates as the tests run. There may be more to it, but with this change `mix test test/livebook_web/live` is like ~4 times faster for me, which makes `mix test` like ~2 times faster.