### PR TITLE
Mount Markdown cell editor lazily

### DIFF
--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -156,6 +156,18 @@ const Cell = {
 
     this.updateInsertModeAvailability();
 
+    if (this.props.type !== "markdown") {
+      // For markdown cells the editor is mounted lazily when needed,
+      // for other cells we mount the editor eagerly, however mounting
+      // is a synchronous operation and is relatively expensive, so we
+      // defer it to run after the current event handlers
+      setTimeout(() => {
+        if (!liveEditor.isMounted()) {
+          liveEditor.mount();
+        }
+      }, 0);
+    }
+
     if (liveEditor === this.currentEditor()) {
       // Once the editor is created, reflect the current insert mode state
       this.maybeFocusCurrentEditor(true);

--- a/assets/js/hooks/cell_editor.js
+++ b/assets/js/hooks/cell_editor.js
@@ -12,8 +12,6 @@ const CellEditor = {
           `[data-el-editor-container]`
         );
 
-        // Remove the content placeholder
-        editorContainer.firstElementChild.remove();
         const editorEl = document.createElement("div");
         editorContainer.appendChild(editorEl);
 
@@ -28,6 +26,11 @@ const CellEditor = {
           intellisense,
           read_only
         );
+
+        this.liveEditor.onMount(() => {
+          // Remove the content placeholder
+          editorContainer.querySelector(`[data-el-skeleton]`).remove();
+        });
 
         this.el.dispatchEvent(
           new CustomEvent("lb:cell:editor_created", {

--- a/lib/livebook_web/live/session_live/cell_editor_component.ex
+++ b/lib/livebook_web/live/session_live/cell_editor_component.ex
@@ -43,7 +43,7 @@ defmodule LivebookWeb.SessionLive.CellEditorComponent do
       data-cell-id={@cell_id}
       data-tag={@tag}>
       <div class="py-3 rounded-lg bg-editor" data-el-editor-container>
-        <div class="px-8">
+        <div class="px-8" data-el-skeleton>
           <.content_skeleton bg_class="bg-gray-500" empty={empty?(@source_view)} />
         </div>
       </div>


### PR DESCRIPTION
Related to #1098.

With this change we create Monaco instances for Markdown cells only when necessary. Also, this brings back an optimization what we used do to, specifically, when navigating to a notebook we complete the hooks and let the page paint, only then mount the editors. This results in a faster and smoother loading, noticeable for larger notebooks.