### PR TITLE
Delete and view secrets from the sidebar

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -132,11 +132,11 @@
   }
 
   .switch-button__checkbox {
-    @apply appearance-none absolute block w-7 h-7 rounded-full bg-gray-400 border-[5px] border-gray-100 cursor-pointer transition-all duration-300;
+    @apply appearance-none absolute block w-7 h-7 rounded-full bg-white border-[5px] border-gray-200 cursor-pointer transition-all duration-300;
   }
 
   .switch-button__bg {
-    @apply block h-full w-full rounded-full bg-gray-100 cursor-pointer transition-all duration-300;
+    @apply block h-full w-full rounded-full bg-gray-200 cursor-pointer transition-all duration-300;
   }
 
   .switch-button__checkbox:checked {

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -570,50 +570,59 @@ defmodule LivebookWeb.SessionLive do
         <div class="flex flex-col space-y-4 mt-6">
           <%= for {secret_name, secret_value} <- session_only_secrets(@data_view.secrets, @livebook_secrets) do %>
             <div
-              class="flex justify-between items-center text-gray-500"
-              id={"session-secret-#{secret_name}-title"}
+              class="flex flex-col text-gray-500 rounded-lg px-2 pt-1"
+              id={"session-secret-#{secret_name}-wrapper"}
             >
               <span
-                class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
+                class="text-sm font-mono break-all w-full cursor-pointer"
+                id={"session-secret-#{secret_name}-title"}
                 phx-click={
                   JS.toggle(to: "#session-secret-#{secret_name}-title")
                   |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+                  |> JS.add_class("bg-gray-100",
+                    to: "#session-secret-#{secret_name}-wrapper"
+                  )
                 }
               >
                 <%= secret_name %>
               </span>
-            </div>
-            <div
-              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden cursor-pointer"
-              id={"session-secret-#{secret_name}-detail"}
-              phx-click={
-                JS.toggle(to: "#session-secret-#{secret_name}-title")
-                |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
-              }
-            >
-              <span class="text-sm font-mono break-all flex-row">
-                <%= secret_name %>
-              </span>
-              <div class="flex flex-row justify-between items-center">
-                <span class="text-sm font-mono break-all flex-row">
-                  <%= secret_value %>
-                </span>
-                <button
-                  id={"app-secret-#{secret_name}-delete"}
-                  type="button"
-                  phx-click={
-                    with_confirm(
-                      JS.push("delete_session_secret", value: %{secret_name: secret_name}),
-                      title: "Delete session secret - #{secret_name}",
-                      description: "Are you sure you want to delete this session secret?",
-                      confirm_text: "Delete",
-                      confirm_icon: "delete-bin-6-line"
-                    )
-                  }
-                  class="hover:text-red-600"
-                >
-                  <.remix_icon icon="delete-bin-line" />
-                </button>
+              <div
+                class="flex flex-col text-gray-500 hidden cursor-pointer"
+                id={"session-secret-#{secret_name}-detail"}
+                phx-click={
+                  JS.toggle(to: "#session-secret-#{secret_name}-title")
+                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+                  |> JS.remove_class("bg-gray-100",
+                    to: "#session-secret-#{secret_name}-wrapper"
+                  )
+                }
+              >
+                <div class="flex flex-col">
+                  <span class="text-sm font-mono break-all flex-row">
+                    <%= secret_name %>
+                  </span>
+                  <div class="flex flex-row justify-between items-center">
+                    <span class="text-sm font-mono break-all flex-row">
+                      <%= secret_value %>
+                    </span>
+                    <button
+                      id={"session-secret-#{secret_name}-delete"}
+                      type="button"
+                      phx-click={
+                        with_confirm(
+                          JS.push("delete_session_secret", value: %{secret_name: secret_name}),
+                          title: "Delete session secret - #{secret_name}",
+                          description: "Are you sure you want to delete this session secret?",
+                          confirm_text: "Delete",
+                          confirm_icon: "delete-bin-6-line"
+                        )
+                      }
+                      class="hover:text-red-600"
+                    >
+                      <.remix_icon icon="delete-bin-line" />
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           <% end %>
@@ -636,48 +645,76 @@ defmodule LivebookWeb.SessionLive do
 
         <div class="flex flex-col space-y-4 mt-6">
           <%= for {secret_name, secret_value} = secret <- Enum.sort(@livebook_secrets) do %>
-            <div class="flex justify-between items-center text-gray-500">
-              <span
-                class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
-                phx-click={JS.toggle(to: "#app-secret-#{secret_name}")}
-              >
-                <%= secret_name %>
-              </span>
-              <.switch_checkbox
-                name="toggle_secret"
-                checked={is_secret_on_session?(secret, @data_view.secrets)}
-                phx-click="toggle_secret"
-                phx-value-secret_name={secret_name}
-                phx-value-secret_value={secret_value}
-              />
-            </div>
             <div
-              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden"
-              id={"app-secret-#{secret_name}"}
+              class="flex flex-col text-gray-500 rounded-lg px-2 pt-1"
+              id={"app-secret-#{secret_name}-wrapper"}
             >
-              <span class="text-sm font-mono break-all flex-row">
-                <%= secret_name %>
-              </span>
-              <div class="flex flex-row justify-between items-center">
-                <span class="text-sm font-mono break-all flex-row">
-                  <%= secret_value %>
-                </span>
-                <button
-                  id={"app-secret-#{secret_name}-delete"}
-                  type="button"
+              <div class="flex" id={"app-secret-#{secret_name}-title"}>
+                <span
+                  class="text-sm font-mono break-all w-full cursor-pointer flex flex-row justify-between items-center"
                   phx-click={
-                    with_confirm(
-                      JS.push("delete_app_secret", value: %{secret_name: secret_name}),
-                      title: "Delete app secret - #{secret_name}",
-                      description: "Are you sure you want to delete this app secret?",
-                      confirm_text: "Delete",
-                      confirm_icon: "delete-bin-6-line"
+                    JS.add_class("hidden", to: "#app-secret-#{secret_name}-title")
+                    |> JS.remove_class("hidden", to: "#app-secret-#{secret_name}-detail")
+                    |> JS.add_class("bg-gray-100",
+                      to: "#app-secret-#{secret_name}-wrapper"
                     )
                   }
-                  class="hover:text-red-600"
                 >
-                  <.remix_icon icon="delete-bin-line" />
-                </button>
+                  <%= secret_name %>
+                </span>
+                <.switch_checkbox
+                  name="toggle_secret"
+                  checked={is_secret_on_session?(secret, @data_view.secrets)}
+                  phx-click="toggle_secret"
+                  phx-value-secret_name={secret_name}
+                  phx-value-secret_value={secret_value}
+                />
+              </div>
+              <div class="flex flex-col text-gray-500 hidden" id={"app-secret-#{secret_name}-detail"}>
+                <div class="flex flex-col">
+                  <div class="flex justify-between items-center">
+                    <span
+                      class="text-sm font-mono break-all flex-row cursor-pointer"
+                      phx-click={
+                        JS.remove_class("hidden", to: "#app-secret-#{secret_name}-title")
+                        |> JS.add_class("hidden", to: "#app-secret-#{secret_name}-detail")
+                        |> JS.remove_class("bg-gray-100",
+                          to: "#app-secret-#{secret_name}-wrapper"
+                        )
+                      }
+                    >
+                      <%= secret_name %>
+                    </span>
+                    <.switch_checkbox
+                      name="toggle_secret"
+                      checked={is_secret_on_session?(secret, @data_view.secrets)}
+                      phx-click="toggle_secret"
+                      phx-value-secret_name={secret_name}
+                      phx-value-secret_value={secret_value}
+                    />
+                  </div>
+                  <div class="flex flex-row justify-between items-center">
+                    <span class="text-sm font-mono break-all flex-row">
+                      <%= secret_value %>
+                    </span>
+                    <button
+                      id={"app-secret-#{secret_name}-delete"}
+                      type="button"
+                      phx-click={
+                        with_confirm(
+                          JS.push("delete_app_secret", value: %{secret_name: secret_name}),
+                          title: "Delete app secret - #{secret_name}",
+                          description: "Are you sure you want to delete this app secret?",
+                          confirm_text: "Delete",
+                          confirm_icon: "delete-bin-6-line"
+                        )
+                      }
+                      class="hover:text-red-600"
+                    >
+                      <.remix_icon icon="delete-bin-line" />
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           <% end %>

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -574,7 +574,7 @@ defmodule LivebookWeb.SessionLive do
               id={"session-secret-#{secret_name}-wrapper"}
             >
               <span
-                class="text-sm font-mono break-all w-full cursor-pointer"
+                class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
                 id={"session-secret-#{secret_name}-title"}
                 phx-click={
                   JS.toggle(to: "#session-secret-#{secret_name}-title")
@@ -587,7 +587,7 @@ defmodule LivebookWeb.SessionLive do
                 <%= secret_name %>
               </span>
               <div
-                class="flex flex-col text-gray-500 hidden cursor-pointer"
+                class="flex flex-col text-gray-800 hidden"
                 id={"session-secret-#{secret_name}-detail"}
                 phx-click={
                   JS.toggle(to: "#session-secret-#{secret_name}-title")
@@ -598,7 +598,7 @@ defmodule LivebookWeb.SessionLive do
                 }
               >
                 <div class="flex flex-col">
-                  <span class="text-sm font-mono break-all flex-row">
+                  <span class="text-sm font-mono break-all flex-row cursor-pointer">
                     <%= secret_name %>
                   </span>
                   <div class="flex flex-row justify-between items-center">
@@ -651,7 +651,7 @@ defmodule LivebookWeb.SessionLive do
             >
               <div class="flex" id={"app-secret-#{secret_name}-title"}>
                 <span
-                  class="text-sm font-mono break-all w-full cursor-pointer flex flex-row justify-between items-center"
+                  class="text-sm font-mono break-all w-full cursor-pointer flex flex-row justify-between items-center hover:text-gray-800"
                   phx-click={
                     JS.add_class("hidden", to: "#app-secret-#{secret_name}-title")
                     |> JS.remove_class("hidden", to: "#app-secret-#{secret_name}-detail")
@@ -670,7 +670,7 @@ defmodule LivebookWeb.SessionLive do
                   phx-value-secret_value={secret_value}
                 />
               </div>
-              <div class="flex flex-col text-gray-500 hidden" id={"app-secret-#{secret_name}-detail"}>
+              <div class="flex flex-col text-gray-800 hidden" id={"app-secret-#{secret_name}-detail"}>
                 <div class="flex flex-col">
                   <div class="flex justify-between items-center">
                     <span

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -569,17 +569,27 @@ defmodule LivebookWeb.SessionLive do
       <div class="flex flex-col">
         <div class="flex flex-col space-y-4 mt-6">
           <%= for {secret_name, secret_value} <- session_only_secrets(@data_view.secrets, @livebook_secrets) do %>
-            <div class="flex justify-between items-center text-gray-500">
+            <div
+              class="flex justify-between items-center text-gray-500"
+              id={"session-secret-#{secret_name}-title"}
+            >
               <span
                 class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
-                phx-click={JS.toggle(to: "#session-secret-#{secret_name}")}
+                phx-click={
+                  JS.toggle(to: "#session-secret-#{secret_name}-title")
+                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+                }
               >
                 <%= secret_name %>
               </span>
             </div>
             <div
-              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden"
-              id={"session-secret-#{secret_name}"}
+              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden cursor-pointer"
+              id={"session-secret-#{secret_name}-detail"}
+              phx-click={
+                JS.toggle(to: "#session-secret-#{secret_name}-title")
+                |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+              }
             >
               <span class="text-sm font-mono break-all flex-row">
                 <%= secret_name %>

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -674,7 +674,7 @@ defmodule LivebookWeb.SessionLive do
                 <div class="flex flex-col">
                   <div class="flex justify-between items-center">
                     <span
-                      class="text-sm font-mono break-all flex-row cursor-pointer"
+                      class="text-sm font-mono w-full break-all flex-row cursor-pointer"
                       phx-click={
                         JS.remove_class("hidden", to: "#app-secret-#{secret_name}-title")
                         |> JS.add_class("hidden", to: "#app-secret-#{secret_name}-detail")

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -577,8 +577,8 @@ defmodule LivebookWeb.SessionLive do
                 class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
                 id={"session-secret-#{secret_name}-title"}
                 phx-click={
-                  JS.toggle(to: "#session-secret-#{secret_name}-title")
-                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+                  JS.add_class("hidden", to: "#session-secret-#{secret_name}-title")
+                  |> JS.remove_class("hidden", to: "#session-secret-#{secret_name}-detail")
                   |> JS.add_class("bg-gray-100",
                     to: "#session-secret-#{secret_name}-wrapper"
                   )
@@ -590,8 +590,8 @@ defmodule LivebookWeb.SessionLive do
                 class="flex flex-col text-gray-800 hidden"
                 id={"session-secret-#{secret_name}-detail"}
                 phx-click={
-                  JS.toggle(to: "#session-secret-#{secret_name}-title")
-                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
+                  JS.remove_class("hidden", to: "#session-secret-#{secret_name}-title")
+                  |> JS.add_class("hidden", to: "#session-secret-#{secret_name}-detail")
                   |> JS.remove_class("bg-gray-100",
                     to: "#session-secret-#{secret_name}-wrapper"
                   )

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -577,8 +577,8 @@ defmodule LivebookWeb.SessionLive do
                 class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
                 id={"session-secret-#{secret_name}-title"}
                 phx-click={
-                  JS.add_class("hidden", to: "#session-secret-#{secret_name}-title")
-                  |> JS.remove_class("hidden", to: "#session-secret-#{secret_name}-detail")
+                  JS.toggle(to: "#session-secret-#{secret_name}-title")
+                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
                   |> JS.add_class("bg-gray-100",
                     to: "#session-secret-#{secret_name}-wrapper"
                   )
@@ -590,8 +590,8 @@ defmodule LivebookWeb.SessionLive do
                 class="flex flex-col text-gray-800 hidden"
                 id={"session-secret-#{secret_name}-detail"}
                 phx-click={
-                  JS.remove_class("hidden", to: "#session-secret-#{secret_name}-title")
-                  |> JS.add_class("hidden", to: "#session-secret-#{secret_name}-detail")
+                  JS.toggle(to: "#session-secret-#{secret_name}-title")
+                  |> JS.toggle(to: "#session-secret-#{secret_name}-detail")
                   |> JS.remove_class("bg-gray-100",
                     to: "#session-secret-#{secret_name}-wrapper"
                   )
@@ -653,8 +653,8 @@ defmodule LivebookWeb.SessionLive do
                 <span
                   class="text-sm font-mono break-all w-full cursor-pointer flex flex-row justify-between items-center hover:text-gray-800"
                   phx-click={
-                    JS.add_class("hidden", to: "#app-secret-#{secret_name}-title")
-                    |> JS.remove_class("hidden", to: "#app-secret-#{secret_name}-detail")
+                    JS.toggle(to: "#app-secret-#{secret_name}-title", display: "flex")
+                    |> JS.toggle(to: "#app-secret-#{secret_name}-detail", display: "flex")
                     |> JS.add_class("bg-gray-100",
                       to: "#app-secret-#{secret_name}-wrapper"
                     )
@@ -676,8 +676,8 @@ defmodule LivebookWeb.SessionLive do
                     <span
                       class="text-sm font-mono w-full break-all flex-row cursor-pointer"
                       phx-click={
-                        JS.remove_class("hidden", to: "#app-secret-#{secret_name}-title")
-                        |> JS.add_class("hidden", to: "#app-secret-#{secret_name}-detail")
+                        JS.toggle(to: "#app-secret-#{secret_name}-title", display: "flex")
+                        |> JS.toggle(to: "#app-secret-#{secret_name}-detail", display: "flex")
                         |> JS.remove_class("bg-gray-100",
                           to: "#app-secret-#{secret_name}-wrapper"
                         )

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -568,27 +568,43 @@ defmodule LivebookWeb.SessionLive do
 
       <div class="flex flex-col">
         <div class="flex flex-col space-y-4 mt-6">
-          <%= for {secret_name, _} <- session_only_secrets(@data_view.secrets, @livebook_secrets) do %>
+          <%= for {secret_name, secret_value} <- session_only_secrets(@data_view.secrets, @livebook_secrets) do %>
             <div class="flex justify-between items-center text-gray-500">
-              <span class="text-sm font-mono break-all">
+              <span
+                class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
+                phx-click={JS.toggle(to: "#session-secret-#{secret_name}")}
+              >
                 <%= secret_name %>
               </span>
-              <button
-                id={"session-secret-#{secret_name}-delete"}
-                type="button"
-                phx-click={
-                  with_confirm(
-                    JS.push("delete_session_secret", value: %{secret_name: secret_name}),
-                    title: "Delete session secret - #{secret_name}",
-                    description: "Are you sure you want to delete this session secret?",
-                    confirm_text: "Delete",
-                    confirm_icon: "delete-bin-6-line"
-                  )
-                }
-                class="hover:text-red-600"
-              >
-                <.remix_icon icon="delete-bin-line" />
-              </button>
+            </div>
+            <div
+              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden"
+              id={"session-secret-#{secret_name}"}
+            >
+              <span class="text-sm font-mono break-all flex-row">
+                <%= secret_name %>
+              </span>
+              <div class="flex flex-row justify-between items-center">
+                <span class="text-sm font-mono break-all flex-row">
+                  <%= secret_value %>
+                </span>
+                <button
+                  id={"app-secret-#{secret_name}-delete"}
+                  type="button"
+                  phx-click={
+                    with_confirm(
+                      JS.push("delete_session_secret", value: %{secret_name: secret_name}),
+                      title: "Delete session secret - #{secret_name}",
+                      description: "Are you sure you want to delete this session secret?",
+                      confirm_text: "Delete",
+                      confirm_icon: "delete-bin-6-line"
+                    )
+                  }
+                  class="hover:text-red-600"
+                >
+                  <.remix_icon icon="delete-bin-line" />
+                </button>
+              </div>
             </div>
           <% end %>
         </div>
@@ -611,17 +627,31 @@ defmodule LivebookWeb.SessionLive do
         <div class="flex flex-col space-y-4 mt-6">
           <%= for {secret_name, secret_value} = secret <- Enum.sort(@livebook_secrets) do %>
             <div class="flex justify-between items-center text-gray-500">
-              <span class="text-sm font-mono break-all">
+              <span
+                class="text-sm font-mono break-all w-full cursor-pointer hover:text-gray-800"
+                phx-click={JS.toggle(to: "#app-secret-#{secret_name}")}
+              >
                 <%= secret_name %>
               </span>
-              <div class="flex gap-4 items-end">
-                <.switch_checkbox
-                  name="toggle_secret"
-                  checked={is_secret_on_session?(secret, @data_view.secrets)}
-                  phx-click="toggle_secret"
-                  phx-value-secret_name={secret_name}
-                  phx-value-secret_value={secret_value}
-                />
+              <.switch_checkbox
+                name="toggle_secret"
+                checked={is_secret_on_session?(secret, @data_view.secrets)}
+                phx-click="toggle_secret"
+                phx-value-secret_name={secret_name}
+                phx-value-secret_value={secret_value}
+              />
+            </div>
+            <div
+              class="flex flex-col text-gray-800 bg-gray-100 p-2 space-y-1 rounded-lg hidden"
+              id={"app-secret-#{secret_name}"}
+            >
+              <span class="text-sm font-mono break-all flex-row">
+                <%= secret_name %>
+              </span>
+              <div class="flex flex-row justify-between items-center">
+                <span class="text-sm font-mono break-all flex-row">
+                  <%= secret_value %>
+                </span>
                 <button
                   id={"app-secret-#{secret_name}-delete"}
                   type="button"


### PR DESCRIPTION

https://user-images.githubusercontent.com/5660941/194973675-cb671563-d879-49db-b565-8ddc46d5f9e5.mp4

I tried to achieve the same result with less code repetition but was not successful.
Toggling classes directly from JS breaks when the session is updated.
`JS.toggle` adds a display block which breaks the app secrets switch buttons layout
Negative margins are very inconsistent between browsers and cause an unwanted "jump" effect