### PR TITLE
Fix smart cell evaluation button in forked notebooks

### DIFF
--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -612,6 +612,6 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   defp evaluated_label(_time_ms), do: nil
 
-  defp smart_cell_js_view_ref(%{type: :smart, js_view: %{ref: ref}}), do: ref
+  defp smart_cell_js_view_ref(%{type: :smart, status: :started, js_view: %{ref: ref}}), do: ref
   defp smart_cell_js_view_ref(_cell_view), do: nil
 end


### PR DESCRIPTION
Currently after forking a notebook with a smart cell, the evaluate button doesn't work on that cell.