### PR TITLE
Track evaluation dependencies and cache results

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - main
 env:
   otp: "25.0"
-  elixir: "1.14.0"
+  elixir: "main"
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
       - main
 env:
   otp: "25.0"
+  # TODO: update to v1.14.2 once it is out
   elixir: "main"
 jobs:
   main:

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -472,23 +472,6 @@ defmodule Livebook.Notebook do
   end
 
   @doc """
-  Returns the list with the given parent cells and all of
-  their child cells.
-
-  The cells are not ordered in any secific way.
-  """
-  @spec cell_ids_with_children(t(), list(Cell.id())) :: list(Cell.id())
-  def cell_ids_with_children(notebook, parent_cell_ids) do
-    graph = cell_dependency_graph(notebook)
-
-    for parent_id <- parent_cell_ids,
-        leaf_id <- Graph.leaves(graph),
-        cell_id <- Graph.find_path(graph, leaf_id, parent_id),
-        uniq: true,
-        do: cell_id
-  end
-
-  @doc """
   Computes cell dependency graph.
 
   Every cell has one or none parent cells, so the graph

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -95,8 +95,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
     Livebook.Runtime.Attached.new(runtime.node, runtime.cookie)
   end
 
-  def evaluate_code(runtime, code, locator, base_locator, opts \\ []) do
-    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, base_locator, opts)
+  def evaluate_code(runtime, code, locator, parent_locators, opts \\ []) do
+    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, parent_locators, opts)
   end
 
   def forget_evaluation(runtime, locator) do
@@ -107,20 +107,20 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
     RuntimeServer.drop_container(runtime.server_pid, container_ref)
   end
 
-  def handle_intellisense(runtime, send_to, request, base_locator) do
-    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
+  def handle_intellisense(runtime, send_to, request, parent_locators) do
+    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, parent_locators)
   end
 
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
-  def start_smart_cell(runtime, kind, ref, attrs, base_locator) do
-    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, base_locator)
+  def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
+    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end
 
-  def set_smart_cell_base_locator(runtime, ref, base_locator) do
-    RuntimeServer.set_smart_cell_base_locator(runtime.server_pid, ref, base_locator)
+  def set_smart_cell_parent_locators(runtime, ref, parent_locators) do
+    RuntimeServer.set_smart_cell_parent_locators(runtime.server_pid, ref, parent_locators)
   end
 
   def stop_smart_cell(runtime, ref) do

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -179,8 +179,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
     Livebook.Runtime.ElixirStandalone.new()
   end
 
-  def evaluate_code(runtime, code, locator, base_locator, opts \\ []) do
-    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, base_locator, opts)
+  def evaluate_code(runtime, code, locator, parent_locators, opts \\ []) do
+    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, parent_locators, opts)
   end
 
   def forget_evaluation(runtime, locator) do
@@ -191,20 +191,20 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
     RuntimeServer.drop_container(runtime.server_pid, container_ref)
   end
 
-  def handle_intellisense(runtime, send_to, request, base_locator) do
-    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
+  def handle_intellisense(runtime, send_to, request, parent_locators) do
+    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, parent_locators)
   end
 
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
-  def start_smart_cell(runtime, kind, ref, attrs, base_locator) do
-    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, base_locator)
+  def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
+    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end
 
-  def set_smart_cell_base_locator(runtime, ref, base_locator) do
-    RuntimeServer.set_smart_cell_base_locator(runtime.server_pid, ref, base_locator)
+  def set_smart_cell_parent_locators(runtime, ref, parent_locators) do
+    RuntimeServer.set_smart_cell_parent_locators(runtime.server_pid, ref, parent_locators)
   end
 
   def stop_smart_cell(runtime, ref) do

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -76,8 +76,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     Livebook.Runtime.Embedded.new()
   end
 
-  def evaluate_code(runtime, code, locator, base_locator, opts \\ []) do
-    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, base_locator, opts)
+  def evaluate_code(runtime, code, locator, parent_locators, opts \\ []) do
+    RuntimeServer.evaluate_code(runtime.server_pid, code, locator, parent_locators, opts)
   end
 
   def forget_evaluation(runtime, locator) do
@@ -88,20 +88,20 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     RuntimeServer.drop_container(runtime.server_pid, container_ref)
   end
 
-  def handle_intellisense(runtime, send_to, request, base_locator) do
-    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, base_locator)
+  def handle_intellisense(runtime, send_to, request, parent_locators) do
+    RuntimeServer.handle_intellisense(runtime.server_pid, send_to, request, parent_locators)
   end
 
   def read_file(runtime, path) do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
-  def start_smart_cell(runtime, kind, ref, attrs, base_locator) do
-    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, base_locator)
+  def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
+    RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end
 
-  def set_smart_cell_base_locator(runtime, ref, base_locator) do
-    RuntimeServer.set_smart_cell_base_locator(runtime.server_pid, ref, base_locator)
+  def set_smart_cell_parent_locators(runtime, ref, parent_locators) do
+    RuntimeServer.set_smart_cell_parent_locators(runtime.server_pid, ref, parent_locators)
   end
 
   def stop_smart_cell(runtime, ref) do

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -23,6 +23,7 @@ defmodule Livebook.Runtime.ErlDist do
     [
       Livebook.Runtime.Evaluator,
       Livebook.Runtime.Evaluator.IOProxy,
+      Livebook.Runtime.Evaluator.Tracer,
       Livebook.Runtime.Evaluator.ObjectTracker,
       Livebook.Runtime.Evaluator.DefaultFormatter,
       Livebook.Intellisense,

--- a/lib/livebook/runtime/erl_dist/runtime_server.ex
+++ b/lib/livebook/runtime/erl_dist/runtime_server.ex
@@ -71,9 +71,15 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
 
   See `Livebook.Runtime.Evaluator` for more details.
   """
-  @spec evaluate_code(pid(), String.t(), Runtime.locator(), Runtime.locator(), keyword()) :: :ok
-  def evaluate_code(pid, code, locator, base_locator, opts \\ []) do
-    GenServer.cast(pid, {:evaluate_code, code, locator, base_locator, opts})
+  @spec evaluate_code(
+          pid(),
+          String.t(),
+          Runtime.locator(),
+          Runtime.parent_locators(),
+          keyword()
+        ) :: :ok
+  def evaluate_code(pid, code, locator, parent_locators, opts \\ []) do
+    GenServer.cast(pid, {:evaluate_code, code, locator, parent_locators, opts})
   end
 
   @doc """
@@ -109,11 +115,11 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
           pid(),
           pid(),
           Runtime.intellisense_request(),
-          Runtime.locator()
+          Runtime.Runtime.parent_locators()
         ) :: reference()
-  def handle_intellisense(pid, send_to, request, base_locator) do
+  def handle_intellisense(pid, send_to, request, parent_locators) do
     ref = make_ref()
-    GenServer.cast(pid, {:handle_intellisense, send_to, ref, request, base_locator})
+    GenServer.cast(pid, {:handle_intellisense, send_to, ref, request, parent_locators})
     ref
   end
 
@@ -144,18 +150,22 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
           String.t(),
           Runtime.smart_cell_ref(),
           Runtime.smart_cell_attrs(),
-          Runtime.locator()
+          Runtime.Runtime.parent_locators()
         ) :: :ok
-  def start_smart_cell(pid, kind, ref, attrs, base_locator) do
-    GenServer.cast(pid, {:start_smart_cell, kind, ref, attrs, base_locator})
+  def start_smart_cell(pid, kind, ref, attrs, parent_locators) do
+    GenServer.cast(pid, {:start_smart_cell, kind, ref, attrs, parent_locators})
   end
 
   @doc """
-  Updates the locator with smart cell context.
+  Updates the parent locator used by a smart cell as its context.
   """
-  @spec set_smart_cell_base_locator(pid(), Runtime.smart_cell_ref(), Runtime.locator()) :: :ok
-  def set_smart_cell_base_locator(pid, ref, base_locator) do
-    GenServer.cast(pid, {:set_smart_cell_base_locator, ref, base_locator})
+  @spec set_smart_cell_parent_locators(
+          pid(),
+          Runtime.smart_cell_ref(),
+          Runtime.Runtime.parent_locators()
+        ) :: :ok
+  def set_smart_cell_parent_locators(pid, ref, parent_locators) do
+    GenServer.cast(pid, {:set_smart_cell_parent_locators, ref, parent_locators})
   end
 
   @doc """
@@ -332,25 +342,12 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
   end
 
   def handle_cast(
-        {:evaluate_code, code, {container_ref, evaluation_ref} = locator, base_locator, opts},
+        {:evaluate_code, code, {container_ref, evaluation_ref} = locator, parent_locators, opts},
         state
       ) do
     state = ensure_evaluator(state, container_ref)
 
