### PR TITLE
Prevent smart cell menu from overlapping with insert buttons

### DIFF
--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -7,7 +7,7 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
       role="toolbar"
       aria-label="insert new"
       data-element="insert-buttons">
-      <div class={"w-full absolute z-10 #{if(@persistent, do: "opacity-100", else: "opacity-0")} hover:opacity-100 focus-within:opacity-100 flex space-x-2 justify-center items-center"}>
+      <div class={"w-full absolute z-10 focus-within:z-[11] #{if(@persistent, do: "opacity-100", else: "opacity-0")} hover:opacity-100 focus-within:opacity-100 flex space-x-2 justify-center items-center"}>
         <button class="button-base button-small"
           phx-click="insert_cell_below"
           phx-value-type="markdown"


### PR DESCRIPTION
That's an interesting one. Each buttons group has absolute position with z-index 10 and the smart cell menu is absolutely positioned with z-index 20. However, the menu z-index is relative to the parent buttons group, and since both groups have the same z-index, the latter is always on the top. To fix this we increase the group z-index while `:focus-within`.

![image](https://user-images.githubusercontent.com/17034772/158889934-03ef133c-273a-423a-b25c-fe5ea93a7d12.png)