### PR TITLE
Increase memory for uffizzi deployment

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -12,3 +12,7 @@ services:
     ports:
       - 8080:8080
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2000M


### PR DESCRIPTION
uffizzi preview is restarting with OOMKilled. Increasing memory to 2GB