### PR TITLE
Reinitialize JS views on reconnection

### DIFF
--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -146,6 +146,11 @@ const JSView = {
     this.props = this.getProps(this);
   },
 
+  disconnected() {
+    // Reinitialize on reconnection
+    this.el.removeAttribute("id");
+  },
+
   destroyed() {
     window.removeEventListener("message", this._handleWindowMessage);
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -233,6 +233,10 @@ const Session = {
   disconnected() {
     // Reinitialize on reconnection
     this.el.removeAttribute("id");
+
+    // If we reconnect, a new hook is mounted and it becomes responsible
+    // for leaving the channel when destroyed
+    this.keepChannel = true;
   },
 
   destroyed() {
@@ -246,7 +250,9 @@ const Session = {
 
     setFavicon("favicon");
 
-    leaveChannel();
+    if (!this.keepChannel) {
+      leaveChannel();
+    }
   },
 
   getProps() {


### PR DESCRIPTION
System hibernation may cause LV socket to disconnect ad reconnect (https://github.com/livebook-dev/livebook/issues/1015#issuecomment-1047064500). During reconnection the JS iframes are reloaded (likely because of DOM patching), so we want to reinitialize the responsible hooks altogether. Another reason for reinitialization is that the iframe may have missed some events (especially in case of collaboration).

https://user-images.githubusercontent.com/17034772/178339524-90bac050-7835-4546-ad50-5fe469f9a702.mp4