### PR TITLE
Fix file system change from S3 to local

### DIFF
--- a/lib/livebook/settings.ex
+++ b/lib/livebook/settings.ex
@@ -59,7 +59,7 @@ defmodule Livebook.Settings do
         {fs_id, storage_to_fs(raw_fs)}
       end)
 
-    [{:local, Livebook.Config.local_filesystem()} | restored_file_systems]
+    [{"local", Livebook.Config.local_filesystem()} | restored_file_systems]
   end
 
   @doc """

--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -370,6 +370,8 @@ defmodule LivebookWeb.FileSelectComponent do
 
   @impl true
   def handle_event("set_file_system", %{"id" => file_system_id}, socket) do
+    file_system_id = if file_system_id == "local", do: :local, else: file_system_id
+
     {^file_system_id, file_system} =
       Enum.find(socket.assigns.file_systems, fn {id, _file_system} ->
         id == file_system_id

--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -370,8 +370,6 @@ defmodule LivebookWeb.FileSelectComponent do
 
   @impl true
   def handle_event("set_file_system", %{"id" => file_system_id}, socket) do
-    file_system_id = if file_system_id == "local", do: :local, else: file_system_id
-
     {^file_system_id, file_system} =
       Enum.find(socket.assigns.file_systems, fn {id, _file_system} ->
         id == file_system_id

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Livebook.MixProject do
   use Mix.Project
 
-  @elixir_requirement "~> 1.14-rc.0"
+  @elixir_requirement "~> 1.14-rc.1"
   @version "0.6.3"
   @description "Interactive and collaborative code notebooks - made with Phoenix LiveView"
 


### PR DESCRIPTION
I've found a tiny bug when u change back from S3 to local, we try to fetch a file system by ID (`string`) but local FS is an `atom`