### PR TITLE
Remove restart button on Mix.install/2 error

### DIFF
--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -374,16 +374,6 @@ defprotocol Livebook.Runtime do
   def handle_intellisense(runtime, send_to, request, base_locator)
 
   @doc """
-  Returns true if the given runtime is self-contained.
-
-  A standalone runtime always starts fresh and frees all resources
-  on termination. This may not be the case for for runtimes that
-  connect to an external running system and use it for code evaluation.
-  """
-  @spec standalone?(Runtime.t()) :: boolean()
-  def standalone?(runtime)
-
-  @doc """
   Reads file at the given absolute path within the runtime file system.
   """
   @spec read_file(Runtime.t(), String.t()) :: {:ok, binary()} | {:error, String.t()}

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -57,7 +57,7 @@ defprotocol Livebook.Runtime do
           # A control element
           | {:control, attrs :: map()}
           # Internal output format for errors
-          | {:error, message :: binary(), type :: :other | :runtime_restart_required}
+          | {:error, message :: binary()}
 
   @typedoc """
   Additional information about a complted evaluation.

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -98,8 +98,6 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
     RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
   end
 
-  def standalone?(_runtime), do: false
-
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -145,8 +145,6 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
     RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
   end
 
-  def standalone?(_runtime), do: true
-
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -92,8 +92,6 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
   end
 
-  def standalone?(_runtime), do: false
-
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end

--- a/lib/livebook/runtime/evaluator/default_formatter.ex
+++ b/lib/livebook/runtime/evaluator/default_formatter.ex
@@ -27,7 +27,7 @@ defmodule Livebook.Runtime.Evaluator.DefaultFormatter do
 
   def format_result({:error, kind, error, stacktrace}) do
     formatted = format_error(kind, error, stacktrace)
-    {:error, formatted, error_type(error)}
+    {:error, formatted}
   end
 
   @compile {:no_warn_undefined, {Kino.Render, :to_livebook, 1}}
@@ -57,7 +57,7 @@ defmodule Livebook.Runtime.Evaluator.DefaultFormatter do
     catch
       kind, error ->
         formatted = format_error(kind, error, __STACKTRACE__)
-        {:error, formatted, :other}
+        {:error, formatted}
     end
   end
 
@@ -84,19 +84,6 @@ defmodule Livebook.Runtime.Evaluator.DefaultFormatter do
       # tuple: :light_black,
       reset: :reset
     ]
-  end
-
-  defp error_type(error) do
-    cond do
-      mix_install_vm_error?(error) -> :runtime_restart_required
-      true -> :other
-    end
-  end
-
-  defp mix_install_vm_error?(exception) do
-    is_struct(exception, Mix.Error) and
-      Exception.message(exception) =~
-        "Mix.install/2 can only be called with the same dependencies"
   end
 
   defp format_error(kind, error, stacktrace) do

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -185,8 +185,6 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
     RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
   end
 
-  def standalone?(_runtime), do: true
-
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -19,8 +19,6 @@ defmodule LivebookWeb.Output do
               id: "output-#{idx}",
               socket: @socket,
               session_id: @session_id,
-              runtime: @runtime,
-              cell_validity: @cell_validity,
               input_values: @input_values
             }) %>
       </div>
@@ -91,35 +89,12 @@ defmodule LivebookWeb.Output do
     live_component(Output.ControlComponent, id: id, attrs: attrs, input_values: input_values)
   end
 
-  defp render_output({:error, formatted, :runtime_restart_required}, %{
-         runtime: runtime,
-         cell_validity: cell_validity
-       })
-       when runtime != nil and cell_validity == :evaluated do
-    assigns = %{formatted: formatted, is_standalone: Livebook.Runtime.standalone?(runtime)}
+  defp render_output({:error, formatted}, %{}) do
+    assigns = %{message: formatted}
 
     ~H"""
