### PR TITLE
Introduce a setup cell

### DIFF
--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -82,12 +82,12 @@ solely client-side operations.
   @apply opacity-100 pointer-events-auto;
 }
 
-[data-element="cell"] [data-element="cell-status"][data-js-changed] {
+[data-element="cell"][data-js-changed] [data-element="cell-status"] {
   @apply italic;
 }
 
-[data-element="cell"]
-  [data-element="cell-status"]:not([data-js-changed])
+[data-element="cell"]:not([data-js-changed])
+  [data-element="cell-status"]
   [data-element="change-indicator"] {
   @apply invisible;
 }
@@ -138,10 +138,10 @@ solely client-side operations.
 }
 
 [data-element="session"]:not([data-js-insert-mode])
-  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"])
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-changed])
   [data-element="editor-box"],
 [data-element="session"]
-  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-focused])
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-changed]):not([data-js-focused])
   [data-element="editor-box"] {
   @apply h-0 overflow-hidden;
 }
@@ -151,6 +151,9 @@ solely client-side operations.
   [data-element="enable-insert-mode-button"],
 [data-element="session"]
   [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="enable-insert-mode-button"],
+[data-element="session"]
+  [data-element="cell"][data-type="setup"][data-js-changed]
   [data-element="enable-insert-mode-button"] {
   @apply hidden;
 }
@@ -160,6 +163,9 @@ solely client-side operations.
   [data-element="info-box"],
 [data-element="session"]
   [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="info-box"],
+[data-element="session"]
+  [data-element="cell"][data-type="setup"][data-js-changed]
   [data-element="info-box"] {
   @apply hidden;
 }

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -34,7 +34,7 @@ solely client-side operations.
 }
 
 [data-element="session"][data-js-insert-mode]
-  [data-element="cell"][data-type="markdown"][data-js-focused]
+  [data-element="cell"][data-js-focused]
   [data-element="enable-insert-mode-button"] {
   @apply hidden;
 }
@@ -137,6 +137,33 @@ solely client-side operations.
   @apply hidden;
 }
 
+[data-element="session"]:not([data-js-insert-mode])
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"])
+  [data-element="editor-box"],
+[data-element="session"]
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-focused])
+  [data-element="editor-box"] {
+  @apply h-0 overflow-hidden;
+}
+
+[data-element="session"][data-js-insert-mode]
+  [data-element="cell"][data-type="setup"][data-js-focused]
+  [data-element="enable-insert-mode-button"],
+[data-element="session"]
+  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="enable-insert-mode-button"] {
+  @apply hidden;
+}
+
+[data-element="session"][data-js-insert-mode]
+  [data-element="cell"][data-type="setup"][data-js-focused]
+  [data-element="info-box"],
+[data-element="session"]
+  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="info-box"] {
+  @apply hidden;
+}
+
 [data-element="cell"][data-type="smart"]:not([data-js-source-visible])
   [data-element="show-ui-icon"] {
   @apply hidden;
@@ -145,17 +172,6 @@ solely client-side operations.
 [data-element="cell"][data-type="smart"][data-js-source-visible]
   [data-element="show-code-icon"] {
   @apply hidden;
-}
-
-[data-element="cell"][data-type="smart"]:not([data-js-source-visible])
-  [data-element="cell-status-container"] {
-  @apply flex justify-end;
-}
-
-[data-element="cell"][data-type="smart"]:not([data-js-source-visible])
-  [data-element="cell-status-container"]
-  > *:first-child {
-  @apply mt-2;
 }
 
 [data-element="cell"][data-type="smart"][data-js-source-visible]

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -138,10 +138,10 @@ solely client-side operations.
 }
 
 [data-element="session"]:not([data-js-insert-mode])
-  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-changed])
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]:not([data-js-empty])):not([data-js-changed])
   [data-element="editor-box"],
 [data-element="session"]
-  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]):not([data-js-changed]):not([data-js-focused])
+  [data-element="cell"][data-type="setup"]:not([data-eval-validity="fresh"]:not([data-js-empty])):not([data-js-changed]):not([data-js-focused])
   [data-element="editor-box"] {
   @apply h-0 overflow-hidden;
 }
