### PR TITLE
Add SVG as acceptable file type in markdown

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -61,7 +61,7 @@ defmodule LivebookWeb.SessionLive do
          |> prune_outputs()
          |> prune_cell_sources()
          |> allow_upload(:cell_image,
-           accept: ~w(.jpg .jpeg .png .gif),
+           accept: ~w(.jpg .jpeg .png .gif .svg),
            max_entries: 1,
            max_file_size: 5_000_000
          )}

--- a/lib/livebook_web/live/session_live/cell_upload_component.ex
+++ b/lib/livebook_web/live/session_live/cell_upload_component.ex
@@ -17,7 +17,7 @@ defmodule LivebookWeb.SessionLive.CellUploadComponent do
       </h3>
       <%= if @uploads.cell_image.errors != [] do %>
         <div class="error-box">
-          Invalid image file. The image must be either GIF, JPEG, or PNG and cannot exceed 5MB in size.
+          Invalid image file. The image must be either GIF, JPEG, SVG or PNG and cannot exceed 5MB in size.
         </div>
       <% end %>
       <%= if @error_message do %>


### PR DESCRIPTION
This PR adds SVG as valid file type in markdown blocks

This is from the discussion started [here](https://github.com/livebook-dev/livebook/discussions/1260#discussioncomment-3065424)

And here is the example

![image](https://user-images.githubusercontent.com/23090224/184000508-041ddde8-312f-4155-8d57-fd79f1722ce6.png)
