### PR TITLE
Make smart cell editor rounded

### DIFF
--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -174,7 +174,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
                   cell_id={@cell_view.id}
                   tag="secondary"
                   source_view={@cell_view.editor.source_view}
-                  language={@cell_view.editor.language} />
+                  language={@cell_view.editor.language}
+                  rounded={@cell_view.editor.placement} />
               <% end %>
             </div>
 

--- a/lib/livebook_web/live/session_live/cell_editor_component.ex
+++ b/lib/livebook_web/live/session_live/cell_editor_component.ex
@@ -13,6 +13,7 @@ defmodule LivebookWeb.SessionLive.CellEditorComponent do
       |> assign(assigns)
       |> assign_new(:intellisense, fn -> false end)
       |> assign_new(:read_only, fn -> false end)
+      |> assign_new(:rounded, fn -> :both end)
 
     socket =
       if not connected?(socket) or socket.assigns.initialized do
@@ -42,7 +43,7 @@ defmodule LivebookWeb.SessionLive.CellEditorComponent do
       phx-hook="CellEditor"
       data-cell-id={@cell_id}
       data-tag={@tag}>
-      <div class="py-3 rounded-lg bg-editor" data-el-editor-container>
+      <div class={"py-3 #{rounded_class(@rounded)} bg-editor"} data-el-editor-container>
         <div class="px-8" data-el-skeleton>
           <.content_skeleton bg_class="bg-gray-500" empty={empty?(@source_view)} />
         </div>
@@ -53,4 +54,8 @@ defmodule LivebookWeb.SessionLive.CellEditorComponent do
 
   defp empty?(%{source: ""} = _source_view), do: true
   defp empty?(_source_view), do: false
+
+  defp rounded_class(:both), do: "rounded-lg"
+  defp rounded_class(:top), do: "rounded-t-lg"
+  defp rounded_class(:bottom), do: "rounded-b-lg"
 end


### PR DESCRIPTION
The smart cell UI is directly adjacent to the editor and we expect it to have some sort of background/border with more info/controls, so this way those will be visually tied.

![image](https://user-images.githubusercontent.com/17034772/163239979-13e838c0-ad70-444b-8857-76d369ae8c07.png)