@@ -150,7 +150,7 @@ solely client-side operations.
   [data-element="cell"][data-type="setup"][data-js-focused]
   [data-element="enable-insert-mode-button"],
 [data-element="session"]
-  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]:not([data-js-empty])
   [data-element="enable-insert-mode-button"],
 [data-element="session"]
   [data-element="cell"][data-type="setup"][data-js-changed]
@@ -162,7 +162,7 @@ solely client-side operations.
   [data-element="cell"][data-type="setup"][data-js-focused]
   [data-element="info-box"],
 [data-element="session"]
-  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]
+  [data-element="cell"][data-type="setup"][data-eval-validity="fresh"]:not([data-js-empty])
   [data-element="info-box"],
 [data-element="session"]
   [data-element="cell"][data-type="setup"][data-js-changed]

--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -174,19 +174,23 @@ const Cell = {
     });
 
     if (tag === "primary") {
+      const source = liveEditor.getSource();
+
+      this.el.toggleAttribute("data-js-empty", source === "");
+
+      liveEditor.onChange((newSource) => {
+        this.el.toggleAttribute("data-js-empty", newSource === "");
+      });
+
       // Setup markdown rendering
       if (this.props.type === "markdown") {
         const markdownContainer = this.el.querySelector(
           `[data-element="markdown-container"]`
         );
-        const markdown = new Markdown(
-          markdownContainer,
-          liveEditor.getSource(),
-          {
-            baseUrl: this.props.sessionPath,
-            emptyText: "Empty markdown cell",
-          }
-        );
+        const markdown = new Markdown(markdownContainer, source, {
+          baseUrl: this.props.sessionPath,
+          emptyText: "Empty markdown cell",
+        });
 
         liveEditor.onChange((newSource) => {
           markdown.setContent(newSource);

--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -259,7 +259,7 @@ const Cell = {
       const source = this.liveEditors.primary.getSource();
       const digest = md5Base64(source);
       const changed = this.props.evaluationDigest !== digest;
-      cellStatus.toggleAttribute("data-js-changed", changed);
+      this.el.toggleAttribute("data-js-changed", changed);
     }
   },
 

--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -28,9 +28,9 @@ class LiveEditor {
     this.language = language;
     this.intellisense = intellisense;
     this.readOnly = readOnly;
-    this._onChange = null;
-    this._onBlur = null;
-    this._onCursorSelectionChange = null;
+    this._onChange = [];
+    this._onBlur = [];
+    this._onCursorSelectionChange = [];
     this._remoteUserByClientPid = {};
 
     this._mountEditor();
@@ -49,7 +49,7 @@ class LiveEditor {
 
     this.editorClient.onDelta((delta) => {
       this.source = delta.applyToString(this.source);
-      this._onChange && this._onChange(this.source);
+      this._onChange.forEach((callback) => callback(this.source));
     });
 
     this.editor.onDidFocusEditorWidget(() => {
@@ -58,12 +58,13 @@ class LiveEditor {
 
     this.editor.onDidBlurEditorWidget(() => {
       this.editor.updateOptions({ matchBrackets: "never" });
-      this._onBlur && this._onBlur();
+      this._onBlur.forEach((callback) => callback());
     });
 
     this.editor.onDidChangeCursorSelection((event) => {
-      this._onCursorSelectionChange &&
-        this._onCursorSelectionChange(event.selection);
+      this._onCursorSelectionChange.forEach((callback) =>
+        callback(event.selection)
+      );
     });
   }
 
@@ -78,21 +79,21 @@ class LiveEditor {
    * Registers a callback called with a new cell content whenever it changes.
    */
   onChange(callback) {
-    this._onChange = callback;
+    this._onChange.push(callback);
   }
 
   /**
    * Registers a callback called with a new cursor selection whenever it changes.
    */
   onCursorSelectionChange(callback) {
-    this._onCursorSelectionChange = callback;
+    this._onCursorSelectionChange.push(callback);
   }
 
   /**
    * Registers a callback called whenever the editor loses focus.
    */
   onBlur(callback) {
-    this._onBlur = callback;
+    this._onBlur.push(callback);
   }
 
   focus() {

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -475,11 +475,15 @@ const Session = {
    * Enters insert mode when a markdown cell is double-clicked.
    */
   handleDocumentDoubleClick(event) {
-    const markdownCell = event.target.closest(
-      `[data-element="cell"][data-type="markdown"]`
-    );
+    const cell = event.target.closest(`[data-element="cell"]`);
+    const type = cell && cell.getAttribute("data-type");
 
-    if (markdownCell && this.focusedId && !this.insertMode) {
+    if (
+      type &&
+      ["markdown", "setup"].includes(type) &&
+      this.focusedId &&
+      !this.insertMode
+    ) {
       this.setInsertMode(true);
     }
   },

--- a/assets/js/lib/notebook.js
+++ b/assets/js/lib/notebook.js
@@ -2,12 +2,12 @@
  * Checks if the given cell type is eligible for evaluation.
  */
 export function isEvaluable(cellType) {
-  return ["code", "smart"].includes(cellType);
+  return ["code", "smart", "setup"].includes(cellType);
 }
 
 /**
  * Checks if the given cell type has primary editable editor.
  */
 export function isDirectlyEditable(cellType) {
-  return ["markdown", "code"].includes(cellType);
+  return ["markdown", "code", "setup"].includes(cellType);
 }

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -67,4 +67,13 @@ defmodule Livebook.Notebook.Cell do
   end
 
   def find_inputs_in_output(_output), do: []
+
+  @doc """
+  Checks if the given cell is the setup code cell.
+  """
+  @spec setup?(t()) :: boolean()
+  def setup?(cell)
+
+  def setup?(%Cell.Code{id: "setup"}), do: true
+  def setup?(_cell), do: false
 end

--- a/lib/livebook/notebook/export/elixir.ex
+++ b/lib/livebook/notebook/export/elixir.ex
@@ -13,10 +13,14 @@ defmodule Livebook.Notebook.Export.Elixir do
   end
 
   defp render_notebook(notebook) do
+    %{setup_section: %{cells: [setup_cell]} = setup_section} = notebook
+
     name = ["# Title: ", notebook.name]
+    setup_cell = render_setup_cell(setup_cell, setup_section)
     sections = Enum.map(notebook.sections, &render_section(&1, notebook))
 
-    [name | sections]
+    [name, setup_cell | sections]
+    |> Enum.reject(&is_nil/1)
     |> Enum.intersperse("\n\n")
   end
 
@@ -39,6 +43,9 @@ defmodule Livebook.Notebook.Export.Elixir do
     [name | cells]
     |> Enum.intersperse("\n\n")
   end
+
+  defp render_setup_cell(%{source: ""}, _section), do: nil
+  defp render_setup_cell(cell, section), do: render_cell(cell, section)
 
   defp render_cell(%Cell.Markdown{} = cell, _section) do
     cell.source

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -13,7 +13,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       data-type={@cell_view.type}
       data-session-path={Routes.session_path(@socket, :page, @session_id)}
       data-evaluation-digest={get_in(@cell_view, [:eval, :evaluation_digest])}
-      data-eval-validity={get_in(@cell_view, [:eval, :validity])}>
+      data-eval-validity={get_in(@cell_view, [:eval, :validity])}
+      data-js-empty={empty?(@cell_view.source_view)}>
       <%= render_cell(assigns) %>
     </div>
     """

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -12,7 +12,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       data-focusable-id={@cell_view.id}
       data-type={@cell_view.type}
       data-session-path={Routes.session_path(@socket, :page, @session_id)}
-      data-evaluation-digest={get_in(@cell_view, [:eval, :evaluation_digest])}>
+      data-evaluation-digest={get_in(@cell_view, [:eval, :evaluation_digest])}
+      data-eval-validity={get_in(@cell_view, [:eval, :validity])}>
       <%= render_cell(assigns) %>
     </div>
     """
@@ -80,7 +81,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
           language="elixir"
           intellisense />
         <div class="absolute bottom-2 right-2">
-          <.cell_status cell_view={@cell_view} />
+          <.cell_status id={@cell_view.id} cell_view={@cell_view} />
         </div>
       </div>
       <.evaluation_outputs
@@ -88,6 +89,51 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         socket={@socket}
         session_id={@session_id}
         runtime={@runtime} />
+    </.cell_body>
+    """
+  end
+
+  defp render_cell(%{cell_view: %{type: :setup}} = assigns) do
+    ~H"""
+    <.cell_actions>
+      <:primary>
+        <.setup_cell_evaluation_button
+          cell_id={@cell_view.id}
+          validity={@cell_view.eval.validity}
+          status={@cell_view.eval.status} />
+      </:primary>
+      <:secondary>
+        <.enable_insert_mode_button />
+        <.cell_link_button cell_id={@cell_view.id} />
+        <.setup_cell_info />
+      </:secondary>
+    </.cell_actions>
+    <.cell_body>
+      <div data-element="info-box">
+        <div class="p-3 flex items-center justify-between border border-gray-200 text-sm text-gray-400 font-medium rounded-lg">
+          <span>Notebook setup</span>
+          <.cell_status id={"#{@cell_view.id}-1"} cell_view={@cell_view} />
+        </div>
+      </div>
+      <div data-element="editor-box">
+        <div class="relative">
+          <.live_component module={LivebookWeb.SessionLive.CellEditorComponent}
+            id={"#{@cell_view.id}-primary"}
+            cell_id={@cell_view.id}
+            tag="primary"
+            source_view={@cell_view.source_view}
+            language="elixir"
+            intellisense />
+          <div class="absolute bottom-2 right-2">
+            <.cell_status id={"#{@cell_view.id}-2"} cell_view={@cell_view} />
+          </div>
+        </div>
+        <.evaluation_outputs
+          cell_view={@cell_view}
+          socket={@socket}
+          session_id={@session_id}
+          runtime={@runtime} />
+      </div>
     </.cell_body>
     """
   end
@@ -114,37 +160,41 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       </:secondary>
     </.cell_actions>
     <.cell_body>
-      <div class="relative">
-        <div data-element="ui-box">
-          <%= case @cell_view.status do %>
-            <% :started -> %>
-              <div class={"flex #{if(@cell_view.editor && @cell_view.editor.placement == :top, do: "flex-col-reverse", else: "flex-col")}"}>
-                <.live_component module={LivebookWeb.JSViewComponent}
-                  id={@cell_view.id}
-                  js_view={@cell_view.js_view}
-                  session_id={@session_id} />
-                <%= if @cell_view.editor do %>
-                  <.live_component module={LivebookWeb.SessionLive.CellEditorComponent}
-                    id={"#{@cell_view.id}-secondary"}
-                    cell_id={@cell_view.id}
-                    tag="secondary"
-                    source_view={@cell_view.editor.source_view}
-                    language={@cell_view.editor.language} />
-                <% end %>
-              </div>
+      <div data-element="ui-box">
+        <%= case @cell_view.status do %>
+          <% :started -> %>
+            <div class={"flex #{if(@cell_view.editor && @cell_view.editor.placement == :top, do: "flex-col-reverse", else: "flex-col")}"}>
+              <.live_component module={LivebookWeb.JSViewComponent}
+                id={@cell_view.id}
+                js_view={@cell_view.js_view}
+                session_id={@session_id} />
+              <%= if @cell_view.editor do %>
+                <.live_component module={LivebookWeb.SessionLive.CellEditorComponent}
+                  id={"#{@cell_view.id}-secondary"}
+                  cell_id={@cell_view.id}
+                  tag="secondary"
+                  source_view={@cell_view.editor.source_view}
+                  language={@cell_view.editor.language} />
+              <% end %>
+            </div>
 
-            <% :dead -> %>
-              <div class="info-box">
-                Evaluate and install dependencies to show the contents of this Smart cell.
-              </div>
+          <% :dead -> %>
+            <div class="info-box">
+              Evaluate and install dependencies to show the contents of this Smart cell.
+            </div>
 
-            <% :starting -> %>
-              <div class="delay-200">
-                <.content_skeleton empty={false} />
-              </div>
-          <% end %>
+          <% :starting -> %>
+            <div class="delay-200">
+              <.content_skeleton empty={false} />
+            </div>
+        <% end %>
+        <div class="flex flex-col items-end space-y-2">
+          <div></div>
+          <.cell_status id={"#{@cell_view.id}-1"} cell_view={@cell_view} />
         </div>
-        <div data-element="editor-box">
+      </div>
+      <div data-element="editor-box">
+        <div class="relative">
           <.live_component module={LivebookWeb.SessionLive.CellEditorComponent}
             id={"#{@cell_view.id}-primary"}
             cell_id={@cell_view.id}
@@ -153,9 +203,9 @@ defmodule LivebookWeb.SessionLive.CellComponent do
             language="elixir"
             intellisense
             read_only />
-        </div>
-        <div data-element="cell-status-container">
-          <.cell_status cell_view={@cell_view} />
+          <div class="absolute bottom-2 right-2">
+            <.cell_status id={"#{@cell_view.id}-2"} cell_view={@cell_view} />
+          </div>
         </div>
       </div>
       <.evaluation_outputs
@@ -168,7 +218,10 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   end
 
   defp cell_actions(assigns) do
-    assigns = assign_new(assigns, :primary, fn -> [] end)
+    assigns =
+      assigns
+      |> assign_new(:primary, fn -> [] end)
+      |> assign_new(:secondary, fn -> [] end)
 
     ~H"""
     <div class="mb-1 flex items-center justify-between">
@@ -226,6 +279,35 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   end
 
   defp cell_evaluation_button(assigns) do
+    ~H"""
+    <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
+      phx-click="cancel_cell_evaluation"
+      phx-value-cell_id={@cell_id}>
+      <.remix_icon icon="stop-circle-fill" class="text-xl" />
+      <span class="text-sm font-medium">
+        Stop
+      </span>
+    </button>
+    """
+  end
+
+  defp setup_cell_evaluation_button(%{status: :ready} = assigns) do
+    ~H"""
+    <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
+      phx-click="queue_cell_evaluation"
+      phx-value-cell_id={@cell_id}>
+      <%= if @validity == :fresh do %>
+        <.remix_icon icon="play-circle-fill" class="text-xl" />
+        <span class="text-sm font-medium">Setup</span>
+      <% else %>
+        <.remix_icon icon="restart-fill" class="text-xl" />
+        <span class="text-sm font-medium">Restart and setup</span>
+      <% end %>
+    </button>
+    """
+  end
+
+  defp setup_cell_evaluation_button(assigns) do
     ~H"""
     <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
       phx-click="cancel_cell_evaluation"
@@ -379,6 +461,23 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
+  defp setup_cell_info(assigns) do
+    ~H"""
+    <span class="tooltip top"
+      data-tooltip={
+        ~s'''
+        The setup cell includes code that initializes the notebook
+        and should run only once. This is the best place to install
+        dependencies and set global configuration.\
+        '''
+      }>
+      <span class="icon-button">
+        <.remix_icon icon="question-line" class="text-xl" />
+      </span>
+    </span>
+    """
+  end
+
   defp evaluation_outputs(assigns) do
     ~H"""
     <div class="flex flex-col"
@@ -404,7 +503,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     ~H"""
     <.status_indicator circle_class="bg-blue-500" animated_circle_class="bg-blue-400" change_indicator={true}>
       <span class="font-mono"
-        id={"cell-timer-#{@cell_view.id}"}
+        id={"#{@id}-cell-timer"}
         phx-hook="Timer"
         phx-update="ignore"
         data-start={DateTime.to_iso8601(@cell_view.eval.evaluation_start)}>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -112,7 +112,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     <.cell_body>
       <div data-element="info-box">
         <div class="p-3 flex items-center justify-between border border-gray-200 text-sm text-gray-400 font-medium rounded-lg">
-          <span>Notebook setup</span>
+          <span>Notebook dependencies and setup</span>
           <.cell_status id={"#{@cell_view.id}-1"} cell_view={@cell_view} />
         </div>
       </div>

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -311,7 +311,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
     assert expected_document == document
   end
 
-  test "formats code in Code cells" do
+  test "formats code in code cells" do
     notebook = %{
       Notebook.new()
       | name: "My Notebook",
@@ -347,7 +347,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
     assert expected_document == document
   end
 
-  test "does not format code in Code cells which have formatting disabled" do
+  test "does not format code in code cells which have formatting disabled" do
     notebook = %{
       Notebook.new()
       | name: "My Notebook",
@@ -998,6 +998,32 @@ defmodule Livebook.LiveMarkdown.ExportTest do
     document = Export.notebook_to_livemd(notebook)
 
     assert expected_document == document
+  end
+
+  describe "setup cell" do
+    test "includes the leading setup cell when it has content" do
+      notebook =
+        %{
+          Notebook.new()
+          | name: "My Notebook",
+            sections: [%{Notebook.Section.new() | name: "Section 1"}]
+        }
+        |> Notebook.put_setup_cell(%{Notebook.Cell.new(:code) | source: "Mix.install([...])"})
+
+      expected_document = """
+      # My Notebook
+
+      ```elixir
+      Mix.install([...])
+      ```
+
+      ## Section 1
+      """
+
+      document = Export.notebook_to_livemd(notebook)
+
+      assert expected_document == document
+    end
   end
 
   defp spawn_widget_with_data(ref, data) do

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -845,10 +845,9 @@ defmodule Livebook.LiveMarkdown.ImportTest do
            } = notebook
   end
 
-  test "import notebook with parent section being a branching section  itself produces a warning" do
+  test "importing notebook with parent section being a branching section itself produces a warning" do
     markdown = """
     # My Notebook
-
 
     ## Section 1
 
@@ -894,5 +893,58 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                }
              ]
            } = notebook
+  end
+
+  describe "setup cell" do
+    test "imports a leading setup cell" do
+      markdown = """
+      # My Notebook
+
+      ```elixir
+      Mix.install([...])
+      ```
+
+      ## Section 1
+      """
+
+      {notebook, []} = Import.notebook_from_livemd(markdown)
+
+      assert %Notebook{
+               name: "My Notebook",
+               setup_section: %{
+                 cells: [
+                   %Cell.Code{id: "setup", source: "Mix.install([...])"}
+                 ]
+               },
+               sections: [
+                 %Notebook.Section{
+                   name: "Section 1",
+                   cells: []
+                 }
+               ]
+             } = notebook
+    end
+
+    test "does not add an implicit section when there is just setup cell" do
+      markdown = """
+      # My Notebook
+
+      ```elixir
+      Mix.install([...])
+      ```
+      """
+
+      {notebook, []} = Import.notebook_from_livemd(markdown)
+
+      assert %Notebook{
+               name: "My Notebook",
+               setup_section: %{
+                 cells: [
+                   %Cell.Code{id: "setup", source: "Mix.install([...])"}
+                 ]
+               },
+               sections: []
+             } = notebook
+    end
   end
 end

--- a/test/livebook/notebook/export/elixir_test.exs
+++ b/test/livebook/notebook/export/elixir_test.exs
@@ -105,4 +105,28 @@ defmodule Livebook.Notebook.Export.ElixirTest do
 
     assert expected_document == document
   end
+
+  describe "setup cell" do
+    test "includes the leading setup cell when it has content" do
+      notebook =
+        %{
+          Notebook.new()
+          | name: "My Notebook",
+            sections: [%{Notebook.Section.new() | name: "Section 1"}]
+        }
+        |> Notebook.put_setup_cell(%{Notebook.Cell.new(:code) | source: "Mix.install([...])"})
+
+      expected_document = """
+      # Title: My Notebook
+
+      Mix.install([...])
+
+      # ── Section 1 ──
+      """
+
+      document = Export.Elixir.notebook_to_elixir(notebook)
+
+      assert expected_document == document
+    end
+  end
 end

--- a/test/livebook/notebook_test.exs
+++ b/test/livebook/notebook_test.exs
@@ -92,7 +92,8 @@ defmodule Livebook.NotebookTest do
                "c4" => "c3",
                "c3" => "c2",
                "c2" => "c1",
-               "c1" => nil
+               "c1" => "setup",
+               "setup" => nil
              }
     end
 
@@ -108,7 +109,8 @@ defmodule Livebook.NotebookTest do
 
       assert Notebook.cell_dependency_graph(notebook) == %{
                "c2" => "c1",
-               "c1" => nil
+               "c1" => "setup",
+               "setup" => nil
              }
     end
 
@@ -150,7 +152,8 @@ defmodule Livebook.NotebookTest do
                "c4" => "c3",
                "c3" => "c2",
                "c2" => "c1",
-               "c1" => nil
+               "c1" => "setup",
+               "setup" => nil
              }
     end
 
@@ -183,7 +186,8 @@ defmodule Livebook.NotebookTest do
 
       assert Notebook.cell_dependency_graph(notebook) == %{
                "c2" => "c1",
-               "c1" => nil
+               "c1" => "setup",
+               "setup" => nil
              }
     end
 
@@ -227,7 +231,8 @@ defmodule Livebook.NotebookTest do
                "c4" => "c2",
                "c3" => "c1",
                "c2" => "c1",
-               "c1" => nil
+               "c1" => "setup",
+               "setup" => nil
              }
     end
 
@@ -250,7 +255,8 @@ defmodule Livebook.NotebookTest do
       assert Notebook.cell_dependency_graph(notebook, cell_filter: &Cell.evaluable?/1) ==
                %{
                  "c3" => "c1",
-                 "c1" => nil
+                 "c1" => "setup",
+                 "setup" => nil
                }
     end
   end

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -660,35 +660,10 @@ defmodule Livebook.SessionTest do
     end
 
     test "given cell in main flow returns nil if there is no previous cell" do
-      cell1 = %{Cell.new(:markdown) | id: "c1"}
-      section1 = %{Section.new() | id: "s1", cells: [cell1]}
-
-      cell2 = %{Cell.new(:code) | id: "c2"}
-      section2 = %{Section.new() | id: "s2", cells: [cell2]}
-
-      notebook = %{Notebook.new() | sections: [section1, section2]}
+      %{setup_section: %{cells: [setup_cell]} = setup_section} = notebook = Notebook.new()
       data = Data.new(notebook)
 
-      assert {:main_flow, nil} = Session.find_base_locator(data, cell2, section2)
-    end
-
-    test "given cell in branching section returns nil in that section if there is no previous cell" do
-      cell1 = %{Cell.new(:markdown) | id: "c1"}
-      section1 = %{Section.new() | id: "s1", cells: [cell1]}
-
-      cell2 = %{Cell.new(:code) | id: "c2"}
-
-      section2 = %{
-        Section.new()
-        | id: "s2",
-          parent_id: "s1",
-          cells: [cell2]
-      }
-
-      notebook = %{Notebook.new() | sections: [section1, section2]}
-      data = Data.new(notebook)
-
-      assert {"s2", nil} = Session.find_base_locator(data, cell2, section2)
+      assert {:main_flow, nil} = Session.find_base_locator(data, setup_cell, setup_section)
     end
 
     test "when :existing is set ignores fresh and aborted cells" do
@@ -708,6 +683,7 @@ defmodule Livebook.SessionTest do
         data_after_operations!(data, [
           {:set_runtime, self(), Livebook.Runtime.NoopRuntime.new()},
           {:queue_cells_evaluation, self(), ["c1"]},
+          {:add_cell_evaluation_response, self(), "setup", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}}
         ])
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -27,7 +27,9 @@ defmodule Livebook.TestHelpers do
   Raises if any of the operations results in an error.
   """
   def data_after_operations!(data \\ Data.new(), operations) do
-    Enum.reduce(operations, data, fn operation, data ->
+    operations
+    |> List.flatten()
+    |> Enum.reduce(data, fn operation, data ->
       case Data.apply_operation(data, operation) do
         {:ok, data, _action} ->
           data


### PR DESCRIPTION
The first towards improved dependency management. This introduces a special cell for code that initializes the notebook (in practice it's just a code cell, but it has a slightly different UI).

https://user-images.githubusercontent.com/17034772/160451806-384b36d9-7fa2-4210-af98-0aaac268bbc0.mp4

The cell is automatically shown in all notebooks, but it's persisted only if it has an actual content. In a way, we just introduce a convention on where to install dependencies and set global configuration.

As shown above, reevaluating the cell automatically restarts the runtime (as indicated by the run button), which makes adding a new dependency more intuitive (as opposed to the error + restart runtime button we currently have).

The setup source is always shown when creating/opening a notebook (so that the user can always review the code), and it gets collapsed once run (since it is a form of boilerplate, conceptually run only once).