### PR TITLE
Fix error when specifying custom learn notebooks

### DIFF
--- a/lib/livebook_web/live/learn_helpers.ex
+++ b/lib/livebook_web/live/learn_helpers.ex
@@ -26,6 +26,7 @@ defmodule LivebookWeb.LearnHelpers do
     <% end %>
     """
   end
+
   defp img_src(_socket, "data:" <> _ = url), do: url
   defp img_src(socket, url), do: Routes.static_path(socket, url)
 end

--- a/lib/livebook_web/live/learn_helpers.ex
+++ b/lib/livebook_web/live/learn_helpers.ex
@@ -12,13 +12,7 @@ defmodule LivebookWeb.LearnHelpers do
             class: "flex flex-col border-2 border-gray-100 hover:border-gray-200 rounded-2xl" do %>
       <div class="flex items-center justify-center p-6 border-b-2 border-gray-100 rounded-t-2xl h-[150px]">
         <img
-          src={
-            cover_url = @notebook_info.details.cover_url
-
-            if String.starts_with?(cover_url, "data:"),
-              do: cover_url,
-              else: Routes.static_path(@socket, cover_url)
-          }
+          src={img_src(@socket, @notebook_info.details.cover_url)}
           class="max-h-full max-w-[75%]"
           alt={"#{@notebook_info.title} logo"}
         />
@@ -32,4 +26,7 @@ defmodule LivebookWeb.LearnHelpers do
     <% end %>
     """
   end
+  
+  defp img_src(_socket, "data:" <> _ = url), do: url
+  defp img_src(socket, url), do: Routes.static_path(socket, url)
 end

--- a/lib/livebook_web/live/learn_helpers.ex
+++ b/lib/livebook_web/live/learn_helpers.ex
@@ -12,7 +12,13 @@ defmodule LivebookWeb.LearnHelpers do
             class: "flex flex-col border-2 border-gray-100 hover:border-gray-200 rounded-2xl" do %>
       <div class="flex items-center justify-center p-6 border-b-2 border-gray-100 rounded-t-2xl h-[150px]">
         <img
-          src={Routes.static_path(@socket, @notebook_info.details.cover_url)}
+          src={
+            cover_url = @notebook_info.details.cover_url
+
+            if String.starts_with?(cover_url, "data:"),
+              do: cover_url,
+              else: Routes.static_path(@socket, cover_url)
+          }
           class="max-h-full max-w-[75%]"
           alt={"#{@notebook_info.title} logo"}
         />

--- a/lib/livebook_web/live/learn_helpers.ex
+++ b/lib/livebook_web/live/learn_helpers.ex
@@ -26,7 +26,6 @@ defmodule LivebookWeb.LearnHelpers do
     <% end %>
     """
   end
-  
   defp img_src(_socket, "data:" <> _ = url), do: url
   defp img_src(socket, url), do: Routes.static_path(socket, url)
 end


### PR DESCRIPTION
This fixes the following error when using a custom learn notebook:

```
07:18:26.178 [error] #PID<0.2236.0> running LivebookWeb.Endpoint (connection #PID<0.2226.0>, stream id 6) terminated
Server: localhost:8080 (http)
Request: GET /
** (exit) an exception was raised:
    ** (ArgumentError) expected a path starting with a single / but got "data:image/svg+xml;base64,PD94bWwgdmVyc2lv..."
        (phoenix 1.6.15) lib/phoenix/endpoint/supervisor.ex:311: Phoenix.Endpoint.Supervisor.raise_invalid_path/1
        (phoenix 1.6.15) lib/phoenix/config.ex:65: Phoenix.Config.cache/3
        (livebook 0.8.0) lib/phoenix/endpoint.ex:597: LivebookWeb.Endpoint.static_path/1
        (livebook 0.8.0) lib/livebook_web/live/learn_helpers.ex:15: anonymous fn/2 in LivebookWeb.LearnHelpers.notebook_card/1
        (livebook 0.8.0) /Users/fhunleth/git/livebook-dev/livebook/lib/livebook_web/live/home_live.ex:119: LivebookWeb.HomeLive.render/1
        (elixir 1.14.2) lib/enum.ex:1780: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```
