### PR TITLE
Downgrade Monaco editor to fix Mermaid graph editing

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -16,7 +16,7 @@
         "hyperlist": "^1.0.0",
         "jest": "^29.1.2",
         "mermaid": "^9.1.3",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "0.33.0",
         "morphdom": "^2.6.1",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
@@ -56,14 +56,14 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.6.11",
+      "version": "1.6.13",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
       "version": "3.2.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.17.11",
+      "version": "0.18.2",
       "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
@@ -9032,9 +9032,9 @@
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.0.1",
@@ -18244,9 +18244,9 @@
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
     },
     "monaco-editor-webpack-plugin": {
       "version": "7.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,7 +20,7 @@
     "hyperlist": "^1.0.0",
     "jest": "^29.1.2",
     "mermaid": "^9.1.3",
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "0.33.0",
     "morphdom": "^2.6.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",


### PR DESCRIPTION
Closes #1470.

A regression in Monaco editor broke editing Markdown code blocks with unknown language. @josevalim it's probably worth a patch release, wdyt?