### PR TITLE
Add support for mix run flags to the Mix runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The following environment variables configure Livebook:
 
   * LIVEBOOK_DEFAULT_RUNTIME - sets the runtime type that is used by default
     when none is started explicitly for the given notebook. Must be either
-    "standalone" (Elixir standalone), "mix[:PATH]" (Mix standalone),
+    "standalone" (Elixir standalone), "mix[:PATH][:FLAGS]" (Mix standalone),
     "attached:NODE:COOKIE" (Attached node) or "embedded" (Embedded).
     Defaults to "standalone".
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -249,7 +249,11 @@ defmodule Livebook.Config do
 
         case mix_path(path) do
           {:ok, path} ->
-            Livebook.Runtime.MixStandalone.new(path, flags)
+            if Livebook.Utils.valid_cli_flags?(flags) do
+              Livebook.Runtime.MixStandalone.new(path, flags)
+            else
+              abort!(~s{"#{flags}" is not a valid flag sequence})
+            end
 
           :error ->
             abort!(~s{"#{path}" does not point to a Mix project})

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -244,10 +244,12 @@ defmodule Livebook.Config do
             )
         end
 
-      "mix:" <> path ->
+      "mix:" <> config ->
+        {path, flags} = parse_mix_config!(config)
+
         case mix_path(path) do
           {:ok, path} ->
-            Livebook.Runtime.MixStandalone.new(path)
+            Livebook.Runtime.MixStandalone.new(path, flags)
 
           :error ->
             abort!(~s{"#{path}" does not point to a Mix project})
