### PR TITLE
Enable :sync mode when writing to the local file system

### DIFF
--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -102,7 +102,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
 
     with :ok <- ensure_local(file_system) do
       with :ok <- File.mkdir_p(dir),
-           :ok <- File.write(path, content) do
+           :ok <- File.write(path, content, [:sync]) do
         :ok
       else
         {:error, error} -> FileSystem.Utils.posix_error(error)


### PR DESCRIPTION
This ensures we always flush changes right away when saving
a notebook. This is important for Nerves Livebook, where it
is more likely the device is stopped abruptly.

cc @fhunleth