### PR TITLE
Improve reproducability of module definitions

### DIFF
--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -607,7 +607,8 @@ defmodule Livebook.Runtime.Evaluator do
           into: identifiers_used
 
     identifiers_defined =
-      for {module, {version, _vars}} <- tracer_info.modules_defined,
+      for {module, _vars} <- tracer_info.modules_defined,
+          version = module.__info__(:md5),
           do: {{:module, module}, version},
           into: identifiers_defined
 
@@ -684,7 +685,7 @@ defmodule Livebook.Runtime.Evaluator do
     # Note that :prune_binding removes variables used by modules
     # (unless used outside), so we get those from the tracer
     module_used_vars =
-      for {_module, {_version, vars}} <- tracer_info.modules_defined,
+      for {_module, vars} <- tracer_info.modules_defined,
           var <- vars,
           into: MapSet.new(),
           do: var

--- a/lib/livebook/runtime/evaluator/tracer.ex
+++ b/lib/livebook/runtime/evaluator/tracer.ex
@@ -21,7 +21,7 @@ defmodule Livebook.Runtime.Evaluator.Tracer do
 
   @doc false
   def trace(event, env) do
-    case to_updates(event, env) do
+    case event_to_updates(event, env) do
       [] ->
         :ok
 
@@ -33,11 +33,21 @@ defmodule Livebook.Runtime.Evaluator.Tracer do
     :ok
   end
 
-  defp to_updates(event, env) do
+  defp event_to_updates(event, env) do
     # Note that import/require/alias/defmodule don't trigger `:alias_reference`
     # for the used alias, so we add it explicitly
 
     case event do
+      :start ->
+        if Code.ensure_loaded?(env.module) do
+          raise CompileError,
+            line: env.line,
+            file: env.file,
+            description: "module #{inspect(env.module)} is already defined"
+        end
+
+        []
+
       {:import, _meta, module, _opts} ->
         if(env.module, do: [], else: [:import_defined]) ++
           [{:module_used, module}, {:alias_used, module}]

--- a/lib/livebook/runtime/evaluator/tracer.ex
+++ b/lib/livebook/runtime/evaluator/tracer.ex
@@ -83,11 +83,10 @@ defmodule Livebook.Runtime.Evaluator.Tracer do
       {:remote_macro, _meta, module, _name, _arity} ->
         [{:module_used, module}, {:require_used, module}]
 
-      {:on_module, bytecode, _ignore} ->
+      {:on_module, _bytecode, _ignore} ->
         module = env.module
-        version = :erlang.md5(bytecode)
         vars = Map.keys(env.versioned_vars)
-        [{:module_defined, module, version, vars}, {:alias_used, module}]
+        [{:module_defined, module, vars}, {:alias_used, module}]
 
       _ ->
         []
@@ -106,8 +105,8 @@ defmodule Livebook.Runtime.Evaluator.Tracer do
     update_in(info.modules_used, &MapSet.put(&1, module))
   end
 
-  defp apply_update(info, {:module_defined, module, version, vars}) do
-    put_in(info.modules_defined[module], {version, vars})
+  defp apply_update(info, {:module_defined, module, vars}) do
+    put_in(info.modules_defined[module], vars)
   end
 
   defp apply_update(info, {:alias_used, alias}) do


### PR DESCRIPTION
We now ensure a module can be defined by a single cell only:

![image](https://user-images.githubusercontent.com/17034772/200883570-e00ba997-a277-4c5d-a8dc-c65d824788cb.png)

Also, when module is no longer defined (e.g. a cell is deleted or commented out), the module is not available as expected.