-    base_evaluation_ref =
-      case base_locator do
-        {^container_ref, evaluation_ref} ->
-          evaluation_ref
-
-        {parent_container_ref, evaluation_ref} ->
-          Evaluator.initialize_from(
-            state.evaluators[container_ref],
-            state.evaluators[parent_container_ref],
-            evaluation_ref
-          )
-
-          nil
-      end
+    parent_evaluation_refs = evaluation_refs_for_container(state, container_ref, parent_locators)
 
     {smart_cell_ref, opts} = Keyword.pop(opts, :smart_cell_ref)
     smart_cell_info = smart_cell_ref && state.smart_cells[smart_cell_ref]
@@ -374,7 +371,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
       state.evaluators[container_ref],
       code,
       evaluation_ref,
-      base_evaluation_ref,
+      parent_evaluation_refs,
       opts
     )
 
@@ -394,15 +391,31 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
     {:noreply, state}
   end
 
-  def handle_cast({:handle_intellisense, send_to, ref, request, base_locator}, state) do
-    {container_ref, evaluation_ref} = base_locator
-    evaluator = state.evaluators[container_ref]
+  def handle_cast({:handle_intellisense, send_to, ref, request, parent_locators}, state) do
+    {container_ref, parent_evaluation_refs} =
+      case parent_locators do
+        [] ->
+          {nil, []}
+
+        [{container_ref, _} | _] ->
+          parent_evaluation_refs =
+            parent_locators
+            # If there is a parent evaluator we ignore it and use whatever
+            # initial context we currently have in the evaluator. We sync
+            # initial context only on evaluation, since it may be blocking
+            |> Enum.take_while(&(elem(&1, 0) == container_ref))
+            |> Enum.map(&elem(&1, 1))
+
+          {container_ref, parent_evaluation_refs}
+      end
+
+    evaluator = container_ref && state.evaluators[container_ref]
 
     intellisense_context =
       if evaluator == nil or elem(request, 0) in [:format] do
         Evaluator.intellisense_context()
       else