-    <div class="flex flex-col space-y-4" role="complementary" aria-label="runtime reconnect required">
-      <%= render_error(@formatted) %>
-      <%= if @is_standalone do %>
-        <div>
-          <button class="button-base button-gray" phx-click="reconnect_runtime">
-            Reconnect runtime
-          </button>
-        </div>
-      <% else %>
-        <div class="text-red-600">
-          <span class="font-semibold">Note:</span>
-          This operation requires restarting the runtime, but we cannot
-          do it automatically for the current runtime
-        </div>
-      <% end %>
-    </div>
+    <div class="whitespace-pre-wrap font-editor text-gray-500" role="complementary" aria-label="error"><%= ansi_string_to_html(@message) %></div>
     """
-  end
-
-  defp render_output({:error, formatted, _type}, %{}) do
-    render_error(formatted)
   end
 
   # TODO: remove on Livebook v0.7
@@ -141,14 +116,6 @@ defmodule LivebookWeb.Output do
     Unknown output format: #{inspect(output)}. If you're using Kino,
     you may want to update Kino and Livebook to the latest version.
     """)
-  end
-
-  defp render_error(message) do
-    assigns = %{message: message}
-
-    ~H"""
-    <div class="whitespace-pre-wrap font-editor text-gray-500" role="complementary" aria-label="error"><%= ansi_string_to_html(@message) %></div>
-    """
   end
 
   defp render_error_message(message) do

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -84,9 +84,7 @@ defmodule LivebookWeb.Output.FrameComponent do
             dom_id_map={@persistent_id_map}
             socket={@socket}
             session_id={@session_id}
-            input_values={@input_values}
-            runtime={nil}
-            cell_validity={nil} />
+            input_values={@input_values} />
           </div>
       <% end %>
     </div>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -88,8 +88,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <.evaluation_outputs
         cell_view={@cell_view}
         socket={@socket}
-        session_id={@session_id}
-        runtime={@runtime} />
+        session_id={@session_id} />
     </.cell_body>
     """
   end
@@ -133,8 +132,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         <.evaluation_outputs
           cell_view={@cell_view}
           socket={@socket}
-          session_id={@session_id}
-          runtime={@runtime} />
+          session_id={@session_id} />
       </div>
     </.cell_body>
     """
@@ -213,8 +211,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <.evaluation_outputs
         cell_view={@cell_view}
         socket={@socket}
-        session_id={@session_id}
-        runtime={@runtime} />
+        session_id={@session_id} />
     </.cell_body>
     """
   end
@@ -514,8 +511,6 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         dom_id_map={%{}}
         socket={@socket}
         session_id={@session_id}
-        runtime={@runtime}
-        cell_validity={@cell_view.eval.validity}
         input_values={@cell_view.eval.input_values} />
     </div>
     """

--- a/test/livebook/runtime/evaluator/default_formatter_test.exs
+++ b/test/livebook/runtime/evaluator/default_formatter_test.exs
@@ -10,7 +10,7 @@ defmodule Livebook.Runtime.Evaluator.DefaultFormatterTest do
 
   test "gracefully handles errors in the inspect protocol" do
     result = %Livebook.TestModules.BadInspect{}
-    assert {:error, error, :other} = DefaultFormatter.format_result({:ok, result})
+    assert {:error, error} = DefaultFormatter.format_result({:ok, result})
     assert error =~ ":bad_return"
   end
 end

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -26,7 +26,6 @@ defmodule Livebook.Runtime.NoopRuntime do
     def drop_container(_, _), do: :ok
     def handle_intellisense(_, _, _, _), do: make_ref()
 
-    def standalone?(_), do: false
     def read_file(_, _), do: raise("not implemented")
     def start_smart_cell(_, _, _, _, _), do: :ok
     def set_smart_cell_base_locator(_, _, _), do: :ok


### PR DESCRIPTION
We now have the setup cell and always reconnect the runtime before reevaluating the setup, so we no longer need this.