### PR TITLE
Don't show output init timeout message on serialization error

### DIFF
--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -95,8 +95,8 @@ const JSView = {
 
     const errorRef = this.channel.on(
       `error:${this.props.ref}`,
-      ({ message }) => {
-        this.handleServerError(message);
+      ({ message, init }) => {
+        this.handleServerError(message, init);
       }
     );
 
@@ -334,7 +334,11 @@ const JSView = {
     });
   },
 
-  handleServerError(message) {
+  handleServerError(message, init) {
+    if (init) {
+      this.clearInitTimeout();
+    }
+
     if (!this.errorContainer) {
       this.errorContainer = document.createElement("div");
       this.errorContainer.classList.add("error-box", "mb-4");

--- a/lib/livebook_web/channels/js_view_channel.ex
+++ b/lib/livebook_web/channels/js_view_channel.ex
@@ -70,7 +70,7 @@ defmodule LivebookWeb.JSViewChannel do
 
     with {:error, error} <- try_push(socket, "init:#{ref}:#{id}", nil, payload) do
       message = "Failed to serialize initial widget data, " <> error
-      push(socket, "error:#{ref}", %{"message" => message})
+      push(socket, "error:#{ref}", %{"message" => message, "init" => true})
     end
 
     {:noreply, socket}


### PR DESCRIPTION
When we receive the initial data, but fail to serialize it, the client should't show the timeout message.

![image](https://user-images.githubusercontent.com/17034772/162544953-c400e52e-f241-42fb-8687-0f276081fc87.png)