### PR TITLE
Keep binding in reversed evaluation order

### DIFF
--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -456,8 +456,8 @@ defmodule Livebook.Runtime.Evaluator do
   defp code_error?(_error), do: false
 
   defp reorder_binding(binding, prev_binding) do
-    # We keep the order of existing binding entries and move
-    # the new ones to the beginning, ordered alphabetically
+    # We keep the order of existing binding entries and move the new
+    # ones to the beginning
 
     binding_map = Map.new(binding)
 
@@ -467,11 +467,9 @@ defmodule Livebook.Runtime.Evaluator do
         :erts_debug.same(val, prev_val)
       end)
 
-    unchanged_keys = for {key, _} <- unchanged_binding, into: MapSet.new(), do: key
-
-    binding
-    |> Enum.reject(fn {key, _} -> MapSet.member?(unchanged_keys, key) end)
-    |> Enum.sort()
+    unchanged_binding
+    |> Enum.reduce(binding_map, fn {key, _}, acc -> Map.delete(acc, key) end)
+    |> Map.to_list()
     |> Kernel.++(unchanged_binding)
   end
 

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -456,6 +456,9 @@ defmodule Livebook.Runtime.Evaluator do
   defp code_error?(_error), do: false
 
   defp reorder_binding(binding, prev_binding) do
+    # We keep the order of existing binding entries and move
+    # the new ones to the beginning, ordered alphabetically
+
     binding_map = Map.new(binding)
 
     prev_idx =

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -471,7 +471,7 @@ defmodule Livebook.Runtime.Evaluator do
 
     binding
     |> Enum.reject(fn {key, _} -> MapSet.member?(unchanged_keys, key) end)
-    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.sort()
     |> Kernel.++(unchanged_binding)
   end
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -311,6 +311,13 @@ defmodule Livebook.Runtime.EvaluatorTest do
   end
 
   describe "binding order" do
+    test "orders binding from the same evaluation alphabetically", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "b = 1; a = 1; c = 1", :code_1)
+
+      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_1)
+      assert [:a, :b, :c] == Enum.map(binding, &elem(&1, 0))
+    end
+
     test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
       Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -310,6 +310,16 @@ defmodule Livebook.Runtime.EvaluatorTest do
     end
   end
 
+  test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
+    Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
+    Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
+    Evaluator.evaluate_code(evaluator, "c = 1", :code_3, :code_2)
+    Evaluator.evaluate_code(evaluator, "x = 1", :code_4, :code_3)
+
+    {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_4)
+    assert [:x, :c, :a, :b] == Enum.map(binding, &elem(&1, 0))
+  end
+
   # Helpers
 
   # Some of the code passed to Evaluator above is expected

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -311,13 +311,6 @@ defmodule Livebook.Runtime.EvaluatorTest do
   end
 
   describe "binding order" do
-    test "orders binding from the same evaluation alphabetically", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "b = 1; a = 1; c = 1", :code_1)
-
-      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_1)
-      assert [:a, :b, :c] == Enum.map(binding, &elem(&1, 0))
-    end
-
     test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
       Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -310,14 +310,25 @@ defmodule Livebook.Runtime.EvaluatorTest do
     end
   end
 
-  test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
-    Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
-    Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
-    Evaluator.evaluate_code(evaluator, "c = 1", :code_3, :code_2)
-    Evaluator.evaluate_code(evaluator, "x = 1", :code_4, :code_3)
+  describe "binding order" do
+    test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
+      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
+      Evaluator.evaluate_code(evaluator, "c = 1", :code_3, :code_2)
+      Evaluator.evaluate_code(evaluator, "x = 1", :code_4, :code_3)
 
-    {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_4)
-    assert [:x, :c, :a, :b] == Enum.map(binding, &elem(&1, 0))
+      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_4)
+      assert [:x, :c, :a, :b] == Enum.map(binding, &elem(&1, 0))
+    end
+
+    test "treats rebound names as new", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
+      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
+      Evaluator.evaluate_code(evaluator, "b = 2", :code_3, :code_2)
+
+      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_3)
+      assert [:b, :a] == Enum.map(binding, &elem(&1, 0))
+    end
   end
 
   # Helpers


### PR DESCRIPTION
This way smart cells get the binding entries ordered from newest to oldest, for more accurate variable selection.