### PR TITLE
Add shortcut for evaluating a cell and advancing to the next one

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -295,6 +295,13 @@ const Session = {
       cancelEvent(event);
       this.queueFullCellsEvaluation(true);
       return;
+    } else if (!cmd && shift && !alt && key === "Enter") {
+      cancelEvent(event);
+      if (isEvaluable(this.focusedCellType())) {
+        this.queueFocusedCellEvaluation();
+      }
+      this.moveFocus(1);
+      return;
     } else if (cmd && !alt && key === "Enter") {
       cancelEvent(event);
       if (isEvaluable(this.focusedCellType())) {

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -113,6 +113,13 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         basic: true
       },
       %{
+        seq: ["shift", "↵"],
+        seq_mac: ["⇧", "↵"],
+        press_all: true,
+        desc: "Evaluate current cell and advance to next cell",
+        basic: true
+      },
+      %{
         seq: ["ctrl", "shift", "↵"],
         seq_mac: ["⌘", "⇧", "↵"],
         press_all: true,

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -116,7 +116,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         seq: ["shift", "↵"],
         seq_mac: ["⇧", "↵"],
         press_all: true,
-        desc: "Evaluate current cell and advance to next cell",
+        desc: "Evaluate cell and advance to next one",
         basic: true
       },
       %{


### PR DESCRIPTION
Addresses #1277
> Jupyter and Deepnote let us execute the current cell and advance to the next cell using Shift + Enter.
Could this also be supported in Livebook?
> When reading through the documentation, sometimes you just want to run the current cell, see the result and move on to the next step.
> Currently, you can hit Ctrl + Enter then k (a vim thing?) but I find the single button more comfortable given the convention in other notebooks.