@@ -261,6 +263,13 @@ defmodule Livebook.Config do
         abort!(
           ~s{expected #{context} to be either "standalone", "mix[:path]" or "embedded", got: #{inspect(other)}}
         )
+    end
+  end
+
+  defp parse_mix_config!(config) do
+    case String.split(config, ":", parts: 2) do
+      [path] -> {path, ""}
+      [path, flags] -> {path, flags}
     end
   end
 

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -110,7 +110,7 @@ defmodule Livebook.Runtime.StandaloneInit do
           loop.(loop)
 
         {:DOWN, ^port_ref, :port, _object, _reason} ->
-          {:error, "Elixir process terminated unexpectedly"}
+          {:error, "Elixir terminated unexpectedly, please check the terminal for errors"}
       after
         # Use a longer timeout to account for longer child node startup,
         # as may happen when starting with Mix.

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -193,6 +193,30 @@ defmodule Livebook.Utils do
   @spec valid_hex_color?(String.t()) :: boolean()
   def valid_hex_color?(hex_color), do: hex_color =~ ~r/^#[0-9a-fA-F]{6}$/
 
+  @doc ~S"""
+  Validates if the given string forms valid CLI flags.
+
+  ## Examples
+
+      iex> Livebook.Utils.valid_cli_flags?("")
+      true
+
+      iex> Livebook.Utils.valid_cli_flags?("--arg1 value --arg2 'value'")
+      true
+
+      iex> Livebook.Utils.valid_cli_flags?("--arg1 \"")
+      false
+  """
+  @spec valid_cli_flags?(String.t()) :: boolean()
+  def valid_cli_flags?(flags) do
+    try do
+      OptionParser.split(flags)
+      true
+    rescue
+      _ -> false
+    end
+  end
+
   @doc """
   Changes the first letter in the given string to upper case.
 

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -45,7 +45,7 @@ defmodule LivebookCLI.Server do
                            explicitly for the given notebook, defaults to standalone
                            Supported options:
                              * standalone - Elixir standalone
-                             * mix[:PATH] - Mix standalone
+                             * mix[:PATH][:FLAGS] - Mix standalone
                              * attached:NODE:COOKIE - Attached
                              * embedded - Embedded
       --home               The home path for the Livebook instance

--- a/lib/livebook_web/live/session_live/mix_standalone_live.ex
+++ b/lib/livebook_web/live/session_live/mix_standalone_live.ex
@@ -54,7 +54,7 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
         </div>
         <form phx-change="validate" phx-submit="init">
           <div>
-            <div class="input-label">Mix run flags</div>
+            <div class="input-label"><code>mix run</code> command-line flags</div>
             <input class="input"
               type="text"
               name="flags"

--- a/lib/livebook_web/live/session_live/mix_standalone_live.ex
+++ b/lib/livebook_web/live/session_live/mix_standalone_live.ex
@@ -155,7 +155,7 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
   defp matching_runtime?(_runtime, _path), do: false
 
   defp data_valid?(data) do
-    mix_project_root?(data.file.path)
+    mix_project_root?(data.file.path) and Livebook.Utils.valid_cli_flags?(data.flags)
   end
 
   defp mix_project_root?(path) do

--- a/lib/livebook_web/live/session_live/mix_standalone_live.ex
+++ b/lib/livebook_web/live/session_live/mix_standalone_live.ex
@@ -136,7 +136,12 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
   end
 
   defp initial_data(%Runtime.MixStandalone{project_path: project_path, flags: flags}) do
-    %{file: FileSystem.File.local(project_path), flags: flags}
+    file =
+      project_path
+      |> FileSystem.Utils.ensure_dir_path()
+      |> FileSystem.File.local()
+
+    %{file: file, flags: flags}
   end
 
   defp initial_data(_runtime) do

--- a/lib/livebook_web/live/session_live/mix_standalone_live.ex
+++ b/lib/livebook_web/live/session_live/mix_standalone_live.ex
@@ -20,8 +20,9 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
        session: session,
        status: :initial,
        current_runtime: current_runtime,
-       file: initial_file(current_runtime),
+       data: initial_data(current_runtime),
        outputs: [],
+       outputs_version: 0,
        emitter: nil
      ), temporary_assigns: [outputs: []]}
   end
@@ -41,27 +42,40 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
         inside a Mix project because the dependencies of the project
         itself have been installed instead.
       </p>
-      <%= if @status == :initial do %>
+      <%= if @status != :initializing do %>
         <div class="h-full h-52">
           <.live_component module={LivebookWeb.FileSelectComponent}
               id="mix-project-dir"
-              file={@file}
+              file={@data.file}
               extnames={[]}
               running_files={[]}
-              submit_event={if(disabled?(@file.path), do: nil, else: :init)}
+              submit_event={if(data_valid?(@data), do: :init, else: nil)}
               file_system_select_disabled={true} />
         </div>
-        <button class="button-base button-blue" phx-click="init" disabled={disabled?(@file.path)}>
-          <%= if(matching_runtime?(@current_runtime, @file.path), do: "Reconnect", else: "Connect") %>
-        </button>
+        <form phx-change="validate" phx-submit="init">
+          <div>
+            <div class="input-label">Mix run flags</div>
+            <input class="input"
+              type="text"
+              name="flags"
+              value={@data.flags}
+              spellcheck="false"
+              autocomplete="off" />
+          </div>
+          <button class="mt-5 button-base button-blue"
+            type="submit"
+            disabled={not data_valid?(@data)}>
+            <%= if(matching_runtime?(@current_runtime, @data), do: "Reconnect", else: "Connect") %>
+          </button>
+        </form>
       <% end %>
       <%= if @status != :initial do %>
         <div class="markdown">
           <pre><code class="max-h-40 overflow-y-auto tiny-scrollbar"
-            id="mix-standalone-init-output"
+            id={"mix-standalone-init-output-#{@outputs_version}"}
             phx-update="append"
             phx-hook="ScrollOnUpdate"
-            ><%= for {output, i} <- @outputs do %><span id={"output-#{i}"}><%= ansi_string_to_html(output) %></span><% end %></code></pre>
+            ><%= for {output, i} <- @outputs do %><span id={"mix-standalone-init-output-#{@outputs_version}-#{i}"}><%= ansi_string_to_html(output) %></span><% end %></code></pre>
         </div>
       <% end %>
     </div>
@@ -73,9 +87,13 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
     handle_init(socket)
   end
 
+  def handle_event("validate", %{"flags" => flags}, socket) do
+    {:noreply, update(socket, :data, &%{&1 | flags: flags})}
+  end
+
   @impl true
   def handle_info({:set_file, file, _info}, socket) do
-    {:noreply, assign(socket, :file, file)}
+    {:noreply, update(socket, :data, &%{&1 | file: file})}
   end
 
   def handle_info(:init, socket) do
@@ -104,31 +122,35 @@ defmodule LivebookWeb.SessionLive.MixStandaloneLive do
 
   defp handle_init(socket) do
     emitter = Utils.Emitter.new(self())
-    runtime = Runtime.MixStandalone.new(socket.assigns.file.path)
+    runtime = Runtime.MixStandalone.new(socket.assigns.data.file.path, socket.assigns.data.flags)
     Runtime.MixStandalone.connect_async(runtime, emitter)
-    {:noreply, assign(socket, status: :initializing, emitter: emitter)}
+
+    {:noreply,
+     socket
+     |> assign(status: :initializing, emitter: emitter, outputs: [])
+     |> update(:outputs_version, &(&1 + 1))}
   end
 
   defp add_output(socket, output) do
     assign(socket, outputs: socket.assigns.outputs ++ [{output, Utils.random_id()}])
   end
 
-  defp initial_file(%Runtime.MixStandalone{} = current_runtime) do
-    FileSystem.File.local(current_runtime.project_path)
+  defp initial_data(%Runtime.MixStandalone{project_path: project_path, flags: flags}) do
+    %{file: FileSystem.File.local(project_path), flags: flags}
   end
 
-  defp initial_file(_runtime) do
-    Livebook.Config.local_filesystem_home()
+  defp initial_data(_runtime) do
+    %{file: Livebook.Config.local_filesystem_home(), flags: ""}
   end
 
-  defp matching_runtime?(%Runtime.MixStandalone{} = runtime, path) do
-    Path.expand(runtime.project_path) == Path.expand(path)
+  defp matching_runtime?(%Runtime.MixStandalone{} = runtime, data) do
+    Path.expand(runtime.project_path) == Path.expand(data.file.path)
   end
 
   defp matching_runtime?(_runtime, _path), do: false
 
-  defp disabled?(path) do
-    not mix_project_root?(path)
+  defp data_valid?(data) do
+    mix_project_root?(data.file.path)
   end
 
   defp mix_project_root?(path) do


### PR DESCRIPTION
Closes #940.

https://user-images.githubusercontent.com/17034772/163288295-fb8b4deb-ce62-46c3-a957-2c195e5b0a01.mp4

@josevalim I went with "Mix run flags" rather than "Mix arguments", because we always want `mix run` and we pass some options there on our own.