### PR TITLE
Fix JS view connection timeout under heavy load

### DIFF
--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -106,11 +106,17 @@ const JSView = {
       this.channel.off(`error:${this.props.ref}`, errorRef);
     };
 
-    this.channel.push("connect", {
-      session_token: this.props.sessionToken,
-      ref: this.props.ref,
-      id: this.id,
-    });
+    this.channel.push(
+      "connect",
+      {
+        session_token: this.props.sessionToken,
+        ref: this.props.ref,
+        id: this.id,
+      },
+      // If the client is very busy with executing JS we may reach the
+      // default timeout of 10s, so we increase it
+      30_000
+    );
   },
 
   updated() {


### PR DESCRIPTION
In the VegaLite notebook if we do `ctrl+shift+enter` to execute everything at once, it generates a heavy load on the client due to all the cell status updates and iframe outputs that need to load. This makes some JS view connections reach the connection timeout, whereas given enough time it would all finish fine.