### PR TITLE
Increase the timeout for topbar

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -10,7 +10,7 @@ export function registerTopbar() {
 
   window.addEventListener("phx:page-loading-start", () => {
     if (!topBarScheduled) {
-      topBarScheduled = setTimeout(() => topbar.show(), 200);
+      topBarScheduled = setTimeout(() => topbar.show(), 500);
     }
   });
 


### PR DESCRIPTION
The topbar still shows way too frequently even
when the navigation feels snap.