### PR TITLE
Support passing an MFA for customizing shutdown

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :livebook,
   force_ssl_host: nil,
   learn_notebooks: [],
   plugs: [],
-  shutdown_enabled: false,
+  shutdown_callback: nil,
   storage: Livebook.Storage.Ets,
   update_instructions_url: nil,
   within_iframe: false

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,7 @@ config :livebook, LivebookWeb.Endpoint,
   ]
 
 config :livebook, :iframe_port, 4001
-config :livebook, :shutdown_enabled, true
+config :livebook, :shutdown_callback, {System, :stop, []}
 
 # Feature flags
 config :livebook, :feature_flags,

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -119,7 +119,7 @@ defmodule Livebook do
     end
 
     if Livebook.Config.boolean!("LIVEBOOK_SHUTDOWN_ENABLED", false) do
-      config :livebook, :shutdown_enabled, true
+      config :livebook, :shutdown_callback, {System, :stop, []}
     end
 
     if Livebook.Config.boolean!("LIVEBOOK_WITHIN_IFRAME", false) do

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -107,11 +107,11 @@ defmodule Livebook.Config do
   end
 
   @doc """
-  Returns whether the shutdown feature is enabled.
+  Returns an mfa if there's a way to shut down the system.
   """
-  @spec shutdown_enabled?() :: boolean()
-  def shutdown_enabled?() do
-    Application.fetch_env!(:livebook, :shutdown_enabled)
+  @spec shutdown_callback() :: mfa() | nil
+  def shutdown_callback() do
+    Application.fetch_env!(:livebook, :shutdown_callback)
   end
 
   @doc """

--- a/lib/livebook_web/live/hooks/sidebar_hook.ex
+++ b/lib/livebook_web/live/hooks/sidebar_hook.ex
@@ -23,11 +23,14 @@ defmodule LivebookWeb.SidebarHook do
   defp handle_info(_event, socket), do: {:cont, socket}
 
   defp handle_event("shutdown", _params, socket) do
-    if Livebook.Config.shutdown_enabled?() do
-      System.stop()
-      {:halt, put_flash(socket, :info, "Livebook is shutting down. You can close this page.")}
-    else
-      socket
+    case Livebook.Config.shutdown_callback() do
+      {m, f, a} ->
+        apply(m, f, a)
+
+        {:halt, put_flash(socket, :info, "Livebook is shutting down. You can close this page.")}
+
+      _ ->
+        socket
     end
   end
 

--- a/lib/livebook_web/live/layout_helpers.ex
+++ b/lib/livebook_web/live/layout_helpers.ex
@@ -113,7 +113,7 @@ defmodule LivebookWeb.LayoutHelpers do
           <.hub_section socket={@socket} hubs={@saved_hubs} current_page={@current_page} />
         </div>
         <div class="flex flex-col">
-          <%= if Livebook.Config.shutdown_enabled?() do %>
+          <%= if Livebook.Config.shutdown_callback() do %>
             <button
               class="h-7 flex items-center text-gray-400 hover:text-white border-l-4 border-transparent hover:border-white"
               aria-label="shutdown"


### PR DESCRIPTION
This commit lets you customize Livebook shutdown to gracefully power
off. One use case is for Nerves-based devices that need to do more than
call `System.stop/0` to power off.

This doesn't change the `LIVEBOOK_SHUTDOWN_ENABLED` environment
variable. It still works the same.

The `:shutdown_enabled` configuration is now `:shutdown_callback`. Valid
values are `nil` or an MFA. An unset or `nil` callback hides the shutdown 
button in the UI.
