### PR TITLE
Scroll to top and bottom of notebooks

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -127,6 +127,16 @@ const Session = {
       this.handleCellIndicatorsClick(event)
     );
 
+    this.getElement("focus-first-button").addEventListener(
+      "click",
+      (event) => this.moveFocusToHeadOrTail()
+    );
+
+    this.getElement("focus-last-button").addEventListener(
+      "click",
+      (event) => this.moveFocusToHeadOrTail(-1)
+    );
+
     this.getElement("code-zen-enable-button").addEventListener(
       "click",
       (event) => this.setCodeZen(true)
@@ -389,8 +399,12 @@ const Session = {
         }
       } else if (keyBuffer.tryMatch(["j"])) {
         this.moveFocus(1);
+      } else if (keyBuffer.tryMatch(["f", "u"])) {
+        this.moveFocusToHeadOrTail();
       } else if (keyBuffer.tryMatch(["k"])) {
         this.moveFocus(-1);
+      } else if (keyBuffer.tryMatch(["f", "d"])) {
+        this.moveFocusToHeadOrTail(-1);
       } else if (keyBuffer.tryMatch(["J"])) {
         this.moveFocusedCell(1);
       } else if (keyBuffer.tryMatch(["K"])) {
@@ -828,6 +842,11 @@ const Session = {
     this.setInsertMode(false);
   },
 
+  moveFocusToHeadOrTail(offset) {
+    const focusableId = this.headOrTailFocusableId(offset);
+    this.setFocusedEl(focusableId);
+  },
+
   moveFocus(offset) {
     const focusableId = this.nearbyFocusableId(this.focusedId, offset);
     this.setFocusedEl(focusableId);
@@ -1146,6 +1165,20 @@ const Session = {
     } else {
       return null;
     }
+  },
+
+  headOrTailFocusableId(offset) {
+    const focusableIds = this.getFocusableIds();
+
+    if (focusableIds.length === 0) {
+      return null;
+    }
+
+    let index = 2;
+    if (offset === -1) {
+      index = focusableIds.length - 1;
+    }
+    return focusableIds[index];
   },
 
   nearbyFocusableId(focusableId, offset) {

--- a/lib/livebook_web/live/session_live/indicators_component.ex
+++ b/lib/livebook_web/live/session_live/indicators_component.ex
@@ -38,6 +38,8 @@ defmodule LivebookWeb.SessionLive.IndicatorsComponent do
           class="flex flex-row-reverse sm:flex-col items-center justify-end p-2 sm:p-0 space-x-2 space-x-reverse sm:space-x-0 sm:space-y-2"
           data-el-notebook-indicators
         >
+          <.focus_first_indicator />
+          <.focus_last_indicator />
           <.code_zen_indicator />
           <.persistence_indicator
             file={@file}
@@ -56,6 +58,34 @@ defmodule LivebookWeb.SessionLive.IndicatorsComponent do
         </div>
       </div>
     </div>
+    """
+  end
+
+  defp focus_first_indicator(assigns) do
+    ~H"""
+    <span class="tooltip left" data-tooltip="Focus on the first cell">
+      <button
+        class="icon-button icon-outlined-button border-gray-200 hover:bg-gray-100 focus:bg-gray-100"
+        aria-label="focus on the first cell"
+        data-el-focus-first-button
+      >
+        <.remix_icon icon="play-line" class="text-xl text-gray-400 -rotate-90" />
+      </button>
+    </span>
+    """
+  end
+
+  defp focus_last_indicator(assigns) do
+    ~H"""
+    <span class="tooltip left" data-tooltip="Focus on the last cell">
+      <button
+        class="icon-button icon-outlined-button border-gray-200 hover:bg-gray-100 focus:bg-gray-100"
+        aria-label="focus on the last cell"
+        data-el-focus-last-button
+      >
+        <.remix_icon icon="play-line" class="text-xl text-gray-400 rotate-90" />
+      </button>
+    </span>
     """
   end
 

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -82,6 +82,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
     ],
     navigation_mode: [
       %{seq: ["?"], desc: "Open this help modal", basic: true},
+      %{seq: ["f", "u"], desc: "Focus on first cell", basic: true},
+      %{seq: ["f", "d"], desc: "Focus on last cell", basic: true},
       %{seq: ["j"], desc: "Focus next cell", basic: true},
       %{seq: ["k"], desc: "Focus previous cell", basic: true},
       %{seq: ["J"], desc: "Move cell down"},


### PR DESCRIPTION
Working through [DockYard's Elixir curriculum](https://github.com/DockYard-Academy/beta_curriculum), I've needed to quickly scroll to the top and bottom of notebooks as there is different navigation at both ends. Some good examples of where this is useful are the course outline at https://github.com/DockYard-Academy/beta_curriculum/blob/main/start.livemd or https://github.com/DockYard-Academy/beta_curriculum/blob/main/reading/recursion.livemd.

I apologize, this state is pretty rough as I got bit by multiple naming conflicts. I reused the move focus functionality to perform the scrolling. These aren't indicators but buttons. It's not technically the head since it's hardcoded to focus on the 1st cell below the setup area, so `moveFocusToHeadOrTail` is awkwardly named. The keys `f, u` for focus up, and `f, d` for focus down are also awkward and I just realized all of the double keys are on the right-hand side of the screen when you bring up the help with `?`.