### PR TITLE
Fix context menu in the file system component

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -77,6 +77,8 @@ export function registerGlobalEventHandlers() {
 
     if (target) {
       event.preventDefault();
+      // LV dispatches phx-click to the target of the preceding mousedown event
+      target.dispatchEvent(new Event("mousedown", { bubbles: true }));
       target.dispatchEvent(new Event("click", { bubbles: true }));
     }
   });


### PR DESCRIPTION
Currently right clicking on files/directories doesn't show the actions menu. We programmatically dispatch the click, however LV now stores `mousedown` target and dispatches `phx-click` to that target. I'm not convinced it should behave this way, but dispatching an additional `mousedown` doesn't hurt and it fixes the issue. See https://github.com/phoenixframework/phoenix_live_view/issues/1920#issuecomment-1135946560.