### PR TITLE
Allow anyone to create /app/releases/COOKIE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,5 +79,8 @@ COPY --from=build /app/_build/prod/rel/livebook /app
 # Make release files available to any user, in case someone
 # runs the container with `--user`
 RUN chmod -R go=u /app
+# Allow anyone to create files in /app/releases, in case someone
+# runs the container with `--user`
+RUN chmod 777 /app/releases
 
 CMD [ "/app/bin/livebook", "start" ]


### PR DESCRIPTION
## Context

Running 

```
docker run -p 8080:8080 -p 8081:8081 --pull always -u $(id -u):$(id -g) -v $(pwd):/data livebook/livebook
```

as specified in the README gave me this error:

```
/app/bin/livebook: 5: /app/releases/0.6.1/env.sh: cannot create /app/releases/COOKIE: Permission denied
```

This is triggered by https://github.com/livebook-dev/livebook/blob/main/rel/server/env.sh.eex#L5

## Changes

- Allow all users to create files in /app/releases (but not subdirectories)