### PR TITLE
only set RELEASE_NODE if not set

### DIFF
--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -1,4 +1,4 @@
-set RELEASE_NODE=livebook_server
+if not defined RELEASE_NODE set RELEASE_NODE=livebook_server
 set RELEASE_MODE=interactive
 
 set cookie_path="!RELEASE_ROOT!\releases\COOKIE"

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -1,4 +1,4 @@
-[ -z "${RELEASE_NODE}" ] && export RELEASE_NODE=livebook_server
+export RELEASE_NODE="${RELEASE_NODE:-livebook_server}"
 export RELEASE_MODE=interactive
 
 cookie_path="${RELEASE_ROOT}/releases/COOKIE"

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -1,4 +1,4 @@
-export RELEASE_NODE=livebook_server
+[ -z "${RELEASE_NODE}" ] && export RELEASE_NODE=livebook_server
 export RELEASE_MODE=interactive
 
 cookie_path="${RELEASE_ROOT}/releases/COOKIE"


### PR DESCRIPTION
we are using docker image and we start it with erlang distribution (in `docker-compose`) to attach to locally working iex session... 

but [this](https://github.com/livebook-dev/livebook/commit/c6286e86309d0265f9fb4c7f7775e745dd96a308) change sets `RELEASE_NODE` no matter if it is already set... so setting `RELEASE_NODE=aa@bb.cc` and `RELEASE_DISTRIBUTION=name` produces:

```
=INFO REPORT==== 8-Sep-2022::18:13:30.991604 ===
Can't set long node name!
Please check your configuration

=SUPERVISOR REPORT==== 8-Sep-2022::18:13:30.991623 ===
    supervisor: {local,net_sup}
    errorContext: start_error
    reason: {'EXIT',nodistribution}
    offender: [{pid,undefined},
               {id,net_kernel},
               {mfargs,{net_kernel,start_link,
                                   [#{clean_halt => true,
                                      name => livebook_server,
                                      name_domain => longnames,
                                      supervisor => net_sup}]}},
               {restart_type,permanent},
               {significant,false},
               {shutdown,2000},
               {child_type,worker}]

{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}})

Crash dump is being written to: erl_crash.dump...done
```

this *SHOULD* fix that... I've only tested this "manually" 