### PR TITLE
Add hyperlink escape codes to URL

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -170,7 +170,11 @@ defmodule Livebook.Application do
 
   defp display_startup_info() do
     if Phoenix.Endpoint.server?(:livebook, LivebookWeb.Endpoint) do
-      IO.puts("[Livebook] Application running at #{LivebookWeb.Endpoint.access_url()}")
+      if IO.ANSI.enabled? do
+        IO.puts("[Livebook] Application running at \e]8;;#{LivebookWeb.Endpoint.access_url()}\e\\#{LivebookWeb.Endpoint.access_url()}\e]8;;\e\\")
+      else
+        IO.puts("[Livebook] Application running at #{LivebookWeb.Endpoint.access_url()}")
+      end
     end
   end
 


### PR DESCRIPTION
Use an OSC 8 escape sequence to mark the displayed URL as a hyperlink.
This functionality was added to GNOME's VTE widget in Spring 2017, and
most recent terminals support it. There's no easy way to detect support,
so use IO.ANSI.enabled? as a best-effort proxy.