### PR TITLE
Move toasts to the top

### DIFF
--- a/lib/livebook_web/templates/layout/live.html.heex
+++ b/lib/livebook_web/templates/layout/live.html.heex
@@ -1,50 +1,62 @@
 <main role="main" class="grow flex flex-col h-screen">
-  <div class="fixed right-8 top-5 z-50 flex flex-col space-y-3 max-h-[80%] overflow-y-auto tiny-scrollbar">
+  <div class="fixed right-8 top-5 z-[1000] flex flex-col space-y-3">
     <%= if live_flash(@flash, :info) do %>
       <div
-        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-blue-100 text-gray-600 hover:text-gray-500 cursor-pointer"
+        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-blue-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="info"
       >
         <.remix_icon icon="information-line" class="text-2xl text-blue-500" />
-        <span class="whitespace-pre-wrap"><%= live_flash(@flash, :info) %></span>
+        <span
+          class="whitespace-pre-wrap pr-2 max-h-52 overflow-y-auto tiny-scrollbar"
+          phx-no-format
+        ><%= live_flash(@flash, :info) %></span>
       </div>
     <% end %>
 
     <%= if live_flash(@flash, :success) do %>
       <div
-        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-green-100 text-gray-600 hover:text-gray-500 cursor-pointer"
+        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg pl-4 pr-2 py-2 border-l-4 rounded-l-none border-blue-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="success"
       >
-        <.remix_icon icon="checkbox-circle-fill" class="text-2xl text-green-500" />
-        <span class="whitespace-pre-wrap"><%= live_flash(@flash, :success) %></span>
+        <.remix_icon icon="checkbox-circle-fill" class="text-2xl text-blue-500" />
+        <span
+          class="whitespace-pre-wrap pr-2 max-h-52 overflow-y-auto tiny-scrollbar"
+          phx-no-format
+        ><%= live_flash(@flash, :success) %></span>
       </div>
     <% end %>
 
     <%= if live_flash(@flash, :warning) do %>
       <div
-        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-yellow-100 text-gray-600 hover:text-gray-500 cursor-pointer"
+        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-yellow-300 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="warning"
       >
         <.remix_icon icon="alert-line" class="text-2xl text-yellow-400" />
-        <span class="whitespace-pre-wrap"><%= live_flash(@flash, :warning) %></span>
+        <span
+          class="whitespace-pre-wrap pr-2 max-h-52 overflow-y-auto tiny-scrollbar"
+          phx-no-format
+        ><%= live_flash(@flash, :warning) %></span>
       </div>
     <% end %>
 
     <%= if live_flash(@flash, :error) do %>
       <div
-        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-red-100 text-gray-600 hover:text-gray-500 cursor-pointer"
+        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-red-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="error"
       >
         <.remix_icon icon="close-circle-line" class="text-2xl text-red-500" />
-        <span class="whitespace-pre-wrap"><%= live_flash(@flash, :error) %></span>
+        <span
+          class="whitespace-pre-wrap pr-2 max-h-52 overflow-y-auto tiny-scrollbar"
+          phx-no-format
+        ><%= live_flash(@flash, :error) %></span>
       </div>
     <% end %>
   </div>

--- a/lib/livebook_web/templates/layout/live.html.heex
+++ b/lib/livebook_web/templates/layout/live.html.heex
@@ -1,8 +1,8 @@
 <main role="main" class="grow flex flex-col h-screen">
-  <div class="fixed right-8 bottom-5 z-50 flex flex-col space-y-3 max-h-[80%] overflow-y-auto tiny-scrollbar">
+  <div class="fixed right-8 top-5 z-50 flex flex-col space-y-3 max-h-[80%] overflow-y-auto tiny-scrollbar">
     <%= if live_flash(@flash, :info) do %>
       <div
-        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-blue-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
+        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-blue-100 text-gray-600 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="info"
@@ -14,19 +14,19 @@
 
     <%= if live_flash(@flash, :success) do %>
       <div
-        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-blue-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
+        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-green-100 text-gray-600 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="success"
       >
-        <.remix_icon icon="checkbox-circle-fill" class="text-2xl text-blue-500" />
+        <.remix_icon icon="checkbox-circle-fill" class="text-2xl text-green-500" />
         <span class="whitespace-pre-wrap"><%= live_flash(@flash, :success) %></span>
       </div>
     <% end %>
 
     <%= if live_flash(@flash, :warning) do %>
       <div
-        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-yellow-300 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
+        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-yellow-100 text-gray-600 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="warning"
@@ -38,7 +38,7 @@
 
     <%= if live_flash(@flash, :error) do %>
       <div
-        class="shadow-custom-1 max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 border-l-4 rounded-l-none border-red-500 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-500 cursor-pointer"
+        class="max-w-2xl flex items-center space-x-3 rounded-lg px-4 py-2 bg-red-100 text-gray-600 hover:text-gray-500 cursor-pointer"
         role="alert"
         phx-click="lv:clear-flash"
         phx-value-key="error"


### PR DESCRIPTION
At the bottom they conflict with the status
indicators and are harder to notice.