### PR TITLE
tiny improvements to explore livebooks

### DIFF
--- a/lib/livebook/notebook/explore/distributed_portals_with_elixir.livemd
+++ b/lib/livebook/notebook/explore/distributed_portals_with_elixir.livemd
@@ -197,7 +197,7 @@ if the date is valid or not? We can use `case` to pattern match on
 the different tuples:
 
 ```elixir
-# Give a random date as input
+# Give an invalid date as input
 input = "2020-02-30"
 
 # And then match on the return value
@@ -214,7 +214,7 @@ In this example, we are using `case` to pattern match on the different
 outcomes of the `Date.from_iso8601`. We say the `case` above has two
 clauses, one matching on `{:ok, date}` and another on `{:error, reason}`.
 Now try changing the `input` variable above and reevaluate the cell
-accordingly. What happens when you give it an invalid date?
+accordingly. What happens when you give it a valid date?
 
 Finally, we can also pattern match on maps. This is used to extract the
 values for the given keys:

--- a/lib/livebook/notebook/explore/kino/intro_to_kino.livemd
+++ b/lib/livebook/notebook/explore/kino/intro_to_kino.livemd
@@ -141,8 +141,6 @@ end
 Having the rows inserted, click on the "Refetch" icon in the table output
 above to see them.
 
-Similar functionality is available for database queries via [Ecto](https://github.com/elixir-ecto/ecto) and the [`Kino.Ecto`](https://hexdocs.pm/kino/Kino.Ecto.html) module.
-
 <!-- livebook:{"branch_parent_index":0} -->
 
 ## Kino.render/1


### PR DESCRIPTION
One minor improvement to the explanation of pattern matching text, and remove dead link to `Kino.Ecto` (which doesn't exist anymore? maybe an alternative link is required now?).