### PR TITLE
Specify ip for iframe endpoint only when present

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -197,14 +197,14 @@ defmodule Livebook.Application do
     port = Livebook.Config.iframe_port()
 
     if server? do
-      livebook_ip = Application.fetch_env!(:livebook, LivebookWeb.Endpoint)[:http][:ip]
+      http = Application.fetch_env!(:livebook, LivebookWeb.Endpoint)[:http]
 
       iframe_opts =
         [
           scheme: :http,
           plug: LivebookWeb.IframeEndpoint,
-          options: [port: port]
-        ] ++ if(livebook_ip, do: [ip: livebook_ip], else: [])
+          port: port
+        ] ++ Keyword.take(http, [:ip])
 
       spec = Plug.Cowboy.child_spec(iframe_opts)
       spec = update_in(spec.start, &{__MODULE__, :start_iframe, [port, &1]})

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -197,12 +197,14 @@ defmodule Livebook.Application do
     port = Livebook.Config.iframe_port()
 
     if server? do
-      iframe_opts = [
-        scheme: :http,
-        plug: LivebookWeb.IframeEndpoint,
-        options: [port: port],
-        ip: Application.fetch_env!(:livebook, LivebookWeb.Endpoint)[:http][:ip]
-      ]
+      livebook_ip = Application.fetch_env!(:livebook, LivebookWeb.Endpoint)[:http][:ip]
+
+      iframe_opts =
+        [
+          scheme: :http,
+          plug: LivebookWeb.IframeEndpoint,
+          options: [port: port]
+        ] ++ if(livebook_ip, do: [ip: livebook_ip], else: [])
 
       spec = Plug.Cowboy.child_spec(iframe_opts)
       spec = update_in(spec.start, &{__MODULE__, :start_iframe, [port, &1]})


### PR DESCRIPTION
Follow up to #1173.

In `nerves_livebook` we don't specify any ip ([ref](https://github.com/livebook-dev/nerves_livebook/blob/3872b10de75ccc8868dc0c0ccb32e10f316e6ba2/config/runtime.exs#L42-L45)) and passing `nil` in the plug configuration fails.