### PR TITLE
List predefined smart cells and automatically add their dependencies

### DIFF
--- a/assets/js/hooks/confirm_modal.js
+++ b/assets/js/hooks/confirm_modal.js
@@ -10,6 +10,8 @@ const ConfirmModal = {
     const descriptionEl = this.el.querySelector("[data-description]");
     const confirmIconEl = this.el.querySelector("[data-confirm-icon]");
     const confirmTextEl = this.el.querySelector("[data-confirm-text]");
+    const confirmButtonEl = this.el.querySelector("[data-confirm-button]");
+    const actionsEl = this.el.querySelector("[data-actions]");
     const optOutEl = this.el.querySelector("[data-opt-out]");
     const optOutElCheckbox = optOutEl.querySelector("input");
 
@@ -18,8 +20,14 @@ const ConfirmModal = {
     this.handleConfirmRequest = (event) => {
       confirmEvent = event;
 
-      const { title, description, confirm_text, confirm_icon, opt_out_id } =
-        event.detail;
+      const {
+        title,
+        description,
+        confirm_text,
+        confirm_icon,
+        danger,
+        opt_out_id,
+      } = event.detail;
 
       if (opt_out_id && optedOutIds.includes(opt_out_id)) {
         liveSocket.execJS(event.target, event.detail.on_confirm);
@@ -33,6 +41,11 @@ const ConfirmModal = {
         } else {
           confirmIconEl.className = "hidden";
         }
+
+        confirmButtonEl.classList.toggle("button-red", danger);
+        confirmButtonEl.classList.toggle("button-blue", !danger);
+        actionsEl.classList.toggle("flex-row-reverse", danger);
+        actionsEl.classList.toggle("space-x-reverse", danger);
 
         optOutElCheckbox.checked = false;
         optOutEl.classList.toggle("hidden", !opt_out_id);

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -64,7 +64,7 @@ defmodule Livebook.Notebook do
   """
   @spec put_setup_cell(t(), Cell.Code.t()) :: t()
   def put_setup_cell(notebook, %Cell.Code{} = cell) do
-    put_in(notebook.setup_section.cells, [%{cell | id: "setup"}])
+    put_in(notebook.setup_section.cells, [%{cell | id: Cell.setup_cell_id()}])
   end
 
   @doc """

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -68,12 +68,20 @@ defmodule Livebook.Notebook.Cell do
 
   def find_inputs_in_output(_output), do: []
 
+  @setup_cell_id "setup"
+
   @doc """
   Checks if the given cell is the setup code cell.
   """
   @spec setup?(t()) :: boolean()
   def setup?(cell)
 
-  def setup?(%Cell.Code{id: "setup"}), do: true
+  def setup?(%Cell.Code{id: @setup_cell_id}), do: true
   def setup?(_cell), do: false
+
+  @doc """
+  The fixed identifier of the setup cell.
+  """
+  @spec setup_cell_id() :: id()
+  def setup_cell_id(), do: @setup_cell_id
 end

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -189,13 +189,13 @@ defprotocol Livebook.Runtime do
     * `{:runtime_smart_cell_definitions, list(smart_cell_definition())}`
 
   Additionally, the runtime may report extra definitions that require
-  installing an external package, as described by `:requirement`.
-  Also see `add_dependency/3`.
+  installing external packages, as described by `:requirement`. Also
+  see `add_dependencies/3`.
   """
   @type smart_cell_definition :: %{
           kind: String.t(),
           name: String.t(),
-          requirement: nil | %{name: String.t(), dependency: dependency()}
+          requirement: nil | %{name: String.t(), dependencies: list(dependency())}
         }
 
   @type dependency :: term()
@@ -406,8 +406,9 @@ defprotocol Livebook.Runtime do
   def stop_smart_cell(runtime, ref)
 
   @doc """
-  Updates the given source code to install the given dependency.
+  Updates the given source code to install the given dependencies.
   """
-  @spec add_dependency(t(), String.t(), dependency()) :: {:ok, String.t()} | {:error, String.t()}
-  def add_dependency(runtime, code, dependency)
+  @spec add_dependencies(t(), String.t(), list(dependency())) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def add_dependencies(runtime, code, dependencies)
 end

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -187,11 +187,18 @@ defprotocol Livebook.Runtime do
   the updated list as
 
     * `{:runtime_smart_cell_definitions, list(smart_cell_definition())}`
+
+  Additionally, the runtime may report extra definitions that require
+  installing an external package, as described by `:requirement`.
+  Also see `add_dependency/3`.
   """
   @type smart_cell_definition :: %{
           kind: String.t(),
-          name: String.t()
+          name: String.t(),
+          requirement: nil | %{name: String.t(), dependency: dependency()}
         }
+
+  @type dependency :: term()
 
   @typedoc """
   A JavaScript view definition.
@@ -397,4 +404,10 @@ defprotocol Livebook.Runtime do
   """
   @spec stop_smart_cell(t(), smart_cell_ref()) :: :ok
   def stop_smart_cell(runtime, ref)
+
+  @doc """
+  Updates the given source code to install the given dependency.
+  """
+  @spec add_dependency(t(), String.t(), dependency()) :: {:ok, String.t()} | {:error, String.t()}
+  def add_dependency(runtime, code, dependency)
 end

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -100,7 +100,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
   end
 
-  def add_dependency(_runtime, code, dependency) do
-    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
+  def add_dependencies(_runtime, code, dependencies) do
+    Livebook.Runtime.Code.add_mix_deps(code, dependencies)
   end
 end

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -28,8 +28,11 @@ defmodule Livebook.Runtime.Attached do
 
     case Node.ping(node) do
       :pong ->
-        opts = [parent_node: node()]
-        server_pid = Livebook.Runtime.ErlDist.initialize(node, opts)
+        server_pid =
+          Livebook.Runtime.ErlDist.initialize(node,
+            node_manager_opts: [parent_node: node()]
+          )
+
         {:ok, %__MODULE__{node: node, cookie: cookie, server_pid: server_pid}}
 
       :pang ->
@@ -95,5 +98,9 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def stop_smart_cell(runtime, ref) do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
+  end
+
+  def add_dependency(_runtime, code, dependency) do
+    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
   end
 end

--- a/lib/livebook/runtime/code.ex
+++ b/lib/livebook/runtime/code.ex
@@ -1,0 +1,98 @@
+defmodule Livebook.Runtime.Code do
+  @moduledoc false
+
+  @doc """
+  Finds or adds a `Mix.install/2` call to `code` and modifies it to
+  include the given Mix dependency.
+  """
+  @spec add_mix_dependency(String.t(), tuple()) :: {:ok, String.t()} | {:error, String.t()}
+  def add_mix_dependency(code, dependency) do
+    with {:ok, ast, comments} <- string_to_quoted_with_comments(code),
+         {:ok, ast} <- insert_dependency(ast, dependency),
+         do: {:ok, format(ast, comments)}
+  end
+
+  defp string_to_quoted_with_comments(code) do
+    try do
+      to_quoted_opts = [
+        literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+        token_metadata: true,
+        unescape: false
+      ]
+
+      {ast, comments} = Code.string_to_quoted_with_comments!(code, to_quoted_opts)
+      {:ok, ast, comments}
+    rescue
+      error -> {:error, Exception.format(:error, error)}
+    end
+  end
+
+  defp insert_dependency(ast, dependency) do
+    dep_name = elem(dependency, 0)
+    dep_node = {:__block__, [], [Macro.escape(dependency)]}
+
+    with :error <- update_install(ast, dep_name, dep_node) do
+      install_node =
+        {{:., [], [{:__aliases__, [], [:Mix]}, :install]}, [],
+         [{:__block__, [newlines: 1], [[dep_node]]}]}
+
+      {:ok, prepend_node(ast, install_node)}
+    end
+  end
+
+  defp format(ast, comments) do
+    ast
+    |> Code.quoted_to_algebra(comments: comments)
+    |> Inspect.Algebra.format(90)
+    |> IO.iodata_to_binary()
+  end
+
+  defp prepend_node({:__block__, meta, nodes}, node) do
+    {:__block__, meta, [node | nodes]}
+  end
+
+  defp prepend_node(ast, node) do
+    {:__block__, [], [node, ast]}
+  end
+
+  defp update_install(
+         {{:., _, [{:__aliases__, _, [:Mix]}, :install]} = target, meta1,
+          [{:__block__, meta2, [deps]} | args]},
+         dep_name,
+         dep_node
+       ) do
+    if has_dep?(deps, dep_name) do
+      {:ok, {target, meta1, [{:__block__, meta2, [deps]} | args]}}
+    else
+      {:ok, {target, meta1, [{:__block__, meta2, [deps ++ [dep_node]]} | args]}}
+    end
+  end
+
+  defp update_install({:__block__, meta, nodes}, dep_name, dep_node) do
+    nodes
+    |> Enum.map_reduce(:error, fn
+      node, :error ->
+        case update_install(node, dep_name, dep_node) do
+          {:ok, node} -> {node, :ok}
+          error -> {node, error}
+        end
+
+      node, result ->
+        {node, result}
+    end)
+    |> case do
+      {nodes, :ok} -> {:ok, {:__block__, meta, nodes}}
+      {_, error} -> error
+    end
+  end
+
+  defp update_install(_node, _dep_name, _dep_node), do: :error
+
+  defp has_dep?(deps, name) do
+    Enum.any?(deps, fn
+      {:__block__, _, [{{:__block__, _, [^name]}, _}]} -> true
+      {:{}, _, [{:__block__, _, [^name]} | _]} -> true
+      _ -> false
+    end)
+  end
+end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -22,17 +22,17 @@ defmodule Livebook.Runtime.ElixirStandalone do
     %{
       kind: "Elixir.Kino.SmartCell.DBConnection",
       name: "Database connection",
-      requirement: %{name: "Kino", dependency: kino_dep}
+      requirement: %{name: "Kino", dependencies: [kino_dep]}
     },
     %{
       kind: "Elixir.Kino.SmartCell.SQL",
       name: "SQL query",
-      requirement: %{name: "Kino", dependency: kino_dep}
+      requirement: %{name: "Kino", dependencies: [kino_dep]}
     },
     %{
       kind: "Elixir.Kino.SmartCell.ChartBuilder",
       name: "Chart builder",
-      requirement: %{name: "Kino", dependency: kino_dep}
+      requirement: %{name: "Kino", dependencies: [kino_dep]}
     }
   ]
 
@@ -146,7 +146,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
   end
 
-  def add_dependency(_runtime, code, dependency) do
-    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
+  def add_dependencies(_runtime, code, dependencies) do
+    Livebook.Runtime.Code.add_mix_deps(code, dependencies)
   end
 end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -17,6 +17,7 @@ defmodule Livebook.Runtime.ElixirStandalone do
         }
 
   kino_dep = {:kino, github: "livebook-dev/kino"}
+  vega_lite_dep = {:vega_lite, "~> 0.1.3"}
 
   @extra_smart_cell_definitions [
     %{
@@ -32,7 +33,7 @@ defmodule Livebook.Runtime.ElixirStandalone do
     %{
       kind: "Elixir.Kino.SmartCell.ChartBuilder",
       name: "Chart builder",
-      requirement: %{name: "Kino", dependencies: [kino_dep]}
+      requirement: %{name: "Kino", dependencies: [kino_dep, vega_lite_dep]}
     }
   ]
 

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -16,6 +16,26 @@ defmodule Livebook.Runtime.ElixirStandalone do
           server_pid: pid()
         }
 
+  kino_dep = {:kino, github: "livebook-dev/kino"}
+
+  @extra_smart_cell_definitions [
+    %{
+      kind: "Elixir.Kino.SmartCell.DBConnection",
+      name: "Database connection",
+      requirement: %{name: "Kino", dependency: kino_dep}
+    },
+    %{
+      kind: "Elixir.Kino.SmartCell.SQL",
+      name: "SQL query",
+      requirement: %{name: "Kino", dependency: kino_dep}
+    },
+    %{
+      kind: "Elixir.Kino.SmartCell.ChartBuilder",
+      name: "Chart builder",
+      requirement: %{name: "Kino", dependency: kino_dep}
+    }
+  ]
+
   @doc """
   Starts a new Elixir node (i.e. a system process) and initializes
   it with Livebook-specific modules and processes.
@@ -36,9 +56,13 @@ defmodule Livebook.Runtime.ElixirStandalone do
     Utils.temporarily_register(self(), child_node, fn ->
       argv = [parent_node]
 
+      init_opts = [
+        runtime_server_opts: [extra_smart_cell_definitions: @extra_smart_cell_definitions]
+      ]
+
       with {:ok, elixir_path} <- find_elixir_executable(),
            port = start_elixir_node(elixir_path, child_node, child_node_eval_string(), argv),
-           {:ok, server_pid} <- parent_init_sequence(child_node, port) do
+           {:ok, server_pid} <- parent_init_sequence(child_node, port, init_opts: init_opts) do
         runtime = %__MODULE__{
           node: child_node,
           server_pid: server_pid
@@ -120,5 +144,9 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
 
   def stop_smart_cell(runtime, ref) do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
+  end
+
+  def add_dependency(_runtime, code, dependency) do
+    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
   end
 end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -99,7 +99,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
   end
 
-  def add_dependency(_runtime, code, dependency) do
-    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
+  def add_dependencies(_runtime, code, dependencies) do
+    Livebook.Runtime.Code.add_mix_deps(code, dependencies)
   end
 end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -34,7 +34,11 @@ defmodule Livebook.Runtime.Embedded do
     # as we already do it for the Livebook application globally
     # (see Livebook.Application.start/2).
 
-    server_pid = ErlDist.initialize(node(), unload_modules_on_termination: false)
+    server_pid =
+      ErlDist.initialize(node(),
+        node_manager_opts: [unload_modules_on_termination: false]
+      )
+
     {:ok, %__MODULE__{node: node(), server_pid: server_pid}}
   end
 end
@@ -93,5 +97,9 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
 
   def stop_smart_cell(runtime, ref) do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
+  end
+
+  def add_dependency(_runtime, code, dependency) do
+    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
   end
 end

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -46,18 +46,24 @@ defmodule Livebook.Runtime.ErlDist do
   If necessary, the required modules are loaded
   into the given node and the node manager process
   is started with `node_manager_opts`.
+
+  ## Options
+
+    * `:node_manager_opts` - see `Livebook.Runtime.ErlDist.NodeManager.start/1`
+
+    * `:runtime_server_opts` - see `Livebook.Runtime.ErlDist.RuntimeServer.start_link/1`
   """
   @spec initialize(node(), keyword()) :: pid()
-  def initialize(node, node_manager_opts \\ []) do
+  def initialize(node, opts \\ []) do
     unless modules_loaded?(node) do
       load_required_modules(node)
     end
 
     unless node_manager_started?(node) do
-      start_node_manager(node, node_manager_opts)
+      start_node_manager(node, opts[:node_manager_opts] || [])
     end
 
-    start_runtime_server(node)
+    start_runtime_server(node, opts[:runtime_server_opts] || [])
   end
 
   defp load_required_modules(node) do
@@ -87,8 +93,8 @@ defmodule Livebook.Runtime.ErlDist do
     :rpc.call(node, Livebook.Runtime.ErlDist.NodeManager, :start, [opts])
   end
 
-  defp start_runtime_server(node) do
-    Livebook.Runtime.ErlDist.NodeManager.start_runtime_server(node)
+  defp start_runtime_server(node, opts) do
+    Livebook.Runtime.ErlDist.NodeManager.start_runtime_server(node, opts)
   end
 
   defp modules_loaded?(node) do

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -56,7 +56,7 @@ defmodule Livebook.Runtime.MixStandalone do
              :ok <- run_mix_task("compile", project_path, output_emitter),
              eval = child_node_eval_string(),
              port = start_elixir_mix_node(elixir_path, child_node, eval, argv, project_path),
-             {:ok, server_pid} <- parent_init_sequence(child_node, port, output_emitter) do
+             {:ok, server_pid} <- parent_init_sequence(child_node, port, emitter: output_emitter) do
           runtime = %__MODULE__{
             node: child_node,
             server_pid: server_pid,
@@ -187,5 +187,9 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
 
   def stop_smart_cell(runtime, ref) do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
+  end
+
+  def add_dependency(_runtime, code, dependency) do
+    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
   end
 end

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -189,7 +189,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
     ErlDist.RuntimeServer.stop_smart_cell(runtime.server_pid, ref)
   end
 
-  def add_dependency(_runtime, code, dependency) do
-    Livebook.Runtime.Code.add_mix_dependency(code, dependency)
+  def add_dependencies(_runtime, code, dependencies) do
+    Livebook.Runtime.Code.add_mix_deps(code, dependencies)
   end
 end

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -311,6 +311,14 @@ defmodule Livebook.Session do
   end
 
   @doc """
+  Sends smart cell dependency addition request to the server.
+  """
+  @spec add_smart_cell_dependency(pid(), String.t()) :: :ok
+  def add_smart_cell_dependency(pid, kind) do
+    GenServer.cast(pid, {:add_smart_cell_dependency, self(), kind})
+  end
+
+  @doc """
   Sends cell evaluation request to the server.
   """
   @spec queue_cell_evaluation(pid(), Cell.id()) :: :ok
@@ -728,6 +736,16 @@ defmodule Livebook.Session do
     {:noreply, state}
   end
 
+  def handle_cast({:add_smart_cell_dependency, _client_pid, kind}, state) do
+    state =
+      case Enum.find(state.data.smart_cell_definitions, &(&1.kind == kind)) do
+        %{requirement: %{dependency: dependency}} -> add_dependency(state, dependency)
+        _ -> state
+      end
+
+    {:noreply, state}
+  end
+
   def handle_cast({:queue_cell_evaluation, client_pid, cell_id}, state) do
     operation = {:queue_cells_evaluation, client_pid, [cell_id]}
     {:noreply, handle_operation(state, operation)}
@@ -1086,6 +1104,35 @@ defmodule Livebook.Session do
   defp do_connect_runtime(runtime, state) do
     runtime_monitor_ref = Runtime.connect(runtime, runtime_broadcast_to: state.worker_pid)
     %{state | runtime_monitor_ref: runtime_monitor_ref}
+  end
+
+  defp add_dependency(%{data: %{runtime: nil}} = state, _dependency), do: state
+
+  defp add_dependency(state, dependency) do
+    {:ok, cell, _} = Notebook.fetch_cell_and_section(state.data.notebook, Cell.setup_cell_id())
+    source = cell.source
+
+    case Runtime.add_dependency(state.data.runtime, source, dependency) do
+      {:ok, ^source} ->
+        state
+
+      {:ok, new_source} ->
+        delta = Livebook.JSInterop.diff(cell.source, new_source)
+        revision = state.data.cell_infos[cell.id].sources.primary.revision + 1
+
+        handle_operation(
+          state,
+          {:apply_cell_delta, self(), cell.id, :primary, delta, revision}
+        )
+
+      {:error, message} ->
+        broadcast_error(
+          state.session_id,
+          "failed to add dependency to the setup cell, reason:\n\n#{message}"
+        )
+
+        state
+    end
   end
 
   # Given any operation on `Livebook.Session.Data`, the process

--- a/lib/livebook_web/live/live_helpers.ex
+++ b/lib/livebook_web/live/live_helpers.ex
@@ -99,16 +99,19 @@ defmodule LivebookWeb.LiveHelpers do
             Don't show this message again
           </span>
         </label>
-        <div class="mt-8 flex justify-end space-x-2">
-          <button class="button-base button-red"
-            phx-click={hide_modal(@id) |> JS.dispatch("lb:confirm", to: "##{@id}")}>
-            <i aria-hidden="true" data-confirm-icon></i>
-            <span data-confirm-text></span>
-          </button>
-          <button class="button-base button-outlined-gray"
-            phx-click={hide_modal(@id)}>
-            Cancel
-          </button>
+        <div class="mt-8 flex justify-end">
+          <div class="flex space-x-2" data-actions>
+            <button class="button-base button-outlined-gray"
+              phx-click={hide_modal(@id)}>
+              Cancel
+            </button>
+            <button class="button-base"
+              phx-click={hide_modal(@id) |> JS.dispatch("lb:confirm", to: "##{@id}")}
+              data-confirm-button>
+              <i aria-hidden="true" data-confirm-icon></i>
+              <span data-confirm-text></span>
+            </button>
+          </div>
         </div>
       </div>
     </.modal>
@@ -129,6 +132,8 @@ defmodule LivebookWeb.LiveHelpers do
     * `:confirm_text` - text of the confirm button. Defaults to `"Yes"`
 
     * `:confirm_icon` - icon in the confirm button. Optional
+
+    * `:danger` - whether the action is destructive or regular. Defaults to `true`
 
     * `:opt_out_id` - enables the "Don't show this message again"
       checkbox. Once checked by the user, the confirmation with this
@@ -154,7 +159,14 @@ defmodule LivebookWeb.LiveHelpers do
     opts =
       Keyword.validate!(
         opts,
-        [:confirm_icon, :description, :opt_out_id, title: "Are you sure?", confirm_text: "Yes"]
+        [
+          :confirm_icon,
+          :description,
+          :opt_out_id,
+          title: "Are you sure?",
+          confirm_text: "Yes",
+          danger: true
+        ]
       )
 
     JS.dispatch(js, "lb:confirm_request",
@@ -164,6 +176,7 @@ defmodule LivebookWeb.LiveHelpers do
         description: Keyword.fetch!(opts, :description),
         confirm_text: opts[:confirm_text],
         confirm_icon: opts[:confirm_icon],
+        danger: opts[:danger],
         opt_out_id: opts[:opt_out_id]
       }
     )

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -721,8 +721,8 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
-  def handle_event("add_smart_cell_dependency", %{"kind" => kind}, socket) do
-    Session.add_smart_cell_dependency(socket.assigns.session.pid, kind)
+  def handle_event("add_smart_cell_dependencies", %{"kind" => kind}, socket) do
+    Session.add_smart_cell_dependencies(socket.assigns.session.pid, kind)
     socket = maybe_restart_runtime(socket)
     Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -723,8 +723,12 @@ defmodule LivebookWeb.SessionLive do
 
   def handle_event("add_smart_cell_dependencies", %{"kind" => kind}, socket) do
     Session.add_smart_cell_dependencies(socket.assigns.session.pid, kind)
-    socket = maybe_restart_runtime(socket)
-    Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
+
+    {status, socket} = maybe_restart_runtime(socket)
+
+    if status == :ok do
+      Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
+    end
 
     {:noreply, socket}
   end
@@ -732,16 +736,18 @@ defmodule LivebookWeb.SessionLive do
   def handle_event("queue_cell_evaluation", %{"cell_id" => cell_id}, socket) do
     data = socket.private.data
 
-    socket =
+    {status, socket} =
       with {:ok, cell, _section} <- Notebook.fetch_cell_and_section(data.notebook, cell_id),
            true <- Cell.setup?(cell),
            false <- data.cell_infos[cell.id].eval.validity == :fresh do
         maybe_restart_runtime(socket)
       else
-        _ -> socket
+        _ -> {:ok, socket}
       end
 
-    Session.queue_cell_evaluation(socket.assigns.session.pid, cell_id)
+    if status == :ok do
+      Session.queue_cell_evaluation(socket.assigns.session.pid, cell_id)
+    end
 
     {:noreply, socket}
   end
@@ -787,16 +793,22 @@ defmodule LivebookWeb.SessionLive do
   end
 
   def handle_event("restart_runtime", %{}, socket) do
-    {:noreply, maybe_restart_runtime(socket)}
+    {_, socket} = maybe_restart_runtime(socket)
+    {:noreply, socket}
   end
 
   def handle_event("start_default_runtime", %{}, socket) do
-    {:noreply, start_default_runtime(socket)}
+    {_, socket} = start_default_runtime(socket)
+    {:noreply, socket}
   end
 
   def handle_event("setup_default_runtime", %{}, socket) do
-    socket = start_default_runtime(socket)
-    Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
+    {status, socket} = start_default_runtime(socket)
+
+    if status == :ok do
+      Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
+    end
+
     {:noreply, socket}
   end
 
@@ -1324,23 +1336,23 @@ defmodule LivebookWeb.SessionLive do
     case apply(runtime_module, :init, args) do
       {:ok, runtime} ->
         Session.connect_runtime(socket.assigns.session.pid, runtime)
-        socket
+        {:ok, socket}
 
       {:error, message} ->
-        put_flash(socket, :error, "Failed to start runtime - #{message}")
+        {:error, put_flash(socket, :error, "Failed to start runtime - #{message}")}
     end
   end
 
-  defp maybe_restart_runtime(%{private: %{data: %{runtime: nil}}} = socket), do: socket
+  defp maybe_restart_runtime(%{private: %{data: %{runtime: nil}}} = socket), do: {:ok, socket}
 
   defp maybe_restart_runtime(%{private: %{data: data}} = socket) do
     case Runtime.duplicate(data.runtime) do
       {:ok, new_runtime} ->
         Session.connect_runtime(socket.assigns.session.pid, new_runtime)
-        clear_flash(socket, :error)
+        {:ok, clear_flash(socket, :error)}
 
       {:error, message} ->
-        put_flash(socket, :error, "Failed to start runtime - #{message}")
+        {:error, put_flash(socket, :error, "Failed to start runtime - #{message}")}
     end
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -721,6 +721,14 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
+  def handle_event("add_smart_cell_dependency", %{"kind" => kind}, socket) do
+    Session.add_smart_cell_dependency(socket.assigns.session.pid, kind)
+    socket = maybe_restart_runtime(socket)
+    Session.queue_cell_evaluation(socket.assigns.session.pid, Cell.setup_cell_id())
+
+    {:noreply, socket}
+  end
+
   def handle_event("queue_cell_evaluation", %{"cell_id" => cell_id}, socket) do
     data = socket.private.data
 

--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -40,9 +40,19 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
         </.menu>
         <%= cond do %>
           <% @runtime == nil -> %>
-            <span class="tooltip right" data-tooltip={"Please start a runtime (or run any cell)\nto see the available smart cells"}>
-              <button class="button-base button-small" disabled>+ Smart</button>
-            </span>
+            <button class="button-base button-small"
+              phx-click={
+                with_confirm(
+                  JS.push("setup_default_runtime"),
+                  title: "Setup runtime",
+                  description: ~s'''
+                  To see the available smart cells, you need to start a runtime.
+                  Do you want to start and setup the default one?
+                  ''',
+                  confirm_text: "Setup runtime",
+                  confirm_icon: "play-line"
+                )
+              }>+ Smart</button>
 
           <% @smart_cell_definitions == [] -> %>
             <span class="tooltip right" data-tooltip="No smart cells available">

--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -50,7 +50,8 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
                   Do you want to start and setup the default one?
                   ''',
                   confirm_text: "Setup runtime",
-                  confirm_icon: "play-line"
+                  confirm_icon: "play-line",
+                  danger: false
                 )
               }>+ Smart</button>
 
@@ -94,7 +95,8 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
       Do you want to add it as a dependency and restart the runtime?
       ''',
       confirm_text: "Add and restart",
-      confirm_icon: "add-line"
+      confirm_icon: "add-line",
+      danger: false
     )
   end
 

--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -38,28 +38,64 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
             </button>
           </:content>
         </.menu>
-        <%= if @smart_cell_definitions != [] do %>
-          <.menu id={"#{@id}-smart-menu"} position="left">
-            <:toggle>
-              <button class="button-base button-small">+ Smart</button>
-            </:toggle>
-            <:content>
-              <%= for smart_cell_definition <- Enum.sort_by(@smart_cell_definitions, & &1.name) do %>
-                <button class="menu-item text-gray-500"
-                  role="menuitem"
-                  phx-click="insert_cell_below"
-                  phx-value-type="smart"
-                  phx-value-kind={smart_cell_definition.kind}
-                  phx-value-section_id={@section_id}
-                  phx-value-cell_id={@cell_id}>
-                  <span class="font-medium"><%= smart_cell_definition.name %></span>
-                </button>
-              <% end %>
-            </:content>
-          </.menu>
+        <%= cond do %>
+          <% @runtime == nil -> %>
+            <span class="tooltip right" data-tooltip={"Please start a runtime (or run any cell)\nto see the available smart cells"}>
+              <button class="button-base button-small" disabled>+ Smart</button>
+            </span>
+
+          <% @smart_cell_definitions == [] -> %>
+            <span class="tooltip right" data-tooltip="No smart cells available">
+              <button class="button-base button-small" disabled>+ Smart</button>
+            </span>
+
+          <% true -> %>
+            <.menu id={"#{@id}-smart-menu"} position="left">
+              <:toggle>
+                <button class="button-base button-small">+ Smart</button>
+              </:toggle>
+              <:content>
+                <%= for definition <- Enum.sort_by(@smart_cell_definitions, & &1.name) do %>
+                  <button class="menu-item text-gray-500"
+                    role="menuitem"
+                    phx-click={on_smart_cell_click(definition, @section_id, @cell_id)}>
+                    <span class="font-medium"><%= definition.name %></span>
+                  </button>
+                <% end %>
+              </:content>
+            </.menu>
         <% end %>
       </div>
     </div>
     """
+  end
+
+  defp on_smart_cell_click(%{requirement: nil} = definition, section_id, cell_id) do
+    insert_smart_cell(definition, section_id, cell_id)
+  end
+
+  defp on_smart_cell_click(%{requirement: %{}} = definition, section_id, cell_id) do
+    with_confirm(
+      JS.push("add_smart_cell_dependency", value: %{kind: definition.kind})
+      |> insert_smart_cell(definition, section_id, cell_id),
+      title: "Add package",
+      description: ~s'''
+      The “#{definition.name}“ smart cell requires #{definition.requirement.name}.
+      Do you want to add it as a dependency and restart the runtime?
+      ''',
+      confirm_text: "Add and restart",
+      confirm_icon: "add-line"
+    )
+  end
+
+  defp insert_smart_cell(js \\ %JS{}, definition, section_id, cell_id) do
+    JS.push(js, "insert_cell_below",
+      value: %{
+        type: "smart",
+        kind: definition.kind,
+        section_id: section_id,
+        cell_id: cell_id
+      }
+    )
   end
 end

--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -76,7 +76,7 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
 
   defp on_smart_cell_click(%{requirement: %{}} = definition, section_id, cell_id) do
     with_confirm(
-      JS.push("add_smart_cell_dependency", value: %{kind: definition.kind})
+      JS.push("add_smart_cell_dependencies", value: %{kind: definition.kind})
       |> insert_smart_cell(definition, section_id, cell_id),
       title: "Add package",
       description: ~s'''

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -102,6 +102,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
               id={"insert-buttons-#{@section_view.id}-first"}
               persistent={@section_view.cell_views == []}
               smart_cell_definitions={@smart_cell_definitions}
+              runtime={@runtime}
               section_id={@section_view.id}
               cell_id={nil} />
           <%= for {cell_view, index} <- Enum.with_index(@section_view.cell_views) do %>
@@ -114,6 +115,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
                 id={"insert-buttons-#{@section_view.id}-#{index}"}
                 persistent={false}
                 smart_cell_definitions={@smart_cell_definitions}
+                runtime={@runtime}
                 section_id={@section_view.id}
                 cell_id={cell_view.id} />
           <% end %>

--- a/test/livebook/runtime/code_test.exs
+++ b/test/livebook/runtime/code_test.exs
@@ -1,0 +1,137 @@
+defmodule Livebook.Runtime.CodeTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Runtime
+
+  @dep {:kino, "~> 0.5.0"}
+
+  describe "add_mix_dependency/2" do
+    test "prepends Mix.install/2 call if there is none" do
+      assert Runtime.Code.add_mix_dependency("", @dep) ==
+               {:ok,
+                """
+                Mix.install([
+                  {:kino, "~> 0.5.0"}
+                ])\
+                """}
+
+      assert Runtime.Code.add_mix_dependency("# Comment", @dep) ==
+               {:ok,
+                """
+                Mix.install([
+                  {:kino, "~> 0.5.0"}
+                ])
+
+                # Comment\
+                """}
+
+      assert Runtime.Code.add_mix_dependency(
+               """
+               # Outer comment
+               for key <- [:key1, :key2] do
+                 # Inner comment
+                 Application.put_env(:app, key, :value)
+               end
+
+               # Final comment\
+               """,
+               @dep
+             ) ==
+               {:ok,
+                """
+                Mix.install([
+                  {:kino, "~> 0.5.0"}
+                ])
+
+                # Outer comment
+                for key <- [:key1, :key2] do
+                  # Inner comment
+                  Application.put_env(:app, key, :value)
+                end
+
+                # Final comment\
+                """}
+    end
+
+    test "appends dependency to an existing Mix.install/2 call" do
+      assert Runtime.Code.add_mix_dependency(
+               """
+               Mix.install([
+                 {:req, "~> 0.2.0"}
+               ])\
+               """,
+               @dep
+             ) ==
+               {:ok,
+                """
+                Mix.install([
+                  {:req, "~> 0.2.0"},
+                  {:kino, "~> 0.5.0"}
+                ])\
+                """}
+
+      assert Runtime.Code.add_mix_dependency(
+               """
+               # Outer comment
+               Mix.install([
+                 # Inner comment leading
+                 {:req, "~> 0.2.0"}
+                 # Inner comment trailing
+               ])
+
+               # Result
+               :ok\
+               """,
+               @dep
+             ) ==
+               {:ok,
+                """
+                # Outer comment
+                Mix.install([
+                  # Inner comment leading
+                  {:req, "~> 0.2.0"},
+                  {:kino, "~> 0.5.0"}
+                  # Inner comment trailing
+                ])
+
+                # Result
+                :ok\
+                """}
+    end
+
+    test "does not add the dependency if it already exists" do
+      code = """
+      Mix.install([
+        {:kino, "~> 0.5.2"}
+      ])\
+      """
+
+      assert Runtime.Code.add_mix_dependency(code, @dep) == {:ok, code}
+
+      code = """
+      Mix.install([
+        {:kino, "~> 0.5.2", runtime: false}
+      ])\
+      """
+
+      assert Runtime.Code.add_mix_dependency(code, @dep) == {:ok, code}
+    end
+
+    test "returns an error if the code has a syntax error" do
+      assert Runtime.Code.add_mix_dependency(
+               """
+               # Comment
+               [,1]
+               """,
+               @dep
+             ) ==
+               {:error,
+                """
+                ** (SyntaxError) nofile:2:2: syntax error before: ','
+                    |
+                  2 | [,1]
+                    |  ^\
+                """}
+    end
+  end
+end

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -12,6 +12,7 @@ defmodule Livebook.Session.DataTest do
 
   @eval_resp {:ok, [1, 2, 3]}
   @eval_meta %{evaluation_time_ms: 10}
+  @smart_cell_definitions [%{kind: "text", name: "Text", requirement: nil}]
 
   describe "new/1" do
     test "called with no arguments defaults to a blank notebook" do
@@ -440,7 +441,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]}
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions}
         ])
 
       operation = {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}}
@@ -457,7 +458,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :code, "c1", %{}},
           {:insert_cell, self(), "s1", 1, :smart, "c2", %{kind: "text"}},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:smart_cell_started, self(), "c2", Delta.new(), %{}, nil}
         ])
 
@@ -796,7 +797,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}},
           {:smart_cell_started, self(), "c1", Delta.new(), %{}, nil}
         ])
@@ -815,7 +816,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :smart, "c2", %{kind: "text"}},
           {:set_runtime, self(), NoopRuntime.new()},
           evaluate_cells_operations(["setup"]),
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:smart_cell_started, self(), "c2", Delta.new(), %{}, nil},
           {:queue_cells_evaluation, self(), ["c1"]},
           {:add_cell_evaluation_response, self(), "c1", @eval_resp, @eval_meta}
@@ -907,7 +908,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}},
           {:delete_cell, self(), "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]}
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions}
         ])
 
       operation = {:restore_cell, self(), "c1"}
@@ -2324,7 +2325,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :smart, "c2", %{kind: "text"}},
           {:set_runtime, self(), NoopRuntime.new()},
           evaluate_cells_operations(["setup"]),
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:smart_cell_started, self(), "c2", Delta.new(), %{}, nil},
           {:queue_cells_evaluation, self(), ["c1"]}
         ])
@@ -2646,7 +2647,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}}
         ])
 
@@ -2665,7 +2666,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}}
         ])
 
@@ -2692,7 +2693,7 @@ defmodule Livebook.Session.DataTest do
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}},
           {:smart_cell_started, self(), "c1", delta1, %{}, nil}
         ])
@@ -2719,7 +2720,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:set_runtime, self(), NoopRuntime.new()},
           evaluate_cells_operations(["setup"]),
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:insert_cell, self(), "s1", 0, :smart, "c1", %{kind: "text"}},
           {:smart_cell_started, self(), "c1", Delta.new(), %{}, nil},
           {:queue_cells_evaluation, self(), ["c1"]},
@@ -2992,18 +2993,6 @@ defmodule Livebook.Session.DataTest do
       assert :error = Data.apply_operation(data, operation)
     end
 
-    test "returns an error given non-joined client pid" do
-      data =
-        data_after_operations!([
-          {:insert_section, self(), 0, "s1"},
-          {:insert_cell, self(), "s1", 0, :code, "c1", %{}}
-        ])
-
-      delta = Delta.new() |> Delta.insert("cats")
-      operation = {:apply_cell_delta, self(), "c1", :primary, delta, 1}
-      assert :error = Data.apply_operation(data, operation)
-    end
-
     test "returns an error given invalid revision" do
       data =
         data_after_operations!([
@@ -3018,10 +3007,27 @@ defmodule Livebook.Session.DataTest do
       assert :error = Data.apply_operation(data, operation)
     end
 
+    test "returns an error given non-joined client pid and older revision" do
+      client1_pid = IEx.Helpers.pid(0, 0, 0)
+
+      delta1 = Delta.new() |> Delta.insert("cats")
+
+      data =
+        data_after_operations!([
+          {:client_join, client1_pid, User.new()},
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :code, "c1", %{}},
+          {:apply_cell_delta, client1_pid, "c1", :primary, delta1, 1}
+        ])
+
+      delta = Delta.new() |> Delta.insert("cats")
+      operation = {:apply_cell_delta, self(), "c1", :primary, delta, 1}
+      assert :error = Data.apply_operation(data, operation)
+    end
+
     test "updates cell source according to the given delta" do
       data =
         data_after_operations!([
-          {:client_join, self(), User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :code, "c1", %{}}
         ])
@@ -3141,7 +3147,7 @@ defmodule Livebook.Session.DataTest do
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 1, :smart, "c1", %{kind: "text"}},
           {:set_runtime, self(), NoopRuntime.new()},
-          {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]},
+          {:set_smart_cell_definitions, self(), @smart_cell_definitions},
           {:smart_cell_started, self(), "c1", Delta.new(), %{},
            %{language: "text", placement: :bottom, source: ""}}
         ])
@@ -3436,7 +3442,7 @@ defmodule Livebook.Session.DataTest do
           {:set_runtime, self(), NoopRuntime.new()}
         ])
 
-      operation = {:set_smart_cell_definitions, self(), [%{kind: "text", name: "Text"}]}
+      operation = {:set_smart_cell_definitions, self(), @smart_cell_definitions}
 
       assert {:ok, %{cell_infos: %{"c1" => %{status: :starting}}}, _actions} =
                Data.apply_operation(data, operation)

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -134,6 +134,75 @@ defmodule Livebook.SessionTest do
     end
   end
 
+  describe "add_smart_cell_dependency/2" do
+    test "applies source change to the setup cell to include the smart cell dependency",
+         %{session: session} do
+      {:ok, runtime} = Livebook.Runtime.Embedded.init()
+      Session.connect_runtime(session.pid, runtime)
+
+      send(
+        session.pid,
+        {:runtime_smart_cell_definitions,
+         [
+           %{
+             kind: "text",
+             name: "Text",
+             requirement: %{name: "Kino", dependency: {:kino, "~> 0.5.0"}}
+           }
+         ]}
+      )
+
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session.id}")
+
+      Session.add_smart_cell_dependency(session.pid, "text")
+
+      session_pid = session.pid
+      assert_receive {:operation, {:apply_cell_delta, ^session_pid, "setup", :primary, _delta, 1}}
+
+      assert %{
+               notebook: %{
+                 setup_section: %{
+                   cells: [
+                     %{
+                       source: """
+                       Mix.install([
+                         {:kino, "~> 0.5.0"}
+                       ])\
+                       """
+                     }
+                   ]
+                 }
+               }
+             } = Session.get_data(session.pid)
+    end
+
+    test "broadcasts an error if modifying the setup source fails" do
+      notebook = Notebook.new() |> Notebook.update_cell("setup", &%{&1 | source: "[,]"})
+      session = start_session(notebook: notebook)
+
+      {:ok, runtime} = Livebook.Runtime.Embedded.init()
+      Session.connect_runtime(session.pid, runtime)
+
+      send(
+        session.pid,
+        {:runtime_smart_cell_definitions,
+         [
+           %{
+             kind: "text",
+             name: "Text",
+             requirement: %{name: "Kino", dependency: {:kino, "~> 0.5.0"}}
+           }
+         ]}
+      )
+
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session.id}")
+
+      Session.add_smart_cell_dependency(session.pid, "text")
+
+      assert_receive {:error, "failed to add dependency to the setup cell, reason:" <> _}
+    end
+  end
+
   describe "queue_cell_evaluation/2" do
     test "triggers evaluation and sends update operation once it finishes",
          %{session: session} do
@@ -577,7 +646,10 @@ defmodule Livebook.SessionTest do
       runtime = Livebook.Runtime.NoopRuntime.new()
       Session.connect_runtime(session.pid, runtime)
 
-      send(session.pid, {:runtime_smart_cell_definitions, [%{kind: "text", name: "Text"}]})
+      send(
+        session.pid,
+        {:runtime_smart_cell_definitions, [%{kind: "text", name: "Text", requirement: nil}]}
+      )
 
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session.id}")
 
@@ -601,7 +673,10 @@ defmodule Livebook.SessionTest do
       runtime = Livebook.Runtime.NoopRuntime.new()
       Session.connect_runtime(session.pid, runtime)
 
-      send(session.pid, {:runtime_smart_cell_definitions, [%{kind: "text", name: "Text"}]})
+      send(
+        session.pid,
+        {:runtime_smart_cell_definitions, [%{kind: "text", name: "Text", requirement: nil}]}
+      )
 
       server_pid = self()
 

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -134,7 +134,7 @@ defmodule Livebook.SessionTest do
     end
   end
 
-  describe "add_smart_cell_dependency/2" do
+  describe "add_smart_cell_dependencies/2" do
     test "applies source change to the setup cell to include the smart cell dependency",
          %{session: session} do
       {:ok, runtime} = Livebook.Runtime.Embedded.init()
@@ -147,14 +147,14 @@ defmodule Livebook.SessionTest do
            %{
              kind: "text",
              name: "Text",
-             requirement: %{name: "Kino", dependency: {:kino, "~> 0.5.0"}}
+             requirement: %{name: "Kino", dependencies: [{:kino, "~> 0.5.0"}]}
            }
          ]}
       )
 
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session.id}")
 
-      Session.add_smart_cell_dependency(session.pid, "text")
+      Session.add_smart_cell_dependencies(session.pid, "text")
 
       session_pid = session.pid
       assert_receive {:operation, {:apply_cell_delta, ^session_pid, "setup", :primary, _delta, 1}}
@@ -190,16 +190,16 @@ defmodule Livebook.SessionTest do
            %{
              kind: "text",
              name: "Text",
-             requirement: %{name: "Kino", dependency: {:kino, "~> 0.5.0"}}
+             requirement: %{name: "Kino", dependencies: [{:kino, "~> 0.5.0"}]}
            }
          ]}
       )
 
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session.id}")
 
-      Session.add_smart_cell_dependency(session.pid, "text")
+      Session.add_smart_cell_dependencies(session.pid, "text")
 
-      assert_receive {:error, "failed to add dependency to the setup cell, reason:" <> _}
+      assert_receive {:error, "failed to add dependencies to the setup cell, reason:" <> _}
     end
   end
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -399,7 +399,8 @@ defmodule LivebookWeb.SessionLiveTest do
 
       send(
         session.pid,
-        {:runtime_smart_cell_definitions, [%{kind: "dbconn", name: "Database connection"}]}
+        {:runtime_smart_cell_definitions,
+         [%{kind: "dbconn", name: "Database connection", requirement: nil}]}
       )
 
       wait_for_session_update(session.pid)

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -28,6 +28,6 @@ defmodule Livebook.Runtime.NoopRuntime do
     def start_smart_cell(_, _, _, _, _), do: :ok
     def set_smart_cell_base_locator(_, _, _), do: :ok
     def stop_smart_cell(_, _), do: :ok
-    def add_dependency(_, code, _), do: {:ok, code}
+    def add_dependencies(_, code, _), do: {:ok, code}
   end
 end

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -28,5 +28,6 @@ defmodule Livebook.Runtime.NoopRuntime do
     def start_smart_cell(_, _, _, _, _), do: :ok
     def set_smart_cell_base_locator(_, _, _), do: :ok
     def stop_smart_cell(_, _), do: :ok
+    def add_dependency(_, code, _), do: {:ok, code}
   end
 end


### PR DESCRIPTION
The Elixir Standalone runtime will now list a number of predefined smart cells upfront. When the user sleects a smart cell that is not available (that is, the corresponding kino* package is not installed), we automatically insert the necessary dependencies and reevaluate the setup cell.

https://user-images.githubusercontent.com/17034772/160917969-27740443-e1d0-41a3-b0df-4730bf5c0a5a.mp4