### PR TITLE
Cache mermaid graph rendering

### DIFF
--- a/assets/js/lib/cache_lru.js
+++ b/assets/js/lib/cache_lru.js
@@ -1,0 +1,33 @@
+/**
+ * A Map-based LRU cache.
+ */
+export default class CacheLRU {
+  constructor(size) {
+    this.size = size;
+    this.cache = new Map();
+  }
+
+  get(key) {
+    if (this.cache.has(key)) {
+      const value = this.cache.get(key);
+      // Map keys are stored and iterated in insertion order,
+      // so we reinsert on every access
+      this.cache.delete(key);
+      this.cache.set(key, value);
+      return value;
+    } else {
+      return undefined;
+    }
+  }
+
+  set(key, val) {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size === this.size) {
+      const oldestKey = this.cache.keys().next().value;
+      this.cache.delete(oldestKey);
+    }
+
+    this.cache.set(key, val);
+  }
+}

--- a/assets/js/lib/cache_lru.js
+++ b/assets/js/lib/cache_lru.js
@@ -20,7 +20,7 @@ export default class CacheLRU {
     }
   }
 
-  set(key, val) {
+  set(key, value) {
     if (this.cache.has(key)) {
       this.cache.delete(key);
     } else if (this.cache.size === this.size) {
@@ -28,6 +28,6 @@ export default class CacheLRU {
       this.cache.delete(oldestKey);
     }
 
-    this.cache.set(key, val);
+    this.cache.set(key, value);
   }
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5007,9 +5007,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
-      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.5.tgz",
+      "integrity": "sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -8810,15 +8810,15 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "8.13.9",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.9.tgz",
-      "integrity": "sha512-kMH676xEomSe/gzxMpDx91L+z9L+9iB3lvtPFA8aeOPRNNrfd3ZDvDCGFnuqQaJvPRCxs3Me2JDaVVNOZjojrg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.14.0.tgz",
+      "integrity": "sha512-ITSHjwVaby1Li738sxhF48sLTxcNyUAoWfoqyztL1f7J6JOLpHOuQPNLBb6lxGPUA0u7xP9IRULgvod0dKu35A==",
       "dependencies": {
         "@braintree/sanitize-url": "^3.1.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.4",
+        "dompurify": "2.3.5",
         "graphlib": "^2.1.8",
         "khroma": "^1.4.1",
         "moment-mini": "^2.24.0",
@@ -16445,9 +16445,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
-      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.5.tgz",
+      "integrity": "sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -19230,15 +19230,15 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "mermaid": {
-      "version": "8.13.9",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.9.tgz",
-      "integrity": "sha512-kMH676xEomSe/gzxMpDx91L+z9L+9iB3lvtPFA8aeOPRNNrfd3ZDvDCGFnuqQaJvPRCxs3Me2JDaVVNOZjojrg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.14.0.tgz",
+      "integrity": "sha512-ITSHjwVaby1Li738sxhF48sLTxcNyUAoWfoqyztL1f7J6JOLpHOuQPNLBb6lxGPUA0u7xP9IRULgvod0dKu35A==",
       "requires": {
         "@braintree/sanitize-url": "^3.1.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.4",
+        "dompurify": "2.3.5",
         "graphlib": "^2.1.8",
         "khroma": "^1.4.1",
         "moment-mini": "^2.24.0",


### PR DESCRIPTION
See #1021.

When typing text in a Markdown cell, the graph definition doesn't change, so we now cache the rendered SVG.

I also noticed a number of `console.log`s, so I bumped mermaid as it's been fixed.