### PR TITLE
Final touchups to secrets

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -124,7 +124,7 @@
   }
 
   .switch-button {
-    @apply relative inline-block w-14 h-7 mr-2 select-none;
+    @apply relative inline-block w-14 h-7 select-none;
   }
 
   .switch-button--disabled {

--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -53,11 +53,9 @@ defmodule Livebook.Hubs do
   @spec save_hub(Provider.t()) :: Provider.t()
   def save_hub(struct) do
     attributes = struct |> Map.from_struct() |> Map.to_list()
-
-    with :ok <- Storage.insert(@namespace, struct.id, attributes),
-         :ok <- broadcast_hubs_change() do
-      struct
-    end
+    :ok = Storage.insert(@namespace, struct.id, attributes)
+    :ok = broadcast_hubs_change()
+    struct
   end
 
   @doc false

--- a/lib/livebook/hubs/fly_client.ex
+++ b/lib/livebook/hubs/fly_client.ex
@@ -62,7 +62,7 @@ defmodule Livebook.Hubs.FlyClient do
     end
   end
 
-  def put_secrets(%Fly{access_token: access_token, application_id: application_id}, secrets) do
+  def set_secrets(%Fly{access_token: access_token, application_id: application_id}, secrets) do
     mutation = """
     mutation($input: SetSecretsInput!) {
       setSecrets(input: $input) {
@@ -85,7 +85,7 @@ defmodule Livebook.Hubs.FlyClient do
     end
   end
 
-  def delete_secrets(%Fly{access_token: access_token, application_id: application_id}, keys) do
+  def unset_secrets(%Fly{access_token: access_token, application_id: application_id}, keys) do
     mutation = """
     mutation($input: UnsetSecretsInput!) {
       unsetSecrets(input: $input) {

--- a/lib/livebook/secrets/secret.ex
+++ b/lib/livebook/secrets/secret.ex
@@ -18,7 +18,7 @@ defmodule Livebook.Secrets.Secret do
     |> cast(attrs, [:name, :value])
     |> update_change(:name, &String.upcase/1)
     |> validate_format(:name, ~r/^\w+$/,
-      message: "should contain only alphanumeric and underscore"
+      message: "should contain only alphanumeric characters and underscore"
     )
     |> validate_required([:name, :value])
   end

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -505,17 +505,17 @@ defmodule Livebook.Session do
   @doc """
   Sends a secret addition request to the server.
   """
-  @spec put_secret(pid(), map()) :: :ok
-  def put_secret(pid, secret) do
-    GenServer.cast(pid, {:put_secret, self(), secret})
+  @spec set_secret(pid(), map()) :: :ok
+  def set_secret(pid, secret) do
+    GenServer.cast(pid, {:set_secret, self(), secret})
   end
 
   @doc """
   Sends a secret deletion request to the server.
   """
-  @spec delete_secret(pid(), map()) :: :ok
-  def delete_secret(pid, secret_name) do
-    GenServer.cast(pid, {:delete_secret, self(), secret_name})
+  @spec unset_secret(pid(), map()) :: :ok
+  def unset_secret(pid, secret_name) do
+    GenServer.cast(pid, {:unset_secret, self(), secret_name})
   end
 
   @doc """
@@ -980,15 +980,15 @@ defmodule Livebook.Session do
     end
   end
 
-  def handle_cast({:put_secret, client_pid, secret}, state) do
+  def handle_cast({:set_secret, client_pid, secret}, state) do
     client_id = client_id(state, client_pid)
-    operation = {:put_secret, client_id, secret}
+    operation = {:set_secret, client_id, secret}
     {:noreply, handle_operation(state, operation)}
   end
 
-  def handle_cast({:delete_secret, client_pid, secret_name}, state) do
+  def handle_cast({:unset_secret, client_pid, secret_name}, state) do
     client_id = client_id(state, client_pid)
-    operation = {:delete_secret, client_id, secret_name}
+    operation = {:unset_secret, client_id, secret_name}
     {:noreply, handle_operation(state, operation)}
   end
 
@@ -1451,12 +1451,12 @@ defmodule Livebook.Session do
     state
   end
 
-  defp after_operation(state, _prev_state, {:put_secret, _client_id, secret}) do
+  defp after_operation(state, _prev_state, {:set_secret, _client_id, secret}) do
     if Runtime.connected?(state.data.runtime), do: set_runtime_secret(state, secret)
     state
   end
 
-  defp after_operation(state, _prev_state, {:delete_secret, _client_id, secret_name}) do
+  defp after_operation(state, _prev_state, {:unset_secret, _client_id, secret_name}) do
     if Runtime.connected?(state.data.runtime), do: delete_runtime_secrets(state, [secret_name])
     state
   end

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -193,8 +193,8 @@ defmodule Livebook.Session.Data do
           | {:set_file, client_id(), FileSystem.File.t() | nil}
           | {:set_autosave_interval, client_id(), non_neg_integer() | nil}
           | {:mark_as_not_dirty, client_id()}
-          | {:put_secret, client_id(), secret()}
-          | {:delete_secret, client_id(), String.t()}
+          | {:set_secret, client_id(), secret()}
+          | {:unset_secret, client_id(), String.t()}
 
   @type action ::
           :connect_runtime
@@ -764,17 +764,17 @@ defmodule Livebook.Session.Data do
     |> wrap_ok()
   end
 
-  def apply_operation(data, {:put_secret, _client_id, secret}) do
+  def apply_operation(data, {:set_secret, _client_id, secret}) do
     data
     |> with_actions()
-    |> put_secret(secret)
+    |> set_secret(secret)
     |> wrap_ok()
   end
 
-  def apply_operation(data, {:delete_secret, _client_id, secret_name}) do
+  def apply_operation(data, {:unset_secret, _client_id, secret_name}) do
     data
     |> with_actions()
-    |> delete_secret(secret_name)
+    |> unset_secret(secret_name)
     |> wrap_ok()
   end
 
@@ -1515,12 +1515,12 @@ defmodule Livebook.Session.Data do
     end
   end
 
-  defp put_secret({data, _} = data_actions, secret) do
+  defp set_secret({data, _} = data_actions, secret) do
     secrets = Map.put(data.secrets, secret.name, secret.value)
     set!(data_actions, secrets: secrets)
   end
 
-  defp delete_secret({data, _} = data_actions, secret_name) do
+  defp unset_secret({data, _} = data_actions, secret_name) do
     secrets = Map.delete(data.secrets, secret_name)
     set!(data_actions, secrets: secrets)
   end

--- a/lib/livebook/settings.ex
+++ b/lib/livebook/settings.ex
@@ -159,17 +159,15 @@ defmodule Livebook.Settings do
     changeset = EnvVar.changeset(env_var, attrs)
 
     with {:ok, env_var} <- apply_action(changeset, :insert) do
-      save_env_var(env_var)
+      {:ok, save_env_var(env_var)}
     end
   end
 
   defp save_env_var(env_var) do
     attributes = env_var |> Map.from_struct() |> Map.to_list()
-
-    with :ok <- Storage.insert(:env_vars, env_var.name, attributes),
-         :ok <- broadcast_env_vars_change({:env_var_set, env_var}) do
-      {:ok, env_var}
-    end
+    :ok = Storage.insert(:env_vars, env_var.name, attributes)
+    :ok = broadcast_env_vars_change({:env_var_set, env_var})
+    env_var
   end
 
   @doc """

--- a/lib/livebook_web/live/hub/edit/fly_component.ex
+++ b/lib/livebook_web/live/hub/edit/fly_component.ex
@@ -161,7 +161,7 @@ defmodule LivebookWeb.Hub.Edit.FlyComponent do
     env_operation = attrs["operation"]
     attrs = %{"key" => attrs["name"], "value" => attrs["value"]}
 
-    case FlyClient.put_secrets(socket.assigns.hub, [attrs]) do
+    case FlyClient.set_secrets(socket.assigns.hub, [attrs]) do
       {:ok, _} ->
         message =
           if env_operation == "new",
@@ -192,7 +192,7 @@ defmodule LivebookWeb.Hub.Edit.FlyComponent do
   end
 
   def handle_event("delete_env_var", %{"env_var" => key}, socket) do
-    case FlyClient.delete_secrets(socket.assigns.hub, [key]) do
+    case FlyClient.unset_secrets(socket.assigns.hub, [key]) do
       {:ok, _} ->
         {:noreply,
          socket

--- a/test/livebook/hubs/fly_client_test.exs
+++ b/test/livebook/hubs/fly_client_test.exs
@@ -115,7 +115,7 @@ defmodule Livebook.Hubs.FlyClientTest do
     end
   end
 
-  describe "put_secrets/2" do
+  describe "set_secrets/2" do
     test "puts a list of secrets inside application", %{bypass: bypass} do
       secrets = [
         %{
@@ -135,7 +135,7 @@ defmodule Livebook.Hubs.FlyClientTest do
       end)
 
       hub = build(:fly)
-      assert {:ok, ^secrets} = FlyClient.put_secrets(hub, [%{key: "FOO", value: "BAR"}])
+      assert {:ok, ^secrets} = FlyClient.set_secrets(hub, [%{key: "FOO", value: "BAR"}])
     end
 
     test "returns error when input is invalid", %{bypass: bypass} do
@@ -172,7 +172,7 @@ defmodule Livebook.Hubs.FlyClientTest do
       end)
 
       hub = build(:fly)
-      assert {:error, ^message} = FlyClient.put_secrets(hub, [%{key: "FOO", Value: "BAR"}])
+      assert {:error, ^message} = FlyClient.set_secrets(hub, [%{key: "FOO", Value: "BAR"}])
     end
 
     test "returns unauthorized when token is invalid", %{bypass: bypass} do
@@ -188,11 +188,11 @@ defmodule Livebook.Hubs.FlyClientTest do
       hub = build(:fly)
 
       assert {:error, "request failed with code: UNAUTHORIZED"} =
-               FlyClient.put_secrets(hub, [%{key: "FOO", value: "BAR"}])
+               FlyClient.set_secrets(hub, [%{key: "FOO", value: "BAR"}])
     end
   end
 
-  describe "delete_secrets/2" do
+  describe "unset_secrets/2" do
     test "deletes a list of secrets inside application", %{bypass: bypass} do
       response = %{"data" => %{"unsetSecrets" => %{"app" => %{"secrets" => []}}}}
 
@@ -203,7 +203,7 @@ defmodule Livebook.Hubs.FlyClientTest do
       end)
 
       hub = build(:fly)
-      assert {:ok, []} = FlyClient.delete_secrets(hub, ["FOO"])
+      assert {:ok, []} = FlyClient.unset_secrets(hub, ["FOO"])
     end
 
     test "returns unauthorized when token is invalid", %{bypass: bypass} do
@@ -219,7 +219,7 @@ defmodule Livebook.Hubs.FlyClientTest do
       hub = build(:fly)
 
       assert {:error, "request failed with code: UNAUTHORIZED"} =
-               FlyClient.delete_secrets(hub, ["FOO"])
+               FlyClient.unset_secrets(hub, ["FOO"])
     end
   end
 end

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -205,10 +205,10 @@ defmodule LivebookWeb.Hub.EditLiveTest do
       response =
         cond do
           body["query"] =~ "setSecrets" ->
-            put_secrets_response()
+            set_secrets_response()
 
           body["query"] =~ "unsetSecrets" ->
-            delete_secrets_response()
+            unset_secrets_response()
 
           true ->
             Agent.get(agent_pid, fn
@@ -299,11 +299,11 @@ defmodule LivebookWeb.Hub.EditLiveTest do
     ]
   end
 
-  defp put_secrets_response do
+  defp set_secrets_response do
     %{"data" => %{"setSecrets" => %{"app" => %{"secrets" => secrets(:add)}}}}
   end
 
-  defp delete_secrets_response do
+  defp unset_secrets_response do
     %{"data" => %{"unsetSecrets" => %{"app" => %{"secrets" => secrets(:mount)}}}}
   end
 end

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -5,6 +5,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
   alias Livebook.{Sessions, Session, Settings, Runtime, Users, FileSystem}
   alias Livebook.Notebook.Cell
+  alias Livebook.Secrets.Secret
 
   setup do
     {:ok, session} = Sessions.create_session(notebook: Livebook.Notebook.new())
@@ -948,13 +949,13 @@ defmodule LivebookWeb.SessionLiveTest do
       |> element(~s{form[phx-submit="save"]})
       |> render_submit(%{data: %{name: "bar", value: "456", store: "livebook"}})
 
-      assert %Livebook.Secrets.Secret{name: "BAR", value: "456"} in Livebook.Secrets.fetch_secrets()
+      assert %Secret{name: "BAR", value: "456"} in Livebook.Secrets.fetch_secrets()
     end
 
     test "sync secrets when they're equal", %{conn: conn, session: session} do
-      Livebook.Secrets.set_secret(%{name: "FOO", value: "123"})
+      Livebook.Secrets.set_secret(%Secret{name: "FOO", value: "123"})
       {:ok, view, _} = live(conn, "/sessions/#{session.id}/secrets")
-      Session.put_secret(session.pid, %{name: "FOO", value: "123"})
+      Session.set_secret(session.pid, %{name: "FOO", value: "123"})
 
       view
       |> element(~s{form[phx-submit="save"]})
@@ -962,13 +963,13 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert %{secrets: %{"FOO" => "456"}} = Session.get_data(session.pid)
 
-      assert %Livebook.Secrets.Secret{name: "FOO", value: "456"} in Livebook.Secrets.fetch_secrets()
+      assert %Secret{name: "FOO", value: "456"} in Livebook.Secrets.fetch_secrets()
     end
 
     test "doesn't sync secrets when they are not the same", %{conn: conn, session: session} do
-      Livebook.Secrets.set_secret(%{name: "FOO_BAR", value: "456"})
+      Livebook.Secrets.set_secret(%Secret{name: "FOO_BAR", value: "456"})
       {:ok, view, _} = live(conn, "/sessions/#{session.id}/secrets")
-      Session.put_secret(session.pid, %{name: "FOO_BAR", value: "123"})
+      Session.set_secret(session.pid, %{name: "FOO_BAR", value: "123"})
 
       view
       |> element(~s{form[phx-submit="save"]})
@@ -976,15 +977,15 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert %{secrets: %{"FOO_BAR" => "123"}} = Session.get_data(session.pid)
 
-      assert %Livebook.Secrets.Secret{name: "FOO_BAR", value: "999"} in Livebook.Secrets.fetch_secrets()
+      assert %Secret{name: "FOO_BAR", value: "999"} in Livebook.Secrets.fetch_secrets()
 
-      refute %Livebook.Secrets.Secret{name: "FOO_BAR", value: "456"} in Livebook.Secrets.fetch_secrets()
+      refute %Secret{name: "FOO_BAR", value: "456"} in Livebook.Secrets.fetch_secrets()
     end
 
     test "never sync secrets when updating from session", %{conn: conn, session: session} do
-      Livebook.Secrets.set_secret(%{name: "FOO", value: "123"})
+      Livebook.Secrets.set_secret(%Secret{name: "FOO", value: "123"})
       {:ok, view, _} = live(conn, "/sessions/#{session.id}/secrets")
-      Session.put_secret(session.pid, %{name: "FOO", value: "123"})
+      Session.set_secret(session.pid, %{name: "FOO", value: "123"})
 
       view
       |> element(~s{form[phx-submit="save"]})
@@ -992,9 +993,9 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert %{secrets: %{"FOO" => "456"}} = Session.get_data(session.pid)
 
-      refute %Livebook.Secrets.Secret{name: "FOO", value: "456"} in Livebook.Secrets.fetch_secrets()
+      refute %Secret{name: "FOO", value: "456"} in Livebook.Secrets.fetch_secrets()
 
-      assert %Livebook.Secrets.Secret{name: "FOO", value: "123"} in Livebook.Secrets.fetch_secrets()
+      assert %Secret{name: "FOO", value: "123"} in Livebook.Secrets.fetch_secrets()
     end
 
     test "shows the 'Add secret' button for unavailable secrets", %{conn: conn, session: session} do


### PR DESCRIPTION
* Use font-mono on secret names
* Unify error handling with changesets
* Unify put_env/delete_env as set_env/unset_env
* Review text

<img width="582" alt="Screenshot 2022-10-06 at 21 35 15" src="https://user-images.githubusercontent.com/9582/194403225-b15334df-87be-4997-8169-ec59202456ee.png">
<img width="1201" alt="Screenshot 2022-10-06 at 21 35 29" src="https://user-images.githubusercontent.com/9582/194403232-eb2ac8db-b4a0-4efc-b75b-171cdd82b60e.png">
<img width="1231" alt="Screenshot 2022-10-06 at 21 34 47" src="https://user-images.githubusercontent.com/9582/194403216-2623ed66-eb89-42e1-bc52-d2e9f9f149a4.png">