-        Evaluator.intellisense_context(evaluator, evaluation_ref)
+        Evaluator.intellisense_context(evaluator, parent_evaluation_refs)
       end
 
     Task.Supervisor.start_child(state.task_supervisor, fn ->
@@ -413,7 +426,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
     {:noreply, state}
   end
 
-  def handle_cast({:start_smart_cell, kind, ref, attrs, base_locator}, state) do
+  def handle_cast({:start_smart_cell, kind, ref, attrs, parent_locators}, state) do
     definition = Enum.find(state.smart_cell_definitions, &(&1.kind == kind))
 
     state =
@@ -440,7 +453,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
             pid: pid,
             monitor_ref: Process.monitor(pid),
             scan_binding: scan_binding,
-            base_locator: base_locator,
+            parent_locators: parent_locators,
             scan_binding_pending: false,
             scan_binding_monitor_ref: nil,
             scan_eval_result: scan_eval_result
@@ -457,11 +470,11 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
     {:noreply, state}
   end
 
-  def handle_cast({:set_smart_cell_base_locator, ref, base_locator}, state) do
+  def handle_cast({:set_smart_cell_parent_locators, ref, parent_locators}, state) do
     state =
       update_in(state.smart_cells[ref], fn
-        %{base_locator: ^base_locator} = info -> info
-        info -> scan_binding_async(ref, %{info | base_locator: base_locator}, state)
+        %{parent_locators: ^parent_locators} = info -> info
+        info -> scan_binding_async(ref, %{info | parent_locators: parent_locators}, state)
       end)
 
     {:noreply, state}
@@ -608,12 +621,28 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
       send(myself, {:scan_binding_ack, ref})
     end
 
-    {container_ref, evaluation_ref} = info.base_locator
-    evaluator = state.evaluators[container_ref]
+    {container_ref, parent_evaluation_refs} =
+      case info.parent_locators do
+        [] ->
+          {nil, []}
+
+        [{container_ref, _} | _] = parent_locators ->
+          parent_evaluation_refs =
+            evaluation_refs_for_container(state, container_ref, parent_locators)
+
+          {container_ref, parent_evaluation_refs}
+      end
+
+    evaluator = container_ref && state.evaluators[container_ref]
 
     worker_pid =
       if evaluator do
-        Evaluator.peek_context(evaluator, evaluation_ref, &scan_and_ack.(&1.binding, &1.env))
+        Evaluator.peek_context(
+          evaluator,
+          parent_evaluation_refs,
+          &scan_and_ack.(&1.binding, &1.env)
+        )
+
         evaluator.pid
       else
         {:ok, pid} =
@@ -631,6 +660,26 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
     %{info | scan_binding_pending: false, scan_binding_monitor_ref: monitor_ref}
   end
 
+  defp evaluation_refs_for_container(state, container_ref, locators) do
+    case Enum.split_while(locators, &(elem(&1, 0) == container_ref)) do
+      {locators, []} ->
+        Enum.map(locators, &elem(&1, 1))
+
+      {locators, [{source_container_ref, _} | _] = source_locators} ->
+        source_evaluation_refs = Enum.map(source_locators, &elem(&1, 1))
+
+        evaluator = state.evaluators[container_ref]
+        source_evaluator = state.evaluators[source_container_ref]
+
+        if evaluator && source_evaluator do
+          # Synchronize initial state in the child evaluator
+          Evaluator.initialize_from(evaluator, source_evaluator, source_evaluation_refs)
+        end
+
+        Enum.map(locators, &elem(&1, 1))
+    end
+  end
+
   defp finish_scan_binding(ref, state) do
     update_in(state.smart_cells[ref], fn info ->
       Process.demonitor(info.scan_binding_monitor_ref, [:flush])
@@ -646,12 +695,12 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
 
   defp scan_binding_after_evaluation(state, locator) do
     update_in(state.smart_cells, fn smart_cells ->
-      Map.new(smart_cells, fn
-        {ref, %{base_locator: ^locator} = info} ->
+      Map.new(smart_cells, fn {ref, info} ->
+        if locator in info.parent_locators do
           {ref, scan_binding_async(ref, info, state)}
-
-        other ->
-          other
+        else
+          {ref, info}
+        end
       end)
     end)
   end

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -56,10 +56,12 @@ defmodule Livebook.Runtime.Evaluator do
           {:ok, result :: any()}
           | {:error, Exception.kind(), error :: any(), Exception.stacktrace()}
 
-  # We store evaluation envs in the process dictionary, so that we
-  # can build intellisense context without asking the evaluator
-  @env_key :evaluation_env
-  @initial_env_key :initial_env
+  # We store some information in the process dictionary for non-blocking
+  # access from other evaluators. In particular we store context metadata,
+  # such as envs, this way we can build intellisense context without
+  # asking the evaluator. We don't store binding though, because that
+  # would take too much memory
+  @evaluator_info_key :evaluator_info
 
   @doc """
   Starts an evaluator.
@@ -117,10 +119,10 @@ defmodule Livebook.Runtime.Evaluator do
   Any exceptions are captured and transformed into an error
   result.
 
-  The resulting contxt (binding and env) is stored under `ref`.
-  Any subsequent calls may specify `base_ref` pointing to a
-  previous evaluation, in which case the corresponding context
-  is used as the entry point for evaluation.
+  The resulting context (binding and env) is stored under `ref`. Any
+  subsequent calls may specify `parent_refs` pointing to a sequence
+  of previous evaluations, in which case the corresponding context is
+  used as the entry point for evaluation.
 
   The evaluation result is transformed with the configured
   formatter send to the configured client (see `start_link/1`).
@@ -134,37 +136,29 @@ defmodule Livebook.Runtime.Evaluator do
       finished. The function receives `t:evaluation_result/0`
       as an argument
   """
-  @spec evaluate_code(t(), String.t(), ref(), ref() | nil, keyword()) :: :ok
-  def evaluate_code(evaluator, code, ref, base_ref \\ nil, opts \\ []) when ref != nil do
-    cast(evaluator, {:evaluate_code, code, ref, base_ref, opts})
+  @spec evaluate_code(t(), String.t(), ref(), list(ref()), keyword()) :: :ok
+  def evaluate_code(evaluator, code, ref, parent_refs, opts \\ []) do
+    cast(evaluator, {:evaluate_code, code, ref, parent_refs, opts})
   end
 
   @doc """
   Fetches the evaluation context (binding and env) for the given
-  evaluation reference.
-
-  ## Options
-
-    * `:cached_id` - id of context that the sender may already have,
-      if it matches the fetched context, `{:error, :not_modified}`
-      is returned instead
+  evaluation sequence.
   """
-  @spec fetch_evaluation_context(t(), ref(), keyword()) ::
-          {:ok, context()} | {:error, :not_modified}
-  def fetch_evaluation_context(evaluator, ref, opts \\ []) do
-    cached_id = opts[:cached_id]
-    call(evaluator, {:fetch_evaluation_context, ref, cached_id})
+  @spec get_evaluation_context(t(), list(ref())) :: context()
+  def get_evaluation_context(evaluator, parent_refs) do
+    call(evaluator, {:get_evaluation_context, parent_refs})
   end
 
   @doc """
-  Fetches an evaluation context from `source_evaluator` and configures
-  it as the initial context for `evaluator`.
+  Fetches an aggregated evaluation context from `source_evaluator`
+  and caches it as the initial context for `evaluator`.
 
   The process dictionary is also copied to match `source_evaluator`.
   """
   @spec initialize_from(t(), t(), ref()) :: :ok
-  def initialize_from(evaluator, source_evaluator, source_evaluation_ref) do
-    call(evaluator, {:initialize_from, source_evaluator, source_evaluation_ref})
+  def initialize_from(evaluator, source_evaluator, source_parent_refs) do
+    call(evaluator, {:initialize_from, source_evaluator, source_parent_refs})
   end
 
   @doc """
@@ -190,15 +184,22 @@ defmodule Livebook.Runtime.Evaluator do
   @doc """
   Builds intellisense context from the given evaluation.
   """
-  @spec intellisense_context(t(), ref()) :: Livebook.Intellisense.intellisense_context()
-  def intellisense_context(evaluator, ref) do
+  @spec intellisense_context(t(), list(ref())) :: Livebook.Intellisense.intellisense_context()
+  def intellisense_context(evaluator, parent_refs) do
     {:dictionary, dictionary} = Process.info(evaluator.pid, :dictionary)
 
-    env =
-      find_in_dictionary(dictionary, {@env_key, ref}) ||
-        find_in_dictionary(dictionary, @initial_env_key)
+    evaluator_info = find_in_dictionary(dictionary, @evaluator_info_key)
+    %{initial_context: {_id, initial_env}} = evaluator_info
 
-    map_binding = fn fun -> map_binding(evaluator, ref, fun) end
+    env =
+      List.foldr(parent_refs, initial_env, fn ref, prev_env ->
+        case evaluator_info.contexts do
+          %{^ref => {_id, env}} -> merge_env(prev_env, env)
+          _ -> prev_env
+        end
+      end)
+
+    map_binding = fn fun -> map_binding(evaluator, parent_refs, fun) end
 
     %{env: env, map_binding: map_binding}
   end
@@ -211,8 +212,8 @@ defmodule Livebook.Runtime.Evaluator do
   end
 
   # Applies the given function to evaluation binding
-  defp map_binding(evaluator, ref, fun) do
-    call(evaluator, {:map_binding, ref, fun})
+  defp map_binding(evaluator, parent_refs, fun) do
+    call(evaluator, {:map_binding, parent_refs, fun})
   end
 
   @doc """
@@ -221,9 +222,9 @@ defmodule Livebook.Runtime.Evaluator do
   Ths function runs within the evaluator process, so that no data
   is copied between processes, unless explicitly sent.
   """
-  @spec peek_context(t(), ref(), (context() -> any())) :: :ok
-  def peek_context(evaluator, ref, fun) do
-    cast(evaluator, {:peek_context, ref, fun})
+  @spec peek_context(t(), list(ref()), (context() -> any())) :: :ok
+  def peek_context(evaluator, parent_refs, fun) do
+    cast(evaluator, {:peek_context, parent_refs, fun})
   end
 
   defp cast(evaluator, message) do
@@ -271,7 +272,13 @@ defmodule Livebook.Runtime.Evaluator do
     evaluator = %{pid: self(), ref: evaluator_ref}
 
     context = initial_context()
-    Process.put(@initial_env_key, context.env)
+
+    Process.put(@evaluator_info_key, %{
+      initial_context: {context.id, context.env},
+      contexts: %{}
+    })
+
+    ignored_pdict_keys = Process.get_keys() |> MapSet.new()
 
     state = %{
       evaluator_ref: evaluator_ref,
@@ -281,7 +288,9 @@ defmodule Livebook.Runtime.Evaluator do
       runtime_broadcast_to: runtime_broadcast_to,
       object_tracker: object_tracker,
       contexts: %{},
-      initial_context: context
+      initial_context: context,
+      initial_context_version: nil,
+      ignored_pdict_keys: ignored_pdict_keys
     }
 
     :proc_lib.init_ack(evaluator)
@@ -304,33 +313,52 @@ defmodule Livebook.Runtime.Evaluator do
 
   defp initial_context() do
     env = Code.env_for_eval([])
-    %{binding: [], env: env, id: random_id()}
+    env = Macro.Env.prepend_tracer(env, Evaluator.Tracer)
+    %{id: random_id(), binding: [], env: env, pdict: %{}}
   end
 
-  defp handle_cast({:evaluate_code, code, ref, base_ref, opts}, state) do
+  defp handle_cast({:evaluate_code, code, ref, parent_refs, opts}, state) do
     Evaluator.ObjectTracker.remove_reference_sync(state.object_tracker, {self(), ref})
 
-    context = get_context(state, base_ref)
+    context = get_context(state, parent_refs)
     file = Keyword.get(opts, :file, "nofile")
     context = put_in(context.env.file, file)
-    start_time = System.monotonic_time()
 
     Evaluator.IOProxy.configure(state.io_proxy, ref, file)
 
-    {result_context, result, code_error} =
-      case eval(code, context.binding, context.env) do
+    set_pdict(context, state.ignored_pdict_keys)
+
+    start_time = System.monotonic_time()
+    eval_result = eval(code, context.binding, context.env)
+    evaluation_time_ms = time_diff_ms(start_time)
+
+    {result_context, result, code_error, identifiers_used, identifiers_defined} =
+      case eval_result do
         {:ok, value, binding, env} ->
-          binding = reorder_binding(binding, context.binding)
-          result_context = %{binding: binding, env: env, id: random_id()}
+          tracer_info = Evaluator.IOProxy.get_tracer_info(state.io_proxy)
+          context_id = random_id()
+
+          result_context = %{
+            id: context_id,
+            binding: binding,
+            env: prune_env(env, tracer_info),
+            pdict: current_pdict(state)
+          }
+
+          {identifiers_used, identifiers_defined} =
+            identifier_dependencies(result_context, tracer_info, context)
+
           result = {:ok, value}
-          {result_context, result, nil}
+          {result_context, result, nil, identifiers_used, identifiers_defined}
 
         {:error, kind, error, stacktrace, code_error} ->
           result = {:error, kind, error, stacktrace}
-          {context, result, code_error}
+          identifiers_used = :unknown
+          identifiers_defined = %{}
+          # Empty context
+          result_context = initial_context()
+          {result_context, result, code_error, identifiers_used, identifiers_defined}
       end
-
-    evaluation_time_ms = get_execution_time_delta(start_time)
 
     state = put_context(state, ref, result_context)
 
@@ -342,7 +370,9 @@ defmodule Livebook.Runtime.Evaluator do
     metadata = %{
       evaluation_time_ms: evaluation_time_ms,
       memory_usage: memory(),
-      code_error: code_error
+      code_error: code_error,
+      identifiers_used: identifiers_used,
+      identifiers_defined: identifiers_defined
     }
 
     send(state.send_to, {:runtime_evaluation_response, ref, output, metadata})
@@ -363,71 +393,142 @@ defmodule Livebook.Runtime.Evaluator do
     {:noreply, state}
   end
 
-  defp handle_cast({:peek_context, ref, fun}, state) do
-    context = get_context(state, ref)
+  defp handle_cast({:peek_context, parent_refs, fun}, state) do
+    context = get_context(state, parent_refs)
     fun.(context)
     {:noreply, state}
   end
 
-  defp handle_call({:fetch_evaluation_context, ref, cached_id}, _from, state) do
-    context = get_context(state, ref)
-
-    reply =
-      if context.id == cached_id do
-        {:error, :not_modified}
-      else
-        {:ok, context}
-      end
-
-    {:reply, reply, state}
+  defp handle_call({:get_evaluation_context, parent_refs}, _from, state) do
+    context = get_context(state, parent_refs)
+    {:reply, context, state}
   end
 
-  defp handle_call({:initialize_from, source_evaluator, source_evaluation_ref}, _from, state) do
+  defp handle_call({:initialize_from, source_evaluator, source_parent_refs}, _from, state) do
+    {:dictionary, dictionary} = Process.info(source_evaluator.pid, :dictionary)
+
+    evaluator_info = find_in_dictionary(dictionary, @evaluator_info_key)
+
+    version =
+      source_parent_refs
+      |> Enum.map(fn ref ->
+        with {id, _env} <- evaluator_info.contexts[ref], do: id
+      end)
+      |> :erlang.md5()
+
     state =
-      case Evaluator.fetch_evaluation_context(
-             source_evaluator,
-             source_evaluation_ref,
-             cached_id: state.initial_context.id
-           ) do
-        {:ok, context} ->
-          # If the context changed, mirror the process dictionary again
-          copy_process_dictionary_from(source_evaluator)
+      if version == state.initial_context_version do
+        state
+      else
+        context = Evaluator.get_evaluation_context(source_evaluator, source_parent_refs)
 
-          Process.put(@initial_env_key, context.env)
-          put_in(state.initial_context, context)
+        update_evaluator_info(fn info ->
+          put_in(info.initial_context, {context.id, context.env})
+        end)
 
-        {:error, :not_modified} ->
-          state
+        %{state | initial_context: context, initial_context_version: version}
       end
 
     {:reply, :ok, state}
   end
 
-  defp handle_call({:map_binding, ref, fun}, _from, state) do
-    context = get_context(state, ref)
+  defp handle_call({:map_binding, parent_refs, fun}, _from, state) do
+    context = get_context(state, parent_refs)
     result = fun.(context.binding)
     {:reply, result, state}
   end
 
   defp put_context(state, ref, context) do
-    Process.put({@env_key, ref}, context.env)
+    update_evaluator_info(fn info ->
+      put_in(info.contexts[ref], {context.id, context.env})
+    end)
+
     put_in(state.contexts[ref], context)
   end
 
   defp delete_context(state, ref) do
-    Process.delete({@env_key, ref})
+    update_evaluator_info(fn info ->
+      {_, info} = pop_in(info.contexts[ref])
+      info
+    end)
+
     {_, state} = pop_in(state.contexts[ref])
     state
   end
 
-  defp get_context(state, ref) do
-    Map.get_lazy(state.contexts, ref, fn -> state.initial_context end)
+  defp update_evaluator_info(fun) do
+    info = Process.get(@evaluator_info_key)
+    Process.put(@evaluator_info_key, fun.(info))
+  end
+
+  defp get_context(state, parent_refs) do
+    List.foldr(parent_refs, state.initial_context, fn ref, prev_context ->
+      if context = state.contexts[ref] do
+        merge_context(prev_context, context)
+      else
+        prev_context
+      end
+    end)
+  end
+
+  defp set_pdict(context, ignored_pdict_keys) do
+    for key <- Process.get_keys(),
+        key not in ignored_pdict_keys,
+        not Map.has_key?(context.pdict, key) do
+      Process.delete(key)
+    end
+
+    for {key, value} <- context.pdict do
+      Process.put(key, value)
+    end
+  end
+
+  defp current_pdict(state) do
+    for {key, value} <- Process.get(),
+        key not in state.ignored_pdict_keys,
+        do: {key, value},
+        into: %{}
+  end
+
+  defp prune_env(env, tracer_info) do
+    env
+    |> Map.replace!(:aliases, Map.to_list(tracer_info.aliases_defined))
+    |> Map.replace!(:requires, MapSet.to_list(tracer_info.requires_defined))
+  end
+
+  defp merge_context(prev_context, context) do
+    binding = merge_binding(prev_context.binding, context.binding)
+    env = merge_env(prev_context.env, context.env)
+    pdict = context.pdict
+    %{id: random_id(), binding: binding, env: env, pdict: pdict}
+  end
+
+  defp merge_binding(prev_binding, binding) do
+    new_keys = MapSet.new(binding, &elem(&1, 0))
+    kept_binding = Enum.reject(prev_binding, &(elem(&1, 0) in new_keys))
+    binding ++ kept_binding
+  end
+
+  defp merge_env(prev_env, env) do
+    env
+    |> Map.update!(:versioned_vars, fn versioned_vars ->
+      Enum.uniq(Map.keys(prev_env.versioned_vars) ++ Map.keys(versioned_vars))
+      |> Enum.with_index()
+      |> Map.new()
+    end)
+    |> Map.update!(:aliases, &Keyword.merge(prev_env.aliases, &1))
+    |> Map.update!(:requires, fn requires ->
+      (prev_env.requires ++ requires)
+      |> Enum.sort()
+      |> Enum.dedup()
+    end)
+    |> Map.replace!(:context_modules, [])
   end
 
   defp eval(code, binding, env) do
     try do
       quoted = Code.string_to_quoted!(code, file: env.file)
-      {value, binding, env} = Code.eval_quoted_with_env(quoted, binding, env)
+      {value, binding, env} = Code.eval_quoted_with_env(quoted, binding, env, prune_binding: true)
       {:ok, value, binding, env}
     catch
       kind, error ->
@@ -449,22 +550,127 @@ defmodule Livebook.Runtime.Evaluator do
   defp code_error?(%CompileError{}), do: true
   defp code_error?(_error), do: false
 
-  defp reorder_binding(binding, prev_binding) do
-    # We keep the order of existing binding entries and move the new
-    # ones to the beginning
+  defp identifier_dependencies(context, tracer_info, prev_context) do
+    identifiers_used = MapSet.new()
+    identifiers_defined = %{}
 
-    binding_map = Map.new(binding)
+    # Variables
 
-    unchanged_binding =
-      Enum.filter(prev_binding, fn {key, prev_val} ->
-        val = binding_map[key]
-        :erts_debug.same(val, prev_val)
-      end)
+    identifiers_used =
+      for var_name <- vars_used(context, tracer_info, prev_context),
+          do: {:variable, var_name},
+          into: identifiers_used
 
-    unchanged_binding
-    |> Enum.reduce(binding_map, fn {key, _}, acc -> Map.delete(acc, key) end)
-    |> Map.to_list()
-    |> Kernel.++(unchanged_binding)
+    identifiers_used =
+      for var_name <- tracer_info.undefined_vars,
+          do: {:variable, var_name},
+          into: identifiers_used
+
+    identifiers_defined =
+      for var_name <- vars_defined(context, prev_context),
+          do: {{:variable, var_name}, context.id},
+          into: identifiers_defined
+
+    # Modules
+
+    identifiers_used =
+      for module <- tracer_info.modules_used,
+          do: {:module, module},
+          into: identifiers_used
+
+    identifiers_defined =
+      for {module, {version, _vars}} <- tracer_info.modules_defined,
+          do: {{:module, module}, version},
+          into: identifiers_defined
+
+    # Aliases
+
+    identifiers_used =
+      for alias <- tracer_info.aliases_used,
+          do: {:alias, alias},
+          into: identifiers_used
+
+    identifiers_defined =
+      for {as, alias} <- tracer_info.aliases_defined,
+          do: {{:alias, as}, alias},
+          into: identifiers_defined
+
+    # Requires
+
+    identifiers_used =
+      for module <- tracer_info.requires_used,
+          do: {:require, module},
+          into: identifiers_used
+
+    identifiers_defined =
+      for module <- tracer_info.requires_defined,
+          do: {{:require, module}, :ok},
+          into: identifiers_defined
+
+    # Imports
+
+    identifiers_used =
+      if tracer_info.imports_used? or tracer_info.imports_defined? do
+        # Imports are not always incremental, due to :except, so if
+        # we define imports, we also implicitly rely on prior imports
+        MapSet.put(identifiers_used, :imports)
+      else
+        identifiers_used
+      end
+
+    identifiers_defined =
+      if tracer_info.imports_defined? do
+        version = :erlang.phash2({context.env.functions, context.env.macros})
+        put_in(identifiers_defined[:imports], version)
+      else
+        identifiers_defined
+      end
+
+    # Process dictionary
+
+    # Every evaluation depends on the pdict
+    identifiers_used = MapSet.put(identifiers_used, :pdict)
+
+    identifiers_defined =
+      if context.pdict == prev_context.pdict do
+        identifiers_defined
+      else
+        version = :erlang.phash2(context.pdict)
+        put_in(identifiers_defined[:pdict], version)
+      end
+
+    {MapSet.to_list(identifiers_used), identifiers_defined}
+  end
+
+  defp vars_used(context, tracer_info, prev_context) do
+    prev_vars =
+      for {{name, nil}, _version} <- prev_context.env.versioned_vars,
+          into: MapSet.new(),
+          do: name
+
+    outer_used_vars =
+      for {{name, nil}, _version} <- context.env.versioned_vars,
+          into: MapSet.new(),
+          do: name
+
+    # Note that :prune_binding removes variables used by modules
+    # (unless used outside), so we get those from the tracer
+    module_used_vars =
+      for {_module, {_version, vars}} <- tracer_info.modules_defined,
+          {name, nil} <- vars,
+          into: MapSet.new(),
+          do: name
+
+    # We take an intersection with previous vars, so we ignore variables
+    # that we know are newly defined
+    MapSet.intersection(prev_vars, MapSet.union(outer_used_vars, module_used_vars))
+  end
+
+  defp vars_defined(context, prev_context) do
+    for {{var, nil}, version} <- context.env.versioned_vars,
+        version >= map_size(prev_context.env.versioned_vars),
+        into: MapSet.new(),
+        do: var
   end
 
   # Adapted from https://github.com/elixir-lang/elixir/blob/1c1654c88adfdbef38ff07fc30f6fbd34a542c07/lib/iex/lib/iex/evaluator.ex#L355-L372
@@ -506,20 +712,7 @@ defmodule Livebook.Runtime.Evaluator do
     :crypto.strong_rand_bytes(20) |> Base.encode32(case: :lower)
   end
 
-  defp copy_process_dictionary_from(source_evaluator) do
-    {:dictionary, dictionary} = Process.info(source_evaluator.pid, :dictionary)
-
-    for {key, value} <- dictionary, not internal_dictionary_key?(key) do
-      Process.put(key, value)
-    end
-  end
-
-  defp internal_dictionary_key?("$" <> _), do: true
-  defp internal_dictionary_key?({@env_key, _ref}), do: true
-  defp internal_dictionary_key?(@initial_env_key), do: true
-  defp internal_dictionary_key?(_), do: false
-
-  defp get_execution_time_delta(started_at) do
+  defp time_diff_ms(started_at) do
     System.monotonic_time()
     |> Kernel.-(started_at)
     |> System.convert_time_unit(:native, :millisecond)

--- a/lib/livebook/runtime/evaluator/tracer.ex
+++ b/lib/livebook/runtime/evaluator/tracer.ex
@@ -1,0 +1,129 @@
+defmodule Livebook.Runtime.Evaluator.Tracer do
+  @moduledoc false
+
+  # Compilation tracer used by the evaluator.
+  #
+  # Events are pre-processed and sent to the group leader, where the
+  # tracer state is accumulated. After evaluation the evaluator reads
+  # the accumulated state.
+
+  alias Livebook.Runtime.Evaluator
+
+  defstruct modules_used: MapSet.new(),
+            modules_defined: %{},
+            aliases_used: MapSet.new(),
+            aliases_defined: %{},
+            requires_used: MapSet.new(),
+            requires_defined: MapSet.new(),
+            imports_used?: false,
+            imports_defined?: false,
+            undefined_vars: MapSet.new()
+
+  @doc false
+  def trace(event, env) do
+    case to_updates(event, env) do
+      [] ->
+        :ok
+
+      updates ->
+        io_proxy = Process.group_leader()
+        Evaluator.IOProxy.tracer_updates(io_proxy, updates)
+    end
+
+    :ok
+  end
+
+  defp to_updates(event, env) do
+    # Note that import/require/alias/defmodule don't trigger `:alias_reference`
+    # for the used alias, so we add it explicitly
+
+    case event do
+      {:import, _meta, module, _opts} when env.module == nil ->
+        [{:module_used, module}, {:alias_used, module}, :import_defined]
+
+      {:imported_function, meta, module, name, _arity} ->
+        var? = Keyword.has_key?(meta, :if_undefined)
+        [{:module_used, module}, {:import_used, name, var?}]
+
+      {:imported_macro, meta, module, name, _arity} ->
+        var? = Keyword.has_key?(meta, :if_undefined)
+        [{:module_used, module}, {:import_used, name, var?}]
+
+      {:alias, _meta, alias, as, _opts} when env.module == nil ->
+        [{:alias_defined, as, alias}, {:alias_used, alias}]
+
+      {:alias_expansion, _meta, as, _alias} ->
+        [{:alias_used, as}]
+
+      {:alias_reference, _meta, alias} when env.module == nil ->
+        [{:alias_used, alias}]
+
+      {:require, _meta, module, _opts} when env.module == nil ->
+        [{:module_used, module}, {:require_defined, module}, {:alias_used, module}]
+
+      {:struct_expansion, _meta, module, _keys} ->
+        [{:module_used, module}]
+
+      {:remote_function, _meta, module, _name, _arity} ->
+        [{:module_used, module}]
+
+      {:remote_macro, _meta, module, _name, _arity} ->
+        [{:module_used, module}, {:require_used, module}]
+
+      {:on_module, bytecode, _ignore} ->
+        module = env.module
+        version = :erlang.md5(bytecode)
+        vars = Map.keys(env.versioned_vars)
+        [{:module_defined, module, version, vars}, {:alias_used, module}]
+
+      _ ->
+        []
+    end
+  end
+
+  @doc """
+  Applies updates to the tracer state.
+  """
+  @spec apply_updates(%__MODULE__{}, list()) :: %__MODULE__{}
+  def apply_updates(info, updates) do
+    Enum.reduce(updates, info, &apply_update(&2, &1))
+  end
+
+  defp apply_update(info, {:module_used, module}) do
+    update_in(info.modules_used, &MapSet.put(&1, module))
+  end
+
+  defp apply_update(info, {:module_defined, module, version, vars}) do
+    put_in(info.modules_defined[module], {version, vars})
+  end
+
+  defp apply_update(info, {:alias_used, alias}) do
+    update_in(info.aliases_used, &MapSet.put(&1, alias))
+  end
+
+  defp apply_update(info, {:alias_defined, as, alias}) do
+    put_in(info.aliases_defined[as], alias)
+  end
+
+  defp apply_update(info, {:require_used, module}) do
+    update_in(info.requires_used, &MapSet.put(&1, module))
+  end
+
+  defp apply_update(info, {:require_defined, module}) do
+    update_in(info.requires_defined, &MapSet.put(&1, module))
+  end
+
+  defp apply_update(info, {:import_used, name, var?}) do
+    info = put_in(info.imports_used?, true)
+
+    if var? do
+      update_in(info.undefined_vars, &MapSet.put(&1, name))
+    else
+      info
+    end
+  end
+
+  defp apply_update(info, :import_defined) do
+    put_in(info.imports_defined?, true)
+  end
+end

--- a/lib/livebook/web_socket/server.ex
+++ b/lib/livebook/web_socket/server.ex
@@ -103,7 +103,7 @@ defmodule Livebook.WebSocket.Server do
   # Private
 
   defp reply(%{caller: nil} = state, response) do
-    Logger.warn("The caller is nil, so we can't reply the message: #{inspect(response)}")
+    Logger.warning("The caller is nil, so we can't reply the message: #{inspect(response)}")
     state
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -1221,10 +1221,10 @@ defmodule LivebookWeb.SessionLive do
 
     data = socket.private.data
 
-    with {:ok, cell, section} <- Notebook.fetch_cell_and_section(data.notebook, cell_id) do
+    with {:ok, cell, _section} <- Notebook.fetch_cell_and_section(data.notebook, cell_id) do
       if Runtime.connected?(data.runtime) do
-        base_locator = Session.find_base_locator(data, cell, section, existing: true)
-        ref = Runtime.handle_intellisense(data.runtime, self(), request, base_locator)
+        parent_locators = Session.parent_locators_for_cell(data, cell)
+        ref = Runtime.handle_intellisense(data.runtime, self(), request, parent_locators)
 
         {:reply, %{"ref" => inspect(ref)}, socket}
       else

--- a/lib/livebook_web/live/session_live/attached_live.ex
+++ b/lib/livebook_web/live/session_live/attached_live.ex
@@ -67,7 +67,11 @@ defmodule LivebookWeb.SessionLive.AttachedLive do
           </div>
           <div>
             <div class="input-label">Cookie</div>
-            <%= text_input(f, :cookie, value: @data["cookie"], class: "input", placeholder: "mycookie") %>
+            <%= text_input(f, :cookie,
+              value: @data["cookie"],
+              class: "input",
+              placeholder: "mycookie"
+            ) %>
           </div>
         </div>
         <button class="mt-5 button-base button-blue" type="submit" disabled={not data_valid?(@data)}>

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -297,8 +297,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
         |> eval(evaluator, 0)
 
       assert %{
-               {:variable, :x} => _,
-               {:variable, :y} => _
+               {:variable, {:x, nil}} => _,
+               {:variable, {:y, nil}} => _
              } = identifiers.defined
 
       identifiers =
@@ -307,8 +307,26 @@ defmodule Livebook.Runtime.EvaluatorTest do
         """
         |> eval(evaluator, 1)
 
-      assert {:variable, :x} in identifiers.used
-      assert {:variable, :y} not in identifiers.used
+      assert {:variable, {:x, nil}} in identifiers.used
+      assert {:variable, {:y, nil}} not in identifiers.used
+    end
+
+    test "variables with non-default context", %{evaluator: evaluator} do
+      identifiers =
+        """
+        var!(x, :context) = 1
+        """
+        |> eval(evaluator, 0)
+
+      assert %{{:variable, {:x, :context}} => _} = identifiers.defined
+
+      identifiers =
+        """
+        var!(x, :context)
+        """
+        |> eval(evaluator, 1)
+
+      assert {:variable, {:x, :context}} in identifiers.used
     end
 
     test "variables used inside a module", %{evaluator: evaluator} do
@@ -321,9 +339,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
         |> eval(evaluator, 0)
 
       assert %{
-               {:variable, :x} => _,
-               {:variable, :y} => _,
-               {:variable, :z} => _
+               {:variable, {:x, nil}} => _,
+               {:variable, {:y, nil}} => _,
+               {:variable, {:z, nil}} => _
              } = identifiers.defined
 
       identifiers =
@@ -336,9 +354,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
         """
         |> eval(evaluator, 1)
 
-      assert {:variable, :x} in identifiers.used
-      assert {:variable, :y} in identifiers.used
-      assert {:variable, :z} not in identifiers.used
+      assert {:variable, {:x, nil}} in identifiers.used
+      assert {:variable, {:y, nil}} in identifiers.used
+      assert {:variable, {:z, nil}} not in identifiers.used
     end
 
     test "reports parentheses-less arity-0 import as a used variable", %{evaluator: evaluator} do
@@ -348,7 +366,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
         """
         |> eval(evaluator, 0)
 
-      assert {:variable, :self} in identifiers.used
+      assert {:variable, {:self, nil}} in identifiers.used
       assert :imports in identifiers.used
     end
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -14,7 +14,13 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
   defmacrop metadata do
     quote do
-      %{evaluation_time_ms: _, memory_usage: %{}, code_error: _}
+      %{
+        evaluation_time_ms: _,
+        memory_usage: %{},
+        code_error: _,
+        identifiers_used: _,
+        identifiers_defined: _
+      }
     end
   end
 
@@ -26,7 +32,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       x + y
       """
 
-      Evaluator.evaluate_code(evaluator, code, :code_1)
+      Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, 3}, metadata() = metadata}
       assert metadata.evaluation_time_ms >= 0
@@ -35,12 +41,12 @@ defmodule Livebook.Runtime.EvaluatorTest do
                metadata.memory_usage
     end
 
-    test "given no base_ref does not see previous evaluation context", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "x = 1", :code_1)
+    test "given no parent refs does not see previous evaluation context", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "x = 1", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
 
       ignore_warnings(fn ->
-        Evaluator.evaluate_code(evaluator, "x", :code_2)
+        Evaluator.evaluate_code(evaluator, "x", :code_2, [])
 
         assert_receive {:runtime_evaluation_response, :code_2,
                         {:error, _kind,
@@ -50,23 +56,36 @@ defmodule Livebook.Runtime.EvaluatorTest do
       end)
     end
 
-    test "given base_ref sees previous evaluation context", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "x = 1", :code_1)
+    test "given parent refs sees previous evaluation context", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "x = 1", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
 
-      Evaluator.evaluate_code(evaluator, "x", :code_2, :code_1)
+      Evaluator.evaluate_code(evaluator, "x", :code_2, [:code_1])
 
       assert_receive {:runtime_evaluation_response, :code_2, {:ok, 1}, metadata()}
     end
 
-    test "given invalid base_ref just uses default context", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, ":hey", :code_1, :code_nonexistent)
+    test "given invalid parent ref uses the default context", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, ":hey", :code_1, [:code_nonexistent])
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, :hey}, metadata()}
     end
 
+    test "given parent refs sees previous process dictionary", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, "Process.put(:x, 1)", :code_1, [])
+      assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
+      Evaluator.evaluate_code(evaluator, "Process.put(:x, 2)", :code_2, [])
+      assert_receive {:runtime_evaluation_response, :code_2, _, metadata()}
+
+      Evaluator.evaluate_code(evaluator, "Process.get(:x)", :code_3, [:code_1])
+      assert_receive {:runtime_evaluation_response, :code_3, {:ok, 1}, metadata()}
+
+      Evaluator.evaluate_code(evaluator, "Process.get(:x)", :code_3, [:code_2])
+      assert_receive {:runtime_evaluation_response, :code_3, {:ok, 2}, metadata()}
+    end
+
     test "captures standard output and sends it to the caller", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, ~s{IO.puts("hey")}, :code_1)
+      Evaluator.evaluate_code(evaluator, ~s{IO.puts("hey")}, :code_1, [])
 
       assert_receive {:runtime_evaluation_output, :code_1, {:stdout, "hey\n"}}
     end
@@ -81,7 +100,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       end
       """
 
-      Evaluator.evaluate_code(evaluator, code, :code_1)
+      Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
       assert_receive {:runtime_evaluation_input, :code_1, reply_to, "input1"}
       send(reply_to, {:runtime_evaluation_input_reply, {:ok, :value}})
@@ -94,7 +113,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       List.first(%{})
       """
 
-      Evaluator.evaluate_code(evaluator, code, :code_1, nil, file: "file.ex")
+      Evaluator.evaluate_code(evaluator, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
                       {:error, :error, :function_clause,
@@ -107,7 +126,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
     test "returns additional metadata when there is a syntax error", %{evaluator: evaluator} do
       code = "1+"
 
-      Evaluator.evaluate_code(evaluator, code, :code_1, nil, file: "file.ex")
+      Evaluator.evaluate_code(evaluator, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
                       {:error, :error, %TokenMissingError{}, _stacktrace},
@@ -122,7 +141,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
     test "returns additional metadata when there is a compilation error", %{evaluator: evaluator} do
       code = "x"
 
-      Evaluator.evaluate_code(evaluator, code, :code_1, nil, file: "file.ex")
+      Evaluator.evaluate_code(evaluator, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
                       {:error, :error, %CompileError{}, _stacktrace},
@@ -139,7 +158,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Code.eval_string("x")
       """
 
-      Evaluator.evaluate_code(evaluator, code, :code_1, nil, file: "file.ex")
+      Evaluator.evaluate_code(evaluator, code, :code_1, [], file: "file.ex")
 
       expected_stacktrace = [
         {:elixir_eval, :__FILE__, 1, [file: ~c"file.ex", line: 1]}
@@ -152,29 +171,30 @@ defmodule Livebook.Runtime.EvaluatorTest do
     test "in case of an error returns only the relevant part of stacktrace",
          %{evaluator: evaluator} do
       code = """
-      defmodule Livebook.EvaluatorTest.Stacktrace.Math do
+      defmodule Livebook.Runtime.EvaluatorTest.Stacktrace.Math do
         def bad_math do
           result = 1 / 0
           {:ok, result}
         end
       end
 
-      defmodule Livebook.EvaluatorTest.Stacktrace.Cat do
+      defmodule Livebook.Runtime.EvaluatorTest.Stacktrace.Cat do
         def meow do
-          Livebook.EvaluatorTest.Stacktrace.Math.bad_math()
+          Livebook.Runtime.EvaluatorTest.Stacktrace.Math.bad_math()
           :ok
         end
       end
 
-      Livebook.EvaluatorTest.Stacktrace.Cat.meow()
+      Livebook.Runtime.EvaluatorTest.Stacktrace.Cat.meow()
       """
 
       ignore_warnings(fn ->
-        Evaluator.evaluate_code(evaluator, code, :code_1)
+        Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
         expected_stacktrace = [
-          {Livebook.EvaluatorTest.Stacktrace.Math, :bad_math, 0, [file: ~c"nofile", line: 3]},
-          {Livebook.EvaluatorTest.Stacktrace.Cat, :meow, 0, [file: ~c"nofile", line: 10]},
+          {Livebook.Runtime.EvaluatorTest.Stacktrace.Math, :bad_math, 0,
+           [file: ~c"nofile", line: 3]},
+          {Livebook.Runtime.EvaluatorTest.Stacktrace.Cat, :meow, 0, [file: ~c"nofile", line: 10]},
           {:elixir_eval, :__FILE__, 1, [file: ~c"nofile", line: 15]}
         ]
 
@@ -185,7 +205,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       end)
     end
 
-    test "in case of an error uses own evaluation context as the resulting context",
+    test "in case of an error uses empty evaluation context as the resulting context",
          %{evaluator: evaluator} do
       code1 = """
       x = 2
@@ -199,14 +219,14 @@ defmodule Livebook.Runtime.EvaluatorTest do
       x * x
       """
 
-      Evaluator.evaluate_code(evaluator, code1, :code_1)
+      Evaluator.evaluate_code(evaluator, code1, :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, _}, metadata()}
 
-      Evaluator.evaluate_code(evaluator, code2, :code_2, :code_1)
+      Evaluator.evaluate_code(evaluator, code2, :code_2, [:code_1])
 
       assert_receive {:runtime_evaluation_response, :code_2, {:error, _, _, _}, metadata()}
 
-      Evaluator.evaluate_code(evaluator, code3, :code_3, :code_2)
+      Evaluator.evaluate_code(evaluator, code3, :code_3, [:code_2, :code_1])
       assert_receive {:runtime_evaluation_response, :code_3, {:ok, 4}, metadata()}
     end
 
@@ -216,7 +236,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       """
 
       opts = [file: "/path/dir/file"]
-      Evaluator.evaluate_code(evaluator, code, :code_1, nil, opts)
+      Evaluator.evaluate_code(evaluator, code, :code_1, [], opts)
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, "/path/dir"}, metadata()}
     end
@@ -224,15 +244,15 @@ defmodule Livebook.Runtime.EvaluatorTest do
     test "kills widgets that that no evaluation points to", %{evaluator: evaluator} do
       # Evaluate the code twice, each time a new widget is spawned.
       # The evaluation reference is the same, so the second one overrides
-      # the first one and the first widget should eventually be kiled.
+      # the first one and the first widget should eventually be killed.
 
-      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1)
+      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1, [])
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, widget_pid1}, metadata()}
 
       ref = Process.monitor(widget_pid1)
 
-      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1)
+      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1, [])
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, widget_pid2}, metadata()}
 
@@ -245,23 +265,390 @@ defmodule Livebook.Runtime.EvaluatorTest do
       # The widget is spawned from a process that terminates,
       # so the widget should terminate immediately as well
 
-      Evaluator.evaluate_code(evaluator, spawn_widget_from_terminating_process_code(), :code_1)
+      Evaluator.evaluate_code(
+        evaluator,
+        spawn_widget_from_terminating_process_code(),
+        :code_1,
+        []
+      )
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, widget_pid1}, metadata()}
 
-      refute Process.alive?(widget_pid1)
+      ref = Process.monitor(widget_pid1)
+      assert_receive {:DOWN, ^ref, :process, ^widget_pid1, _reason}
+    end
+  end
+
+  describe "evaluate_code/6 identifier tracking" do
+    defp eval(code, evaluator, eval_idx) do
+      ref = eval_idx
+      parent_refs = Enum.to_list((eval_idx - 1)..0//-1)
+      Evaluator.evaluate_code(evaluator, code, ref, parent_refs)
+      assert_receive {:runtime_evaluation_response, ^ref, {:ok, _}, metadata}
+      %{used: metadata.identifiers_used, defined: metadata.identifiers_defined}
+    end
+
+    test "variables", %{evaluator: evaluator} do
+      identifiers =
+        """
+        x = 1
+        y = 1
+        """
+        |> eval(evaluator, 0)
+
+      assert %{
+               {:variable, :x} => _,
+               {:variable, :y} => _
+             } = identifiers.defined
+
+      identifiers =
+        """
+        x
+        """
+        |> eval(evaluator, 1)
+
+      assert {:variable, :x} in identifiers.used
+      assert {:variable, :y} not in identifiers.used
+    end
+
+    test "variables used inside a module", %{evaluator: evaluator} do
+      identifiers =
+        """
+        x = 1
+        y = 1
+        z = 1
+        """
+        |> eval(evaluator, 0)
+
+      assert %{
+               {:variable, :x} => _,
+               {:variable, :y} => _,
+               {:variable, :z} => _
+             } = identifiers.defined
+
+      identifiers =
+        """
+        defmodule Livebook.Runtime.EvaluatorTest.Identifiers.UsedVars do
+          def fun(), do: unquote(x)
+        end
+
+        y
+        """
+        |> eval(evaluator, 1)
+
+      assert {:variable, :x} in identifiers.used
+      assert {:variable, :y} in identifiers.used
+      assert {:variable, :z} not in identifiers.used
+    end
+
+    test "reports parentheses-less arity-0 import as a used variable", %{evaluator: evaluator} do
+      identifiers =
+        """
+        self
+        """
+        |> eval(evaluator, 0)
+
+      assert {:variable, :self} in identifiers.used
+      assert :imports in identifiers.used
+    end
+
+    test "module definition", %{evaluator: evaluator} do
+      identifiers =
+        """
+        defmodule Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition do
+          def fun(), do: 1
+        end
+        """
+        |> eval(evaluator, 0)
+
+      assert {:alias, :"Elixir.Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition"} in identifiers.used
+
+      assert %{
+               {:module, :"Elixir.Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition"} =>
+                 version1
+             } = identifiers.defined
+
+      identifiers =
+        """
+        defmodule Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition do
+          def fun(), do: 1
+        end
+        """
+        |> eval(evaluator, 0)
+
+      assert %{
+               {:module, :"Elixir.Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition"} =>
+                 ^version1
+             } = identifiers.defined
+
+      identifiers =
+        """
+        defmodule Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition do
+          def fun(), do: 2
+        end
+        """
+        |> eval(evaluator, 0)
+
+      assert %{
+               {:module, :"Elixir.Livebook.Runtime.EvaluatorTest.Identifiers.ModuleDefinition"} =>
+                 version2
+             } = identifiers.defined
+
+      assert version2 != version1
+    end
+
+    test "module function call", %{evaluator: evaluator} do
+      identifiers =
+        """
+        Enum.uniq([1, 2])
+        """
+        |> eval(evaluator, 0)
+
+      assert {:module, :"Elixir.Enum"} in identifiers.used
+    end
+
+    test "alias", %{evaluator: evaluator} do
+      identifiers =
+        """
+        alias Map, as: M
+        """
+        |> eval(evaluator, 0)
+
+      assert {:alias, :"Elixir.Map"} in identifiers.used
+
+      assert %{{:alias, :"Elixir.M"} => :"Elixir.Map"} = identifiers.defined
+
+      identifiers =
+        """
+        M.new()
+        """
+        |> eval(evaluator, 1)
+
+      assert {:alias, :"Elixir.M"} in identifiers.used
+      assert {:module, :"Elixir.Map"} in identifiers.used
+    end
+
+    test "require", %{evaluator: evaluator} do
+      identifiers =
+        """
+        require Integer
+        """
+        |> eval(evaluator, 0)
+
+      assert {:alias, :"Elixir.Integer"} in identifiers.used
+
+      assert %{{:require, :"Elixir.Integer"} => :ok} = identifiers.defined
+
+      identifiers =
+        """
+        Integer.is_even(2)
+        """
+        |> eval(evaluator, 1)
+
+      assert {:alias, :"Elixir.Integer"} in identifiers.used
+      assert {:require, :"Elixir.Integer"} in identifiers.used
+      assert {:module, :"Elixir.Integer"} in identifiers.used
+    end
+
+    test "import", %{evaluator: evaluator} do
+      identifiers =
+        """
+        import Enum
+        """
+        |> eval(evaluator, 0)
+
+      assert %{:imports => version1} = identifiers.defined
+
+      identifiers =
+        """
+        import Enum
+        """
+        |> eval(evaluator, 0)
+
+      assert %{:imports => ^version1} = identifiers.defined
+
+      identifiers =
+        """
+        import Integer
+        """
+        |> eval(evaluator, 0)
+
+      assert :imports in identifiers.used
+      assert {:alias, :"Elixir.Integer"} in identifiers.used
+      assert {:module, :"Elixir.Integer"} in identifiers.used
+
+      assert %{
+               :imports => version2,
+               {:require, :"Elixir.Integer"} => :ok
+             } = identifiers.defined
+
+      assert version2 != version1
+
+      identifiers =
+        """
+        is_even(2)
+        """
+        |> eval(evaluator, 1)
+
+      assert :imports in identifiers.used
+      assert {:module, :"Elixir.Integer"} in identifiers.used
+
+      identifiers =
+        """
+        Integer.is_even(2)
+        """
+        |> eval(evaluator, 1)
+
+      assert {:require, :"Elixir.Integer"} in identifiers.used
+      assert {:module, :"Elixir.Integer"} in identifiers.used
+    end
+
+    test "struct", %{evaluator: evaluator} do
+      identifiers =
+        """
+        %URI{}
+        """
+        |> eval(evaluator, 0)
+
+      assert {:alias, :"Elixir.URI"} in identifiers.used
+      assert {:module, :"Elixir.URI"} in identifiers.used
+    end
+
+    test "process dictionary", %{evaluator: evaluator} do
+      identifiers =
+        """
+        :ok
+        """
+        |> eval(evaluator, 0)
+
+      # Every evaluation should depend on process dictionary
+      assert :pdict in identifiers.used
+
+      identifiers =
+        """
+        Process.put(:x, 1)
+        """
+        |> eval(evaluator, 0)
+
+      assert %{pdict: version1} = identifiers.defined
+
+      identifiers =
+        """
+        Process.put(:x, 1)
+        """
+        |> eval(evaluator, 0)
+
+      assert %{pdict: ^version1} = identifiers.defined
+
+      identifiers =
+        """
+        Process.put(:x, 2)
+        """
+        |> eval(evaluator, 0)
+
+      assert %{pdict: version2} = identifiers.defined
+
+      assert version2 != version1
+    end
+
+    test "context merging", %{evaluator: evaluator} do
+      """
+      x = 1
+      y = 1
+
+      alias Enum, as: E
+      alias Map, as: M
+
+      require Enum
+
+      import Integer, only: [is_odd: 1, is_even: 1, to_string: 2, to_charlist: 2]
+
+      Process.put(:x, 1)
+      Process.put(:y, 1)
+      Process.put(:z, 1)
+      """
+      |> eval(evaluator, 0)
+
+      """
+      y = 2
+
+      alias MapSet, as: M
+
+      require Map
+
+      import Integer, except: [is_even: 1, to_string: 2]
+
+      Process.put(:y, 2)
+      Process.delete(:z)
+      """
+      |> eval(evaluator, 1)
+
+      # Evaluation 0 context
+
+      context = Evaluator.get_evaluation_context(evaluator, [0])
+
+      assert Enum.sort(context.binding) == [x: 1, y: 1]
+
+      assert Enum.sort(context.env.aliases) == [{E, Enum}, {M, Map}]
+
+      assert Enum in context.env.requires
+
+      assert [_, _ | _] = context.env.functions[Integer]
+      assert [_, _ | _] = context.env.macros[Integer]
+
+      assert context.env.versioned_vars == %{{:x, nil} => 0, {:y, nil} => 1}
+
+      assert context.pdict == %{x: 1, y: 1, z: 1}
+
+      # Evaluation 1 context
+
+      context = Evaluator.get_evaluation_context(evaluator, [1])
+
+      assert Enum.sort(context.binding) == [y: 2]
+
+      assert Enum.sort(context.env.aliases) == [{M, MapSet}]
+
+      assert Map in context.env.requires
+      assert Enum not in context.env.requires
+
+      # Imports are not diffed
+      assert {Integer, [to_charlist: 2]} in context.env.functions
+      assert {Integer, [is_odd: 1]} in context.env.macros
+
+      assert context.env.versioned_vars == %{{:y, nil} => 0}
+
+      # Process dictionary is not diffed
+      assert context.pdict == %{x: 1, y: 2}
+
+      # Merged context
+
+      context = Evaluator.get_evaluation_context(evaluator, [1, 0])
+
+      assert Enum.sort(context.binding) == [x: 1, y: 2]
+
+      assert Enum.sort(context.env.aliases) == [{E, Enum}, {M, MapSet}]
+
+      assert Enum in context.env.requires
+      assert Map in context.env.requires
+
+      assert {Integer, [to_charlist: 2]} in context.env.functions
+      assert {Integer, [is_odd: 1]} in context.env.macros
+
+      assert context.env.versioned_vars == %{{:x, nil} => 0, {:y, nil} => 1}
+
+      assert context.pdict == %{x: 1, y: 2}
     end
   end
 
   describe "forget_evaluation/2" do
     test "invalidates the given reference", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "x = 1", :code_1)
+      Evaluator.evaluate_code(evaluator, "x = 1", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
 
       Evaluator.forget_evaluation(evaluator, :code_1)
 
       ignore_warnings(fn ->
-        Evaluator.evaluate_code(evaluator, "x", :code_2, :code_1)
+        Evaluator.evaluate_code(evaluator, "x", :code_2, [:code_1])
 
         assert_receive {:runtime_evaluation_response, :code_2,
                         {:error, _kind,
@@ -272,7 +659,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
     end
 
     test "kills widgets that no evaluation points to", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1)
+      Evaluator.evaluate_code(evaluator, spawn_widget_code(), :code_1, [])
 
       assert_receive {:runtime_evaluation_response, :code_1, {:ok, widget_pid1}, metadata()}
 
@@ -295,44 +682,37 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
     test "copies the given context and sets as the initial one",
          %{evaluator: evaluator, parent_evaluator: parent_evaluator} do
-      Evaluator.evaluate_code(parent_evaluator, "x = 1", :code_1)
+      Evaluator.evaluate_code(parent_evaluator, "x = 1", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
 
-      Evaluator.initialize_from(evaluator, parent_evaluator, :code_1)
+      Evaluator.initialize_from(evaluator, parent_evaluator, [:code_1])
 
-      Evaluator.evaluate_code(evaluator, "x", :code_2)
-      assert_receive {:runtime_evaluation_response, :code_2, {:ok, 1}, metadata()}
-    end
-
-    test "mirrors process dictionary of the given evaluator",
-         %{evaluator: evaluator, parent_evaluator: parent_evaluator} do
-      Evaluator.evaluate_code(parent_evaluator, "Process.put(:data, 1)", :code_1)
-      assert_receive {:runtime_evaluation_response, :code_1, _, metadata()}
-
-      Evaluator.initialize_from(evaluator, parent_evaluator, :code_1)
-
-      Evaluator.evaluate_code(evaluator, "Process.get(:data)", :code_2)
+      Evaluator.evaluate_code(evaluator, "x", :code_2, [])
       assert_receive {:runtime_evaluation_response, :code_2, {:ok, 1}, metadata()}
     end
   end
 
   describe "binding order" do
     test "keeps binding in evaluation order, starting from most recent", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
-      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
-      Evaluator.evaluate_code(evaluator, "c = 1", :code_3, :code_2)
-      Evaluator.evaluate_code(evaluator, "x = 1", :code_4, :code_3)
+      Evaluator.evaluate_code(evaluator, "b = 1", :code_1, [])
+      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, [:code_1])
+      Evaluator.evaluate_code(evaluator, "c = 1", :code_3, [:code_2, :code_1])
+      Evaluator.evaluate_code(evaluator, "x = 1", :code_4, [:code_3, :code_2, :code_1])
 
-      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_4)
+      %{binding: binding} =
+        Evaluator.get_evaluation_context(evaluator, [:code_4, :code_3, :code_2, :code_1])
+
       assert [:x, :c, :a, :b] == Enum.map(binding, &elem(&1, 0))
     end
 
     test "treats rebound names as new", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, "b = 1", :code_1)
-      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, :code_1)
-      Evaluator.evaluate_code(evaluator, "b = 2", :code_3, :code_2)
+      Evaluator.evaluate_code(evaluator, "b = 1", :code_1, [])
+      Evaluator.evaluate_code(evaluator, "a = 1", :code_2, [:code_1])
+      Evaluator.evaluate_code(evaluator, "b = 2", :code_3, [:code_2, :code_1])
 
-      {:ok, %{binding: binding}} = Evaluator.fetch_evaluation_context(evaluator, :code_3)
+      %{binding: binding} =
+        Evaluator.get_evaluation_context(evaluator, [:code_3, :code_2, :code_1])
+
       assert [:b, :a] == Enum.map(binding, &elem(&1, 0))
     end
   end
@@ -359,6 +739,11 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
     ref = make_ref()
     send(Process.group_leader(), {:io_request, self(), ref, {:livebook_reference_object, widget_pid, self()}})
+
+    receive do
+      {:io_reply, ^ref, :ok} -> :ok
+    end
+
     send(Process.group_leader(), {:io_request, self(), ref, {:livebook_monitor_object, widget_pid, widget_pid, :stop}})
 
     receive do
@@ -383,6 +768,11 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       ref = make_ref()
       send(Process.group_leader(), {:io_request, self(), ref, {:livebook_reference_object, widget_pid, self()}})
+
+      receive do
+        {:io_reply, ^ref, :ok} -> :ok
+      end
+
       send(Process.group_leader(), {:io_request, self(), ref, {:livebook_monitor_object, widget_pid, widget_pid, :stop}})
 
       receive do

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -28,7 +28,7 @@ defmodule Livebook.Runtime.NoopRuntime do
 
     def read_file(_, _), do: raise("not implemented")
     def start_smart_cell(_, _, _, _, _), do: :ok
-    def set_smart_cell_base_locator(_, _, _), do: :ok
+    def set_smart_cell_parent_locators(_, _, _), do: :ok
     def stop_smart_cell(_, _), do: :ok
 
     def fixed_dependencies?(_), do: false


### PR DESCRIPTION
This adds a mechanism for tracking how cells depend on each other in terms of variables, imports, aliases, modules, process dictionary, etc. Based on this information cells are marked as "stale" and **reevaluated only if necessary**.

**Note:** this requires Elixir v1.14.2 to work as expected for variables.

## Motivation

Currently, whenever a cell is evaluated, all subsequent cells are marked as stale and require reevaluation. This happens regardless of whether those cells depend on the evaluated cell. This simple approach ensures reproducability by always evaluating cells sequentially.

The main issue with this "greedy" approach is that a cell may do a long computation and changing anything above it require running the long computation again.

## Idea

We now track which **identifiers** each cell **references** and **defines** (or redefines), then when a cell is reevaluated we know which cells it affects and we mark only those as "stale".

At evaluation level, instead of storing full evaluation context (all variables/aliases after an evaluation), we store diffs (new variables/aliases defined during an evaluation). Then, when evaluating a cell, we combine all the diffs from previous cells into full evaluation context. For example:

```elixir
# Cell 1
x = 1

# Cell 2
y = 1

# Cell 3
x + y
```

The diffs for cells 1 and 2 are `[x: 1]` and `[y: 1]` respectively. Now, when we change the first cell to `x = 2`, the diff becomes `[x: 2]`. Then to evaluate cell 3 we merge `[x: 2]` with `[y: 1]` and have `[x: 2, y: 1]` as the context, without reevaluating cell 2.

## Implementation details

### Session data

On the Livebook side, each cell has an additional information:

```elixir
%{
  ...,
  identifiers_used: list(identifier :: term()) | :unknown,
  identifiers_defined: %{(identifier :: term()) => version :: term()},
}
```

An identifier can be anything, a variable name, a module name, a fixed term such as `:pdict`. Each defined identifier has a version, which again can be anything, an hash digest, a random id, a fixed value.

This information is used when computing which cells are stale. To determine cell validity we already compute snapshots, but now a cell snapshot looks only at the parent cells that define identifiers used by that cell, and the identifier versions.

### Evaluator

On the Runtime side (specifically in the evaluator), after an evaluation we determine the identifiers it depends on, mostly by using a compilation tracer. The identifiers are reported/tracked with varying granularity, for example we have `{:variable, name}`, `{:module, name}` to track individual variables/modules, but we also have a single identifier `:pdict` to atomically track the process dictionary.

Depending on the identifier type, we approach the "version" differently:

* for variables it's a random id (reevaluating a cell like `x = 1` changes the snapshots anyway)
* for modules we compute MD5
* for pdict and imports we compute phash2
* for aliases we use the alias expanded value
* for requires we use a fixed `:ok` version