### PR TITLE
Show the correct amount of free memory available on the system

### DIFF
--- a/lib/livebook/system_resources.ex
+++ b/lib/livebook/system_resources.ex
@@ -66,7 +66,7 @@ defmodule Livebook.SystemResources do
 
   defp measure() do
     memory_data = :memsup.get_system_memory_data()
-    free_memory = measure_free_memory(Enum.into(memory_data, %{}))
+    free_memory = measure_free_memory(Map.new(memory_data))
     memory = %{total: memory_data[:total_memory], free: free_memory}
     :ets.insert(@name, {:memory, memory})
     memory

--- a/lib/livebook/system_resources.ex
+++ b/lib/livebook/system_resources.ex
@@ -66,10 +66,20 @@ defmodule Livebook.SystemResources do
 
   defp measure() do
     memory_data = :memsup.get_system_memory_data()
-    memory = %{total: memory_data[:total_memory], free: memory_data[:free_memory]}
+    free_memory = measure_free_memory(Enum.into(memory_data, %{}))
+    memory = %{total: memory_data[:total_memory], free: free_memory}
     :ets.insert(@name, {:memory, memory})
     memory
   end
+
+  defp measure_free_memory(%{available_memory: available}), do: available
+
+  defp measure_free_memory(%{cached_memory: cached, buffered_memory: buffered, free_memory: free}) do
+    cached + buffered + free
+  end
+
+  defp measure_free_memory(%{free_memory: free}), do: free
+  defp measure_free_memory(_), do: 0
 
   defp schedule() do
     Process.send_after(self(), :measure, 15000)

--- a/lib/livebook/system_resources.ex
+++ b/lib/livebook/system_resources.ex
@@ -66,20 +66,20 @@ defmodule Livebook.SystemResources do
 
   defp measure() do
     memory_data = :memsup.get_system_memory_data()
-    free_memory = measure_free_memory(Map.new(memory_data))
+    free_memory = free_memory(Map.new(memory_data))
     memory = %{total: memory_data[:total_memory], free: free_memory}
     :ets.insert(@name, {:memory, memory})
     memory
   end
 
-  defp measure_free_memory(%{available_memory: available}), do: available
+  defp free_memory(%{available_memory: available}), do: available
 
-  defp measure_free_memory(%{cached_memory: cached, buffered_memory: buffered, free_memory: free}) do
+  defp free_memory(%{cached_memory: cached, buffered_memory: buffered, free_memory: free}) do
     cached + buffered + free
   end
 
-  defp measure_free_memory(%{free_memory: free}), do: free
-  defp measure_free_memory(_), do: 0
+  defp free_memory(%{free_memory: free}), do: free
+  defp free_memory(_), do: 0
 
   defp schedule() do
     Process.send_after(self(), :measure, 15000)


### PR DESCRIPTION
Attempts to use the `available_memory` stat, otherwise tries to cobble it together using cached+buffered+free as per the erlang docs on `:memsup:get_system_memory_data` and only failing that flals back to `free_memory`. 

I have only been able to test it so far on Linux, but have tested all the branches of the `measure_free_memory` functions.  Testing it on other OS's would be good.

Incorrect without this patch:

![memory_reporting_before](https://user-images.githubusercontent.com/2236/167404711-c1dbf9bc-696f-4ef7-a74c-349ac82cb09f.png)

Correct, after this patch:

![memory_reporting_after](https://user-images.githubusercontent.com/2236/167404706-421e395a-b90e-40ab-bb4b-c1e4c4d87390.png)
.