### PR TITLE
Widen the inputs for the authentication screen

### DIFF
--- a/lib/livebook_web/templates/auth/index.html.eex
+++ b/lib/livebook_web/templates/auth/index.html.eex
@@ -19,10 +19,10 @@
       <form method="post" class="flex flex-col space-y-4 items-center">
         <input type="hidden" value="<%= Phoenix.Controller.get_csrf_token() %>" name="_csrf_token"/>
         <%= if @auth_mode == :password do %>
-          <div phx-feedback-for="password" class="<%= if(@errors, do: "show-errors w-full", else: "w-full") %>">
+          <div phx-feedback-for="password" class="<%= if(@errors, do: "show-errors w-[20ch]", else: "w-[20ch]") %>">
           <input type="password" name="password" class="input" placeholder="Password" autofocus />
         <% else %>
-          <div phx-feedback-for="token" class="<%= if(@errors, do: "show-errors w-full", else: "w-full") %>">
+          <div phx-feedback-for="token" class="<%= if(@errors, do: "show-errors w-[20ch]", else: "w-[20ch]") %>">
           <input type="text" name="token" class="input" placeholder="Token" autofocus />
         <% end %>
         <%= for error <- @errors || [] do %>

--- a/lib/livebook_web/templates/auth/index.html.eex
+++ b/lib/livebook_web/templates/auth/index.html.eex
@@ -19,10 +19,10 @@
       <form method="post" class="flex flex-col space-y-4 items-center">
         <input type="hidden" value="<%= Phoenix.Controller.get_csrf_token() %>" name="_csrf_token"/>
         <%= if @auth_mode == :password do %>
-          <div phx-feedback-for="password" class="<%= if(@errors, do: "show-errors", else: "") %>">
+          <div phx-feedback-for="password" class="<%= if(@errors, do: "show-errors w-full", else: "w-full") %>">
           <input type="password" name="password" class="input" placeholder="Password" autofocus />
         <% else %>
-          <div phx-feedback-for="token" class="<%= if(@errors, do: "show-errors", else: "") %>">
+          <div phx-feedback-for="token" class="<%= if(@errors, do: "show-errors w-full", else: "w-full") %>">
           <input type="text" name="token" class="input" placeholder="Token" autofocus />
         <% end %>
         <%= for error <- @errors || [] do %>


### PR DESCRIPTION
I thought it would be useful to expand the input fields on the authentication screen to take up the full width of the container it's in. 

Instead of
<img width="1680" alt="Livebook Authentication screen with input squished to center of the box" src="https://user-images.githubusercontent.com/489986/206885282-fbe54550-51b1-48ee-920f-b6632dc299a4.png">

what about

https://user-images.githubusercontent.com/489986/206885338-79fbb5f7-8619-4003-9303-9b5a178cce54.mp4

Padding on the container like `px-2` or `px-4` could also be applied to reduce the size of the input field just a little bit as it currently is flush with the message above it.