### PR TITLE
Fix Markdown formatting of narrow table columns

### DIFF
--- a/lib/livebook/live_markdown/markdown_helpers.ex
+++ b/lib/livebook/live_markdown/markdown_helpers.ex
@@ -353,6 +353,7 @@ defmodule Livebook.LiveMarkdown.MarkdownHelpers do
       cells
       |> Enum.map(&IO.iodata_length/1)
       |> Enum.max()
+      |> max(3)
     end)
   end
 

--- a/test/livebook/live_markdown/markdown_helpers_test.exs
+++ b/test/livebook/live_markdown/markdown_helpers_test.exs
@@ -205,8 +205,18 @@ defmodule Livebook.LiveMarkdown.MarkdownHelpersTest do
 
     test "table without header" do
       markdown = """
-      | Texas | TX | Austin  |
-      | Maine | ME | Augusta |\
+      | Texas | TX  | Austin  |
+      | Maine | ME  | Augusta |\
+      """
+
+      assert markdown == reformat(markdown)
+    end
+
+    test "table with narrow column" do
+      markdown = """
+      | x   | y   | x and y |
+      | :-: | --- | ------- |
+      | 1   | 1   | 0       |\
       """
 
       assert markdown == reformat(markdown)


### PR DESCRIPTION
Today it crashes if the column content is less than 3 characters wide.