### PR TITLE
Change Hexdocs link caption

### DIFF
--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -503,7 +503,7 @@ defmodule Livebook.Intellisense do
 
     if vsn = app && Application.spec(app, :vsn) do
       url = "https://hexdocs.pm/#{app}/#{vsn}/#{inspect(module)}.html#{hash}"
-      "[view on hexdocs](#{url})"
+      "[View on Hexdocs](#{url})"
     end
   end
 

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -503,7 +503,7 @@ defmodule Livebook.Intellisense do
 
     if vsn = app && Application.spec(app, :vsn) do
       url = "https://hexdocs.pm/#{app}/#{vsn}/#{inspect(module)}.html#{hash}"
-      "[Hexdocs](#{url})"
+      "[view on hexdocs](#{url})"
     end
   end
 


### PR DESCRIPTION

What do you think about matching VScode?

### VScode
<img width="997" alt="image" src="https://user-images.githubusercontent.com/43606066/192766684-17bf38f2-8364-4130-9bb9-3ac8272989bd.png">

## Livebook
<img width="940" alt="image" src="https://user-images.githubusercontent.com/43606066/192767497-242c7a87-6643-4e24-95b6-3c4d6f916ddf.png">

