### PR TITLE
Add importJS to the JS view client context

### DIFF
--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -26,7 +26,7 @@ import { sha256Base64 } from "../../lib/utils";
 // (2): https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 // (3): https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 
-const IFRAME_SHA256 = "Ogec/87xIEbz3xVctg9QCMqCPCTCf6vyL88bl41PR3I=";
+const IFRAME_SHA256 = "Hv1+aRcOVLP2dGLIOC9EPGA6Tv1pOhsN8bcUpoAsrfI=";
 
 export function initializeIframeSource(iframe, iframePort, iframeUrl) {
   const url = getIframeUrl(iframePort, iframeUrl);

--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -26,7 +26,7 @@ import { sha256Base64 } from "../../lib/utils";
 // (2): https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 // (3): https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 
-const IFRAME_SHA256 = "Hv1+aRcOVLP2dGLIOC9EPGA6Tv1pOhsN8bcUpoAsrfI=";
+const IFRAME_SHA256 = "vd7g1B8fLBFZH6C6KNpG4H8B0SQ/oIuqKaTW6jD053A=";
 
 export function initializeIframeSource(iframe, iframePort, iframeUrl) {
   const url = getIframeUrl(iframePort, iframeUrl);

--- a/iframe/priv/static/iframe/v4.html
+++ b/iframe/priv/static/iframe/v4.html
@@ -78,6 +78,21 @@
             });
           },
 
+          importJS(url) {
+            return new Promise((resolve, reject) => {
+              const scriptEl = document.createElement("script");
+              scriptEl.addEventListener(
+                "load",
+                (event) => {
+                  resolve();
+                },
+                { once: true }
+              );
+              scriptEl.src = url;
+              document.head.appendChild(scriptEl);
+            });
+          },
+
           handleSync(callback) {
             state.syncHandler = callback;
           },

--- a/iframe/priv/static/iframe/v4.html
+++ b/iframe/priv/static/iframe/v4.html
@@ -97,7 +97,7 @@
             state.syncHandler = callback;
           },
 
-          selectSecret(callback, preselectName, options) {
+          selectSecret(callback, preselectName, options = {}) {
             state.secretHandler = callback;
             postMessage({ type: "selectSecret", preselectName, options });
           },


### PR DESCRIPTION
Using the `import` syntax works for a group of cases, but depending on how JS packages are distributed, we may need to import them using a `<script>` tag, rather than a module. This adds `importJS` akin to `importCSS`, just so we have this option.

(Adding it now, since we are releasing a new version of the iframe html anyway)