### PR TITLE
Synchronize smart cell source before evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Restructured cell insert buttons ([#1073](https://github.com/livebook-dev/livebook/pull/1073))
 - Allowed inserting images without specifying name in Markdown cells ([#1083](https://github.com/livebook-dev/livebook/pull/1083))
 - Unified authentication to always redirect to the initial URL ([#1104](https://github.com/livebook-dev/livebook/pull/1104) and [#1112](https://github.com/livebook-dev/livebook/pull/1112))
+- Erase outputs action to clear cell indicators ([#1160](https://github.com/livebook-dev/livebook/pull/1160))
 
 ### Removed
 

--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -343,7 +343,7 @@ const Cell = {
   },
 
   handleDispatchQueueEvaluation(dispatch) {
-    if (this.props.type === "smart") {
+    if (this.props.type === "smart" && this.props.smartCellJSViewRef) {
       // Ensure the smart cell UI is reflected on the server, before the evaluation
       globalPubSub.broadcast(`js_views:${this.props.smartCellJSViewRef}`, {
         type: "sync",

--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -83,6 +83,11 @@ const Cell = {
     this.unsubscribeFromCellsEvents = globalPubSub.subscribe("cells", (event) =>
       this.handleCellsEvent(event)
     );
+
+    this.unsubscribeFromCellEvents = globalPubSub.subscribe(
+      `cells:${this.props.cellId}`,
+      (event) => this.handleCellEvent(event)
+    );
   },
 
   disconnected() {
@@ -93,6 +98,7 @@ const Cell = {
   destroyed() {
     this.unsubscribeFromNavigationEvents();
     this.unsubscribeFromCellsEvents();
+    this.unsubscribeFromCellEvents();
   },
 
   updated() {
@@ -114,6 +120,11 @@ const Cell = {
         "data-evaluation-digest",
         null
       ),
+      smartCellJSViewRef: getAttributeOrDefault(
+        this.el,
+        "data-smart-cell-js-view-ref",
+        null
+      ),
     };
   },
 
@@ -132,6 +143,12 @@ const Cell = {
       this.handleCellMoved(event.cellId);
     } else if (event.type === "cell_upload") {
       this.handleCellUpload(event.cellId, event.url);
+    }
+  },
+
+  handleCellEvent(event) {
+    if (event.type === "dispatch_queue_evaluation") {
+      this.handleDispatchQueueEvaluation(event.dispatch);
     }
   },
 
@@ -322,6 +339,18 @@ const Cell = {
     if (this.props.cellId === cellId) {
       const markdown = `![](${url})`;
       liveEditor.insert(markdown);
+    }
+  },
+
+  handleDispatchQueueEvaluation(dispatch) {
+    if (this.props.type === "smart") {
+      // Ensure the smart cell UI is reflected on the server, before the evaluation
+      globalPubSub.broadcast(`js_views:${this.props.smartCellJSViewRef}`, {
+        type: "sync",
+        callback: dispatch,
+      });
+    } else {
+      dispatch();
     }
   },
 

--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -26,7 +26,7 @@ import { sha256Base64 } from "../../lib/utils";
 // (2): https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 // (3): https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 
-const IFRAME_SHA256 = "4gyeA71Bpb4SGj2M0BUdT1jtk6wjUqOf6Q8wVYp7htc=";
+const IFRAME_SHA256 = "fA00WeO9LAvgpbMz9vKEU0WTr4Uk5bTt/BxKHdweEz8=";
 
 export function initializeIframeSource(iframe, iframePort) {
   const iframeUrl = getIframeUrl(iframePort);

--- a/iframe/priv/static/iframe/v3.html
+++ b/iframe/priv/static/iframe/v3.html
@@ -28,6 +28,7 @@
           importPromise: null,
           eventHandlers: {},
           eventQueue: [],
+          syncHandler: null,
         };
 
         function postMessage(message) {
@@ -74,6 +75,10 @@
               linkEl.href = url;
               document.head.appendChild(linkEl);
             });
+          },
+
+          handleSync(callback) {
+            state.syncHandler = callback;
           },
         };
 
@@ -128,6 +133,12 @@
             } else {
               state.eventQueue.push({ event, payload });
             }
+          } else if (message.type === "sync") {
+            Promise.resolve(state.syncHandler && state.syncHandler()).then(
+              () => {
+                postMessage({ type: "syncReply" });
+              }
+            );
           }
         }
 

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -30,11 +30,11 @@ defmodule Livebook do
 
       [
         %{
-          dependency: {:kino, "~> 0.6.0"},
+          dependency: {:kino, "~> 0.6.1"},
           description: "Interactive widgets for Livebook",
           name: "kino",
           url: "https://hex.pm/packages/kino",
-          version: "0.6.0"
+          version: "0.6.1"
         }
       ]
 

--- a/lib/livebook/notebook/explore/elixir_and_livebook.livemd
+++ b/lib/livebook/notebook/explore/elixir_and_livebook.livemd
@@ -56,7 +56,7 @@ double-click on "Notebook dependencies and setup", add and run the code.
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/intro_to_vega_lite.livemd
+++ b/lib/livebook/notebook/explore/intro_to_vega_lite.livemd
@@ -3,7 +3,7 @@
 ```elixir
 Mix.install([
   {:vega_lite, "~> 0.1.4"},
-  {:kino_vega_lite, "~> 0.1.0"}
+  {:kino_vega_lite, "~> 0.1.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/kino/chat_app.livemd
+++ b/lib/livebook/notebook/explore/kino/chat_app.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/kino/custom_kinos.livemd
+++ b/lib/livebook/notebook/explore/kino/custom_kinos.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/kino/intro_to_kino.livemd
+++ b/lib/livebook/notebook/explore/kino/intro_to_kino.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/kino/pong.livemd
+++ b/lib/livebook/notebook/explore/kino/pong.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/lib/livebook/notebook/explore/kino/smart_cells.livemd
+++ b/lib/livebook/notebook/explore/kino/smart_cells.livemd
@@ -90,8 +90,14 @@ defmodule KinoGuide.PrintCell do
         textEl.value = text;
       });
 
-      textEl.addEventListener("blur", (event) => {
+      textEl.addEventListener("change", (event) => {
         ctx.pushEvent("update_text", event.target.value);
+      });
+
+      ctx.handleSync(() => {
+        // Synchronously invokes change listeners
+        document.activeElement &&
+          document.activeElement.dispatchEvent(new Event("change"));
       });
     }
     """
@@ -125,15 +131,21 @@ so that Livebook picks it up. Note that in practice we would put the
 Smart cell in a package and we would register it in `application.ex`
 when starting the application.
 
+Note that we register a synchronization handler on the client with
+`ctx.handleSync(() => ...)`. This optional handler is invoked before
+evaluation and it should flush any deferred UI changes to the server.
+In our example we listen to input's "change" event, which is only
+triggered on blur, so on synchronization we trigger it programmatically.
+
 <!-- livebook:{"break_markdown":true} -->
 
 Now let's try out the new cell! We already inserted one below, but you
 can add more with the <kbd>+ Smart</kbd> button.
 
-<!-- livebook:{"attrs":{"text":"something"},"kind":"Elixir.KinoGuide.PrintCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":{"text":"Hello!"},"kind":"Elixir.KinoGuide.PrintCell","livebook_object":"smart_cell"} -->
 
 ```elixir
-IO.puts("something")
+IO.puts("Hello!")
 ```
 
 Focus the Smart cell and click the "Source" icon. You should see the
@@ -329,12 +341,18 @@ defmodule KinoGuide.JSONConverterCell do
       const variableEl = ctx.root.querySelector(`[name="variable"]`);
       variableEl.value = payload.variable;
 
-      variableEl.addEventListener("blur", (event) => {
+      variableEl.addEventListener("change", (event) => {
         ctx.pushEvent("update_variable", event.target.value);
       });
 
       ctx.handleEvent("update_variable", (variable) => {
         variableEl.value = variable;
+      });
+
+      ctx.handleSync(() => {
+        // Synchronously invokes change listeners
+        document.activeElement &&
+          document.activeElement.dispatchEvent(new Event("change"));
       });
     }
     """

--- a/lib/livebook/notebook/explore/kino/smart_cells.livemd
+++ b/lib/livebook/notebook/explore/kino/smart_cells.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"},
+  {:kino, "~> 0.6.1"},
   {:jason, "~> 1.3"}
 ])
 ```

--- a/lib/livebook/notebook/explore/kino/vm_introspection.livemd
+++ b/lib/livebook/notebook/explore/kino/vm_introspection.livemd
@@ -2,8 +2,8 @@
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"},
-  {:kino_vega_lite, "~> 0.1.0"}
+  {:kino, "~> 0.6.1"},
+  {:kino_vega_lite, "~> 0.1.1"}
 ])
 
 alias VegaLite, as: Vl

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -411,7 +411,7 @@ defprotocol Livebook.Runtime do
   to the runtime owner whenever attrs and the generated source code
   change.
 
-    * `{:runtime_smart_cell_update, ref, attrs, source}`
+    * `{:runtime_smart_cell_update, ref, attrs, source, %{reevaluate: boolean()}}`
 
   The attrs are persisted and may be used to restore the smart cell
   state later. Note that for persistence they get serialized and

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -17,8 +17,8 @@ defmodule Livebook.Runtime.ElixirStandalone do
           server_pid: pid() | nil
         }
 
-  kino_vega_lite = %{name: "kino_vega_lite", dependency: {:kino_vega_lite, "~> 0.1.0"}}
-  kino_db = %{name: "kino_db", dependency: {:kino_db, "~> 0.1.0"}}
+  kino_vega_lite = %{name: "kino_vega_lite", dependency: {:kino_vega_lite, "~> 0.1.1"}}
+  kino_db = %{name: "kino_db", dependency: {:kino_db, "~> 0.1.1"}}
 
   @extra_smart_cell_definitions [
     %{

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1001,6 +1001,18 @@ defmodule Livebook.Session do
     end
   end
 
+  def handle_info({:pong, {:smart_cell_evaluation, cell_id}, _info}, state) do
+    state =
+      with {:ok, cell, section} <- Notebook.fetch_cell_and_section(state.data.notebook, cell_id),
+           :evaluating <- state.data.cell_infos[cell.id].eval.status do
+        start_evaluation(state, cell, section)
+      else
+        _ -> state
+      end
+
+    {:noreply, state}
+  end
+
   def handle_info(_message, state), do: {:noreply, state}
 
   @impl true
@@ -1308,28 +1320,20 @@ defmodule Livebook.Session do
   end
 
   defp handle_action(state, {:start_evaluation, cell, section}) do
-    path =
-      case state.data.file do
-        nil -> ""
-        file -> file.path
-      end
+    info = state.data.cell_infos[cell.id]
 
-    file = path <> "#cell"
+    if is_struct(cell, Cell.Smart) and info.status != :dead do
+      # We do a ping and start evaluation only once we get a reply,
+      # this way we make sure we received all relevant source changes
+      send(
+        cell.js_view.pid,
+        {:ping, self(), {:smart_cell_evaluation, cell.id}, %{ref: cell.js_view.ref}}
+      )
 
-    smart_cell_ref =
-      case cell do
-        %Cell.Smart{} -> cell.id
-        _ -> nil
-      end
-
-    opts = [file: file, smart_cell_ref: smart_cell_ref]
-
-    locator = {container_ref_for_section(section), cell.id}
-    base_locator = find_base_locator(state.data, cell, section)
-    Runtime.evaluate_code(state.data.runtime, cell.source, locator, base_locator, opts)
-
-    evaluation_digest = :erlang.md5(cell.source)
-    handle_operation(state, {:evaluation_started, self(), cell.id, evaluation_digest})
+      state
+    else
+      start_evaluation(state, cell, section)
+    end
   end
 
   defp handle_action(state, {:stop_evaluation, section}) do
@@ -1383,6 +1387,31 @@ defmodule Livebook.Session do
   end
 
   defp handle_action(state, _action), do: state
+
+  defp start_evaluation(state, cell, section) do
+    path =
+      case state.data.file do
+        nil -> ""
+        file -> file.path
+      end
+
+    file = path <> "#cell"
+
+    smart_cell_ref =
+      case cell do
+        %Cell.Smart{} -> cell.id
+        _ -> nil
+      end
+
+    opts = [file: file, smart_cell_ref: smart_cell_ref]
+
+    locator = {container_ref_for_section(section), cell.id}
+    base_locator = find_base_locator(state.data, cell, section)
+    Runtime.evaluate_code(state.data.runtime, cell.source, locator, base_locator, opts)
+
+    evaluation_digest = :erlang.md5(cell.source)
+    handle_operation(state, {:evaluation_started, self(), cell.id, evaluation_digest})
+  end
 
   defp broadcast_operation(session_id, operation) do
     broadcast_message(session_id, {:operation, operation})

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1322,7 +1322,7 @@ defmodule Livebook.Session do
   defp handle_action(state, {:start_evaluation, cell, section}) do
     info = state.data.cell_infos[cell.id]
 
-    if is_struct(cell, Cell.Smart) and info.status != :dead do
+    if is_struct(cell, Cell.Smart) and info.status == :started do
       # We do a ping and start evaluation only once we get a reply,
       # this way we make sure we received all relevant source changes
       send(

--- a/lib/livebook_web/channels/js_view_channel.ex
+++ b/lib/livebook_web/channels/js_view_channel.ex
@@ -39,6 +39,12 @@ defmodule LivebookWeb.JSViewChannel do
     {:noreply, socket}
   end
 
+  def handle_in("ping", %{"ref" => ref}, socket) do
+    pid = socket.assigns.ref_with_info[ref].pid
+    send(pid, {:ping, self(), nil, %{ref: ref}})
+    {:noreply, socket}
+  end
+
   def handle_in("disconnect", %{"ref" => ref}, socket) do
     socket =
       if socket.assigns.ref_with_info[ref].count == 1 do
@@ -73,6 +79,11 @@ defmodule LivebookWeb.JSViewChannel do
       push(socket, "error:#{ref}", %{"message" => message, "init" => true})
     end
 
+    {:noreply, socket}
+  end
+
+  def handle_info({:pong, _, %{ref: ref}}, socket) do
+    push(socket, "pong:#{ref}", %{})
     {:noreply, socket}
   end
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -14,7 +14,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       data-session-path={Routes.session_path(@socket, :page, @session_id)}
       data-evaluation-digest={get_in(@cell_view, [:eval, :evaluation_digest])}
       data-eval-validity={get_in(@cell_view, [:eval, :validity])}
-      data-js-empty={empty?(@cell_view.source_view)}>
+      data-js-empty={empty?(@cell_view.source_view)}
+      data-smart-cell-js-view-ref={smart_cell_js_view_ref(@cell_view)}>
       <%= render_cell(assigns) %>
     </div>
     """
@@ -272,8 +273,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp cell_evaluation_button(%{status: :ready} = assigns) do
     ~H"""
     <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
-      phx-click="queue_cell_evaluation"
-      phx-value-cell_id={@cell_id}>
+      data-el-queue-cell-evaluation-button
+      data-cell-id={@cell_id}>
       <.remix_icon icon="play-circle-fill" class="text-xl" />
       <span class="text-sm font-medium">
         <%= if(@validity == :evaluated, do: "Reevaluate", else: "Evaluate") %>
@@ -298,8 +299,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp setup_cell_evaluation_button(%{status: :ready} = assigns) do
     ~H"""
     <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
-      phx-click="queue_cell_evaluation"
-      phx-value-cell_id={@cell_id}>
+      data-el-queue-cell-evaluation-button
+      data-cell-id={@cell_id}>
       <%= if @validity == :fresh do %>
         <.remix_icon icon="play-circle-fill" class="text-xl" />
         <span class="text-sm font-medium">Setup</span>
@@ -611,4 +612,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   end
 
   defp evaluated_label(_time_ms), do: nil
+
+  defp smart_cell_js_view_ref(%{type: :smart, js_view: %{ref: ref}}), do: ref
+  defp smart_cell_js_view_ref(_cell_view), do: nil
 end

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -389,10 +389,10 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         </button>
       </span>
     <% else %>
-      <span class="tooltip top" data-tooltip="Add dependency (sp)">
+      <span class="tooltip top" data-tooltip="Add package (sp)">
         <%= live_patch to: Routes.session_path(@socket, :package_search, @session_id),
               class: "icon-button",
-              aria_label: "add dependency",
+              aria_label: "add package",
               role: "button",
               data_btn_package_search: true do %>
           <.remix_icon icon="play-list-add-line" class="text-xl" />


### PR DESCRIPTION
Currently when evaluating a smart cell (especially with `ctrl + enter`) we may evaluate

Currently we have a race condition where the smart cell could be evaluated before the source is updated. A clear case is a smart cell field that sends update on blur, so `ctrl + enter` doesn't consider this change. Even if the field update was sent on every change, there is no guarantee that the smart cell source will update before evaluation.

To fix it, we ensure the following linearity:

  * evaluation triggered from UI or via a shortcut
  * run smart cell callback `ctx.handleSync(() => ...)` that should flush any deferred UI changes to the server
  * we ping the smart cell server from the client and await reply, this acknowledges all previous changes
  * we send evaluation request to the session
  * the session pings the smart cell server and awaits reply, this ensures the session receives all relevant source updates