### PR TITLE
Fix user profile edits to not crash on the homepage

### DIFF
--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -341,6 +341,8 @@ defmodule LivebookWeb.HomeLive do
     {:noreply, assign(socket, memory: memory)}
   end
 
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   defp files(sessions) do
     Enum.map(sessions, & &1.file)
   end

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -388,6 +388,16 @@ defmodule LivebookWeb.HomeLiveTest do
     end
   end
 
+  test "handles user profile update", %{conn: conn} do
+    {:ok, view, _} = live(conn, "/")
+
+    view
+    |> element("#user_form")
+    |> render_submit(%{data: %{hex_color: "#123456"}})
+
+    assert render(view) =~ "#123456"
+  end
+
   # Helpers
 
   defp test_notebook_path(name) do


### PR DESCRIPTION
User lifecycle hook does the necessary `handle_info`, but the the home LV doesn't have a catch-all `handle_info` and crashes. Currently it actually works, because we persist the profile change locally and LV restarts on crash.