### PR TITLE
Add full view mode on notebook content

### DIFF
--- a/assets/js/hooks/editor_settings.js
+++ b/assets/js/hooks/editor_settings.js
@@ -26,6 +26,9 @@ const EditorSettings = {
     const editorMarkdownWordWrapCheckbox = this.el.querySelector(
       `[name="editor_markdown_word_wrap"][value="true"]`
     );
+    const notebookFullWidthCheckbox = this.el.querySelector(
+      `[name="notebook_full_width"][value="true"]`
+    );
 
     editorAutoCompletionCheckbox.checked = settings.editor_auto_completion;
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
@@ -34,6 +37,7 @@ const EditorSettings = {
     editorHighContrastCheckbox.checked =
       settings.editor_theme === EDITOR_THEME.highContrast ? true : false;
     editorMarkdownWordWrapCheckbox.checked = settings.editor_markdown_word_wrap;
+    notebookFullWidthCheckbox.checked = settings.notebook_full_width;
 
     editorAutoCompletionCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ editor_auto_completion: event.target.checked });
@@ -61,6 +65,10 @@ const EditorSettings = {
 
     editorMarkdownWordWrapCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ editor_markdown_word_wrap: event.target.checked });
+    });
+
+    notebookFullWidthCheckbox.addEventListener("change", (event) => {
+      settingsStore.update({ notebook_full_width: event.target.checked });
     });
   },
 };

--- a/assets/js/hooks/full_view.js
+++ b/assets/js/hooks/full_view.js
@@ -1,0 +1,23 @@
+import { settingsStore } from "../lib/settings";
+
+/**
+ * A hook used to make the notebook content in full view mode.
+ */
+const FullView = {
+  mounted() {
+    this.setWidth();
+  },
+
+  updated() {
+    this.setWidth();
+  },
+
+  setWidth() {
+    const settings = settingsStore.get();
+    if (settings.notebook_full_width) {
+      this.el.classList.remove("max-w-screen-lg");
+    }
+  },
+};
+
+export default FullView;

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -4,6 +4,7 @@ import ConfirmModal from "./confirm_modal";
 import Dropzone from "./dropzone";
 import EditorSettings from "./editor_settings";
 import FocusOnUpdate from "./focus_on_update";
+import FullView from "./full_view";
 import Headline from "./headline";
 import Highlight from "./highlight";
 import JSView from "./js_view";
@@ -22,6 +23,7 @@ export default {
   Dropzone,
   EditorSettings,
   FocusOnUpdate,
+  FullView,
   Headline,
   Highlight,
   JSView,

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS = {
   editor_font_size: EDITOR_FONT_SIZE.normal,
   editor_theme: EDITOR_THEME.default,
   editor_markdown_word_wrap: true,
+  notebook_full_width: false,
 };
 
 /**

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -145,7 +145,7 @@ defmodule LivebookWeb.SessionLive do
           autosave_interval_s={@data_view.autosave_interval_s}
           runtime={@data_view.runtime}
           global_status={@data_view.global_status} />
-        <div class="w-full max-w-screen-lg px-4 sm:pl-8 sm:pr-16 md:pl-16 pt-4 sm:py-7 mx-auto" data-el-notebook-content>
+        <div phx-hook="FullView" class="w-full max-w-screen-lg px-4 sm:pl-8 sm:pr-16 md:pl-16 pt-4 sm:py-7 mx-auto" data-el-notebook-content>
           <div class="flex items-center pb-4 mb-2 space-x-4 border-b border-gray-200"
             data-el-notebook-headline
             data-focusable-id="notebook"

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -153,6 +153,10 @@ defmodule LivebookWeb.SettingsLive do
                   name="editor_markdown_word_wrap"
                   label="Wrap words in Markdown"
                   checked={false} />
+                <.switch_checkbox
+                  name="notebook_full_width"
+                  label="Full width in notebooks"
+                  checked={false} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
| Normal width | Full Width |
|:--------------:|:----------------:|
| ![no full width](https://user-images.githubusercontent.com/19409687/180587484-23cc3d33-7009-4c89-8c86-7c2792ff5cae.png) | ![full width mode](https://user-images.githubusercontent.com/19409687/180587505-cf3d5352-580c-4397-a114-3609fadcba9c.png) |

It is really useful to have a full width mode when reading and working with a notebook, special now with smart cell where they have huge outputs.