### PR TITLE
Add test for appending to Mix install with options

### DIFF
--- a/test/livebook/runtime/dependencies_test.exs
+++ b/test/livebook/runtime/dependencies_test.exs
@@ -99,6 +99,32 @@ defmodule Livebook.Runtime.DependenciesTest do
                 # Result
                 :ok\
                 """}
+
+      assert Dependencies.add_mix_deps(
+               """
+               Mix.install(
+                 [
+                   {:req, "~> 0.2.0"}
+                 ],
+                 system_env: [
+                   # {"XLA_TARGET", "cuda111"}
+                 ]
+               )\
+               """,
+               [@kino]
+             ) ==
+               {:ok,
+                """
+                Mix.install(
+                  [
+                    {:req, "~> 0.2.0"},
+                    {:kino, "~> 0.5.0"}
+                  ],
+                  system_env: [
+                    # {"XLA_TARGET", "cuda111"}
+                  ]
+                )\
+                """}
     end
 
     test "does not add the dependency if it already exists" do


### PR DESCRIPTION
@josevalim we already handle it correctly, I was looking at the place where we insert new node, not the one when we match the existing. So here's just a test that verifies that :)