### PR TITLE
Delay update instructions

### DIFF
--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -85,9 +85,8 @@ defmodule Livebook.UpdateCheck do
 
     state =
       case response do
-        {:ok, version} ->
-          new_version = if newer?(version), do: version
-          state = %{state | new_version: new_version}
+        {:ok, release} ->
+          state = %{state | new_version: new_version(release)}
           schedule_check(state, @day_in_ms)
 
         {:error, error} ->
@@ -124,8 +123,6 @@ defmodule Livebook.UpdateCheck do
     %{state | timer_ref: nil}
   end
 
-  @one_day_in_seconds 60 * 60 * 24
-
   defp fetch_latest_version() do
     url = "https://api.github.com/repos/livebook-dev/livebook/releases/latest"
     headers = [{"accept", "application/vnd.github.v3+json"}]
@@ -133,17 +130,8 @@ defmodule Livebook.UpdateCheck do
     case Livebook.Utils.HTTP.request(:get, url, headers: headers) do
       {:ok, status, _headers, body} ->
         with 200 <- status,
-             {:ok, data} <- Jason.decode(body),
-             %{
-               "tag_name" => "v" <> version,
-               "published_at" => published_at,
-               "draft" => false,
-               "prerelease" => false
-             } <- data,
-             {:ok, published_at} <- NaiveDateTime.from_iso8601(published_at),
-             true <-
-               NaiveDateTime.diff(NaiveDateTime.utc_now(), published_at) > @one_day_in_seconds do
-          {:ok, version}
+             {:ok, release} <- Jason.decode(body) do
+          {:ok, release}
         else
           _ -> {:error, "unexpected response"}
         end
@@ -153,9 +141,27 @@ defmodule Livebook.UpdateCheck do
     end
   end
 
-  defp newer?(version) do
+  defp new_version(release) do
     current_version = Application.spec(:livebook, :vsn) |> List.to_string()
-    stable?(version) and Version.compare(current_version, version) == :lt
+
+    with %{
+           "tag_name" => "v" <> version,
+           "published_at" => published_at,
+           "draft" => false
+         } <- release,
+         {:ok, published_at} <- NaiveDateTime.from_iso8601(published_at),
+         true <- at_least_one_day_ago?(published_at) and stable?(version),
+         :lt <- Version.compare(current_version, version) do
+      version
+    else
+      _ -> nil
+    end
+  end
+
+  @one_day_in_seconds 60 * 60 * 24
+
+  defp at_least_one_day_ago?(naive_datetime) do
+    NaiveDateTime.diff(NaiveDateTime.utc_now(), naive_datetime) > @one_day_in_seconds
   end
 
   defp stable?(version) do

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -134,7 +134,12 @@ defmodule Livebook.UpdateCheck do
       {:ok, status, _headers, body} ->
         with 200 <- status,
              {:ok, data} <- Jason.decode(body),
-             %{"tag_name" => "v" <> version, "published_at" => published_at} <- data,
+             %{
+               "tag_name" => "v" <> version,
+               "published_at" => published_at,
+               "draft" => false,
+               "prerelease" => false
+             } <- data,
              {:ok, published_at} <- NaiveDateTime.from_iso8601(published_at),
              true <-
                NaiveDateTime.diff(NaiveDateTime.utc_now(), published_at) > @one_day_in_seconds do

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -134,9 +134,10 @@ defmodule Livebook.UpdateCheck do
       {:ok, status, _headers, body} ->
         with 200 <- status,
              {:ok, data} <- Jason.decode(body),
-             %{"tag_name" => "v" <> version, "created_at" => created_at} <- data,
-             {:ok, created_at} <- NaiveDateTime.from_iso8601(created_at),
-             true <- NaiveDateTime.diff(NaiveDateTime.utc_now(), created_at) > @one_day_in_seconds do
+             %{"tag_name" => "v" <> version, "published_at" => published_at} <- data,
+             {:ok, published_at} <- NaiveDateTime.from_iso8601(published_at),
+             true <-
+               NaiveDateTime.diff(NaiveDateTime.utc_now(), published_at) > @one_day_in_seconds do
           {:ok, version}
         else
           _ -> {:error, "unexpected response"}


### PR DESCRIPTION
This gives us time to update desktop artifacts
and, in case we mess something up, it avoids
everyone upgrading to a broken release at the
same time.

Also make sure it is not a draft and not a prerelease.