### PR TITLE
Show a message when JS view data is not available

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -238,4 +238,8 @@
   .error-box {
     @apply rounded-lg px-4 py-2 bg-red-100 text-red-400 font-medium;
   }
+
+  .info-box {
+    @apply p-4 bg-gray-100 text-sm text-gray-500 font-medium rounded-lg;
+  }
 }

--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -57,6 +57,7 @@ const JSView = {
     this.childToken = randomToken();
     this.childReadyPromise = null;
     this.childReady = false;
+    this.initReceived = false;
 
     this.initTimeout = setTimeout(() => this.handleInitTimeout(), 2_000);
 
@@ -318,6 +319,7 @@ const JSView = {
 
   handleServerInit(payload) {
     this.clearInitTimeout();
+    this.initReceived = true;
 
     this.childReadyPromise.then(() => {
       this.postMessage({ type: "init", data: payload });
@@ -325,6 +327,10 @@ const JSView = {
   },
 
   handleServerEvent(event, payload) {
+    if (!this.initReceived) {
+      return;
+    }
+
     this.childReadyPromise.then(() => {
       this.postMessage({ type: "event", event, payload });
     });

--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -1,5 +1,5 @@
 import { getAttributeOrThrow, parseInteger } from "../lib/attribute";
-import { randomToken } from "../lib/utils";
+import { randomId, randomToken } from "../lib/utils";
 import {
   getChannel,
   transportDecode,
@@ -50,6 +50,7 @@ const JSView = {
   mounted() {
     this.props = this.getProps();
 
+    this.id = randomId();
     this.childToken = randomToken();
     this.childReadyPromise = null;
     this.childReady = false;
@@ -73,10 +74,13 @@ const JSView = {
 
     // Channel events
 
-    const initRef = this.channel.on(`init:${this.props.ref}`, (raw) => {
-      const [, payload] = transportDecode(raw);
-      this.handleServerInit(payload);
-    });
+    const initRef = this.channel.on(
+      `init:${this.props.ref}:${this.id}`,
+      (raw) => {
+        const [, payload] = transportDecode(raw);
+        this.handleServerInit(payload);
+      }
+    );
 
     const eventRef = this.channel.on(`event:${this.props.ref}`, (raw) => {
       const [[event], payload] = transportDecode(raw);
@@ -91,7 +95,7 @@ const JSView = {
     );
 
     this.unsubscribeFromChannelEvents = () => {
-      this.channel.off(`init:${this.props.ref}`, initRef);
+      this.channel.off(`init:${this.props.ref}:${this.id}`, initRef);
       this.channel.off(`event:${this.props.ref}`, eventRef);
       this.channel.off(`error:${this.props.ref}`, errorRef);
     };
@@ -99,6 +103,7 @@ const JSView = {
     this.channel.push("connect", {
       session_token: this.props.sessionToken,
       ref: this.props.ref,
+      id: this.id,
     });
   },
 

--- a/lib/livebook_web/live/js_view_component.ex
+++ b/lib/livebook_web/live/js_view_component.ex
@@ -2,6 +2,14 @@ defmodule LivebookWeb.JSViewComponent do
   use LivebookWeb, :live_component
 
   @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:timeout_message, fn -> "Not available" end)}
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div id={"js-output-#{@id}-#{@js_view.ref}"}
@@ -12,7 +20,8 @@ defmodule LivebookWeb.JSViewComponent do
       data-js-path={@js_view.assets.js_path}
       data-session-token={session_token(@js_view.pid)}
       data-session-id={@session_id}
-      data-iframe-local-port={LivebookWeb.IframeEndpoint.port()}>
+      data-iframe-local-port={LivebookWeb.IframeEndpoint.port()}
+      data-timeout-message={@timeout_message}>
     </div>
     """
   end

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -65,7 +65,8 @@ defmodule LivebookWeb.Output do
     live_component(LivebookWeb.JSViewComponent,
       id: id,
       js_view: js_info.js_view,
-      session_id: session_id
+      session_id: session_id,
+      timeout_message: "Output data no longer available, please reevaluate this cell"
     )
   end
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -134,7 +134,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
               </div>
 
             <% :dead -> %>
-              <div class="p-4 bg-gray-100 text-sm text-gray-500 font-medium rounded-lg">
+              <div class="info-box">
                 Evaluate and install dependencies to show the contents of this Smart cell.
               </div>
 

--- a/test/livebook_web/channels/js_view_channel_test.exs
+++ b/test/livebook_web/channels/js_view_channel_test.exs
@@ -15,16 +15,29 @@ defmodule LivebookWeb.JSViewChannelTest do
   end
 
   test "loads initial data from the widget server and pushes to the client", %{socket: socket} do
-    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1"})
+    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id1"})
 
     assert_receive {:connect, from, %{}}
     send(from, {:connect_reply, [1, 2, 3], %{ref: "1"}})
 
-    assert_push "init:1", %{"root" => [nil, [1, 2, 3]]}
+    assert_push "init:1:id1", %{"root" => [nil, [1, 2, 3]]}
+  end
+
+  test "loads initial data for multiple connections separately", %{socket: socket} do
+    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id1"})
+    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id2"})
+
+    assert_receive {:connect, from, %{}}
+    send(from, {:connect_reply, [1, 2, 3], %{ref: "1"}})
+    assert_push "init:1:id1", %{"root" => [nil, [1, 2, 3]]}
+
+    assert_receive {:connect, from, %{}}
+    send(from, {:connect_reply, [1, 2, 3], %{ref: "1"}})
+    assert_push "init:1:id2", %{"root" => [nil, [1, 2, 3]]}
   end
 
   test "sends client events to the corresponding widget server", %{socket: socket} do
-    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1"})
+    push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id1"})
 
     assert_receive {:connect, from, %{}}
     send(from, {:connect_reply, [1, 2, 3], %{ref: "1"}})
@@ -36,17 +49,18 @@ defmodule LivebookWeb.JSViewChannelTest do
 
   describe "binary payload" do
     test "initial data", %{socket: socket} do
-      push(socket, "connect", %{"session_token" => session_token(), "ref" => "1"})
+      push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id1"})
 
       assert_receive {:connect, from, %{}}
       payload = {:binary, %{message: "hey"}, <<1, 2, 3>>}
       send(from, {:connect_reply, payload, %{ref: "1"}})
 
-      assert_push "init:1", {:binary, <<24::size(32), "[null,{\"message\":\"hey\"}]", 1, 2, 3>>}
+      assert_push "init:1:id1",
+                  {:binary, <<24::size(32), "[null,{\"message\":\"hey\"}]", 1, 2, 3>>}
     end
 
     test "form client to server", %{socket: socket} do
-      push(socket, "connect", %{"session_token" => session_token(), "ref" => "1"})
+      push(socket, "connect", %{"session_token" => session_token(), "ref" => "1", "id" => "id1"})
 
       assert_receive {:connect, from, %{}}
       send(from, {:connect_reply, [1, 2, 3], %{ref: "1"}})


### PR DESCRIPTION
When a cell with JS output is restored, its data on Kino side may have already been garbage-collected. We now show a corresponding message:

https://user-images.githubusercontent.com/17034772/159536029-68eaa81e-4722-4d85-b6f9-cb0ee54a813e.mp4

This also improves the experience in other cases. For example when the user restarts the runtime and refreshes the page.

Also fixes duplicated initialization, for edge cases like this:

https://user-images.githubusercontent.com/17034772/159536221-4c26ea4c-f4d0-40d4-b3a4-5861bff45773.mp4