### PR TITLE
Fix absolute URL detection when traversing markdown links

### DIFF
--- a/assets/js/lib/markdown.js
+++ b/assets/js/lib/markdown.js
@@ -134,13 +134,18 @@ function remarkExpandUrls(options) {
   return (ast) => {
     if (options.baseUrl) {
       visit(ast, "link", (node) => {
-        if (node.url && !isAbsoluteUrl(node.url) && !isPageAnchor(node.url)) {
+        if (
+          node.url &&
+          !isAbsoluteUrl(node.url) &&
+          !isInternalUrl(node.url) &&
+          !isPageAnchor(node.url)
+        ) {
           node.url = urlAppend(options.baseUrl, node.url);
         }
       });
 
       visit(ast, "image", (node) => {
-        if (node.url && !isAbsoluteUrl(node.url)) {
+        if (node.url && !isAbsoluteUrl(node.url) && !isInternalUrl(node.url)) {
           node.url = urlAppend(options.baseUrl, node.url);
         }
       });
@@ -220,7 +225,7 @@ function rehypeExternalLinks(options) {
 }
 
 function isAbsoluteUrl(url) {
-  return url.startsWith("http") || url.startsWith("/");
+  return /^(?:[a-z]+:)?\/\//i.test(url);
 }
 
 function isPageAnchor(url) {


### PR DESCRIPTION
Currently we rewrite some URLs that we are not supposed to

```markdown
<!-- Treated as absolute -->
[link](httpwhatever.livemd)
<!-- Treated as relative -->
[link](custom://ok)
```