### PR TITLE
Make `notebook_card` clickable

### DIFF
--- a/lib/livebook_web/live/learn_helpers.ex
+++ b/lib/livebook_web/live/learn_helpers.ex
@@ -8,25 +8,22 @@ defmodule LivebookWeb.LearnHelpers do
   """
   def notebook_card(assigns) do
     ~H"""
-    <div class="flex flex-col">
-      <%= live_redirect to: Routes.learn_path(@socket, :notebook, @notebook_info.slug),
-            class: "flex items-center justify-center p-6 border-2 border-gray-100 rounded-t-2xl h-[150px]" do %>
+    <%= live_redirect to: Routes.learn_path(@socket, :notebook, @notebook_info.slug),
+            class: "flex flex-col border-2 border-gray-100 hover:border-gray-200 rounded-2xl" do %>
+      <div class="flex items-center justify-center p-6 border-b-2 border-gray-100 rounded-t-2xl h-[150px]">
         <img
           src={@notebook_info.details.cover_url}
           class="max-h-full max-w-[75%]"
           alt={"#{@notebook_info.title} logo"}
         />
-      <% end %>
+      </div>
       <div class="px-6 py-4 bg-gray-100 rounded-b-2xl grow">
-        <%= live_redirect(@notebook_info.title,
-          to: Routes.learn_path(@socket, :notebook, @notebook_info.slug),
-          class: "text-gray-800 font-semibold cursor-pointer"
-        ) %>
+        <span class="text-gray-800 font-semibold"><%= @notebook_info.title %></span>
         <p class="mt-2 text-sm text-gray-600">
           <%= @notebook_info.details.description %>
         </p>
       </div>
-    </div>
+    <% end %>
     """
   end
 end

--- a/lib/livebook_web/live/learn_live.ex
+++ b/lib/livebook_web/live/learn_live.ex
@@ -39,7 +39,7 @@ defmodule LivebookWeb.LearnLive do
         </div>
         <div
           id="welcome-to-livebook"
-          class="p-8 bg-gray-900 rounded-2xl flex flex-col sm:flex-row space-y-8 sm:space-y-0 space-x-0 sm:space-x-8 items-center shadow-xl"
+          class="p-8 bg-gray-900 rounded-2xl flex flex-col sm:flex-row space-y-8 sm:space-y-0 space-x-0 sm:space-x-8 items-center"
         >
           <img src={@lead_notebook_info.details.cover_url} width="100" alt="livebook" />
           <div>


### PR DESCRIPTION
Previously only the image and the title were clickable.
This makes the whole card clickable and changes the border-color on hover:

https://user-images.githubusercontent.com/792046/197785861-db0534a9-f709-4b07-84ce-a0f6cfd9f18b.mov

I also removed the shadow from the "Welcome to Livebook" banner which was bleeding into the `notebook_card` 

Before: 

<img width="1031" alt="Screenshot 2022-10-25 at 15 08 00" src="https://user-images.githubusercontent.com/792046/197785270-61ac396b-217e-4aea-b00c-8f94a7a6712b.png">

After: 

<img width="1006" alt="Screenshot 2022-10-25 at 15 08 09" src="https://user-images.githubusercontent.com/792046/197785317-0c297c80-c3a3-4a16-a5a2-4320be815ce7.png">

