### PR TITLE
Queue cells on ctrl+shift+enter even when a cells is evaluating

### DIFF
--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -1893,6 +1893,8 @@ defmodule Livebook.Session.Data do
     evaluable_cell_ids =
       for {cell, _} <- evaluable_cells_with_section,
           cell_outdated?(data, cell) or cell.id in forced_cell_ids,
+          info = data.cell_infos[cell.id],
+          info.eval.status == :ready,
           uniq: true,
           do: cell.id
 

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -3562,6 +3562,20 @@ defmodule Livebook.Session.DataTest do
 
       assert Data.cell_ids_for_full_evaluation(data, ["c2"]) |> Enum.sort() == ["c2", "c3"]
     end
+
+    test "excludes evaluating and queued cells" do
+      data =
+        data_after_operations!([
+          {:insert_section, @cid, 0, "s1"},
+          {:insert_cell, @cid, "s1", 0, :code, "c1", %{}},
+          {:insert_cell, @cid, "s1", 1, :code, "c2", %{}},
+          {:insert_cell, @cid, "s1", 2, :code, "c3", %{}},
+          {:set_runtime, @cid, connected_noop_runtime()},
+          {:queue_cells_evaluation, @cid, ["c1", "c2"]}
+        ])
+
+      assert Data.cell_ids_for_full_evaluation(data, []) |> Enum.sort() == ["c3"]
+    end
   end
 
   describe "cell_ids_for_reevaluation/2" do


### PR DESCRIPTION
Currently <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>enter</kbd> doesn't do anything if there is a running cell.