### PR TITLE
Delay appearing input focus

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -96,7 +96,12 @@ window.liveSocket = liveSocket;
 // Handling custom events dispatched with JS.dispatch/3
 
 window.addEventListener("lb:focus", (event) => {
-  event.target.focus();
+  // The element may be about to show up via JS.show, which wraps the
+  // change in requestAnimationFrame, so we do the same to make sure
+  // the focus is applied only after we change the element visibility
+  requestAnimationFrame(() => {
+    event.target.focus();
+  });
 });
 
 window.addEventListener("lb:set_value", (event) => {


### PR DESCRIPTION
Closes #999.

We have a button that shows the input using `LiveView.JS` like this:

https://github.com/livebook-dev/livebook/blob/353e1f78895d33fe8a617d4cb44aeee60596c3e0/lib/livebook_web/live/file_select_component.ex#L321-L326

We need to wait for the input to appear before focusing it. I believe that `JS.show` uses `requestAnimationFrame`, which means in practice the focus event could be dispatched and handled before showing the element. Wrapping `element.focus()` inside `requestAnimationFrame` seems to fix the problem. @chrismccord please let me know if this makes sense :)