### PR TITLE
Fix launching Windows desktop app

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -163,20 +163,25 @@ defmodule Livebook.MixProject do
               ]
             ]
           ],
-          additional_paths: [
-            "rel/vendor/otp/bin",
-            "rel/vendor/elixir/bin",
-            "/usr/local/bin"
-          ],
           macos: [
             app_type: :agent,
             icon_path: "rel/app/icon-macos.png",
             build_dmg: macos_notarization != nil,
-            notarization: macos_notarization
+            notarization: macos_notarization,
+            additional_paths: [
+              "rel/vendor/otp/bin",
+              "rel/vendor/elixir/bin",
+              "/usr/local/bin"
+            ]
           ],
           windows: [
             icon_path: "rel/app/icon.ico",
-            build_installer: true
+            build_installer: true,
+            additional_paths: [
+              "rel/vendor/otp/erts-#{:erlang.system_info(:version)}/bin",
+              "rel/vendor/otp/bin",
+              "rel/vendor/elixir/bin"
+            ]
           ]
         ]
       ]


### PR DESCRIPTION
Closes #1507

On Windows we have erl.exe in two directories: OTP/bin and OTP/erts-VSN/bin. The executable is identical but what is different is the latter directory, the erts one, contains erlexec.dll which needs to be present for the VM to start.

Interestingly, regardless of OS, the erl[.exe] executable always prepends the OTP/erts-VSN/bin and OTP/bin directories to the PATH:

    iex> System.get_env("PATH") |> String.split(":") |> Enum.take(2)
    ["/Users/wojtek/.asdf/installs/erlang/25.1.2/erts-13.1.2/bin",
     "/Users/wojtek/.asdf/installs/erlang/25.1.2/bin"]

Manually prepending the erts bin directory to the PATH, which makes the erl.exe that is to be launched to be the erts one, fixed the issue.
