### PR TITLE
Add support for JavaScript highlighting in Markdown cells

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -55,7 +55,7 @@ module.exports = (env, options) => {
       }),
       new MiniCssExtractPlugin({ filename: "../css/app.css" }),
       new MonacoWebpackPlugin({
-        languages: ["markdown", "elixir", "xml", "json", "sql", "html", "css", "javascript", "js"],
+        languages: ["markdown", "elixir", "xml", "json", "sql", "html", "css", "javascript"],
       }),
     ],
     optimization: {

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -55,7 +55,7 @@ module.exports = (env, options) => {
       }),
       new MiniCssExtractPlugin({ filename: "../css/app.css" }),
       new MonacoWebpackPlugin({
-        languages: ["markdown", "elixir", "xml", "json", "sql", "html", "css"],
+        languages: ["markdown", "elixir", "xml", "json", "sql", "html", "css", "javascript", "js"],
       }),
     ],
     optimization: {


### PR DESCRIPTION
Include javascript in editor highlighting

![image](https://user-images.githubusercontent.com/14877564/191871652-fceec659-5ccb-44ec-a347-fe758cdb7d17.png)

Closes #1425 