### PR TITLE
Add an option for wrapping words in Markdown editor by default

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -262,6 +262,10 @@ class LiveEditor {
       // of the line we would get "defmodule" as a word completion.
       wordBasedSuggestions: !this.intellisense,
       parameterHints: this.intellisense && settings.editor_auto_signature,
+      wordWrap:
+        this.language === "markdown" && settings.editor_markdown_word_wrap
+          ? "on"
+          : "off",
     });
 
     this.editor.addAction({

--- a/assets/js/hooks/editor_settings.js
+++ b/assets/js/hooks/editor_settings.js
@@ -23,6 +23,9 @@ const EditorSettings = {
     const editorHighContrastCheckbox = this.el.querySelector(
       `[name="editor_high_contrast"][value="true"]`
     );
+    const editorMarkdownWordWrapCheckbox = this.el.querySelector(
+      `[name="editor_markdown_word_wrap"][value="true"]`
+    );
 
     editorAutoCompletionCheckbox.checked = settings.editor_auto_completion;
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
@@ -30,6 +33,7 @@ const EditorSettings = {
       settings.editor_font_size === EDITOR_FONT_SIZE.large ? true : false;
     editorHighContrastCheckbox.checked =
       settings.editor_theme === EDITOR_THEME.highContrast ? true : false;
+    editorMarkdownWordWrapCheckbox.checked = settings.editor_markdown_word_wrap;
 
     editorAutoCompletionCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ editor_auto_completion: event.target.checked });
@@ -53,6 +57,10 @@ const EditorSettings = {
           ? EDITOR_THEME.highContrast
           : EDITOR_THEME.default,
       });
+    });
+
+    editorMarkdownWordWrapCheckbox.addEventListener("change", (event) => {
+      settingsStore.update({ editor_markdown_word_wrap: event.target.checked });
     });
   },
 };

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS = {
   editor_auto_signature: true,
   editor_font_size: EDITOR_FONT_SIZE.normal,
   editor_theme: EDITOR_THEME.default,
+  editor_markdown_word_wrap: true,
 };
 
 /**

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -121,6 +121,10 @@ defmodule LivebookWeb.SettingsLive do
                   name="editor_high_contrast"
                   label="Use high contrast theme"
                   checked={false} />
+                <.switch_checkbox
+                  name="editor_markdown_word_wrap"
+                  label="Wrap words in Markdown"
+                  checked={false} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Closes #1085.

https://user-images.githubusercontent.com/17034772/163275889-62e47aa9-e36b-4fbe-bfba-fc865ca4bd34.mp4
