### PR TITLE
Allow image upload when no name provided

### DIFF
--- a/lib/livebook_web/live/session_live/cell_upload_component.ex
+++ b/lib/livebook_web/live/session_live/cell_upload_component.ex
@@ -56,7 +56,7 @@ defmodule LivebookWeb.SessionLive.CellUploadComponent do
           <%= live_patch "Cancel", to: @return_to, class: "button-base button-outlined-gray" %>
           <button class="button-base button-blue"
             type="submit"
-            disabled={@uploads.cell_image.entries == [] or @name == ""}>
+            disabled={@uploads.cell_image.entries == []}>
             Upload
           </button>
         </div>
@@ -79,7 +79,7 @@ defmodule LivebookWeb.SessionLive.CellUploadComponent do
       path = Path.expand(path)
       upload_file = FileSystem.File.local(path)
       ext = Path.extname(entry.client_name)
-      filename = name <> ext
+      filename = if name == "", do: entry.client_name, else: name <> ext
       destination_file = FileSystem.File.resolve(images_dir, filename)
 
       result =


### PR DESCRIPTION
This is my first Livebook PR, please let me know if I can make any changes!
 
resolves #1080 

Image uploads no longer require the name field and instead use the entry file name as the default value.

![image](https://user-images.githubusercontent.com/14877564/161353232-c6334395-0f52-440e-934a-1ab03561d0b3.png)

![image](https://user-images.githubusercontent.com/14877564/161353276-b851802c-741f-4761-af5f-6a43d11a20e1.png)