### PR TITLE
Build CUDA images for both amd and arm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,10 +104,25 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: livebook/livebook
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}-cuda11.8
+            type=raw,value=latest-cuda11.8
       - name: Build and push
-        run: |
-          version=${GITHUB_REF#refs/*/v}
-          docker/build_and_push.sh $version,latest true
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            BASE_IMAGE=livebook/utils:elixir-cuda11.8
 
   create_draft_release:
     if: github.ref_type == 'tag'

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,36 +1,17 @@
 #!/bin/bash
 
-set -e
+# Builds base images used to build extra flavours of Livebook images
+
+set -ex
 cd "$(dirname "$0")/.."
-
-print_usage_and_exit() {
-  echo "Usage: $0 <versions> <push>"
-  echo ""
-  echo "Builds extra variants of the regular Livebook Docker image."
-  echo ""
-  echo "<versions> is a comma-separated list of versions to use in the image tags (such as 0.1.0 or latest)."
-  echo "Set <push> to 'true' to also pushe the images."
-  exit 1
-}
-
-if [ $# -ne 2 ]; then
-  print_usage_and_exit
-fi
-
-versions=$1
-push=$2
 
 elixir=1.14.2
 erlang=24.3.4.2
 
-docker build -t elixir-cuda11.8 --build-arg ELIXIR_VERSION=$elixir --build-arg ERLANG_VERSION=$erlang --build-arg CUDA_VERSION=11.8.0 -f docker/base/elixir-cuda.dockerfile docker/base
-docker build -t livebook-cuda11.8 --build-arg BASE_IMAGE=elixir-cuda11.8 .
-
-for version in ${versions//,/ }; do
-  image=livebook/livebook:$version-cuda11.8
-  docker tag livebook-cuda11.8 $image
-
-  if [[ "$2" == "true" ]]; then
-    docker push $image
-  fi
-done
+docker buildx build --push --platform linux/amd64,linux/arm64 \
+  -t livebook/utils:elixir-cuda11.8 \
+  --build-arg ELIXIR_VERSION=$elixir \
+  --build-arg ERLANG_VERSION=$erlang \
+  --build-arg CUDA_VERSION=11.8.0 \
+  -f docker/base/elixir-cuda.dockerfile \
+  docker/base


### PR DESCRIPTION
See #1589.

We will now build `livebook/utils:elixir-cuda11.8` for both architectures off-CI. Then use it as a base image to build both architectures on the CI on every release.