### PR TITLE
Adding support for capturing images from a camera

### DIFF
--- a/lib/livebook_web/live/output/image_input_component.ex
+++ b/lib/livebook_web/live/output/image_input_component.ex
@@ -58,7 +58,7 @@ defmodule LivebookWeb.Output.ImageInputComponent do
         <div class="flex items-center justify-center text-gray-500" data-from-camera="true" data-camera-select-menu>
           <.menu id={"#{@id}-camera-select-menu"} position="bottom-left">
             <:toggle>
-              <button class="icon-button" aria-label="select camera" data-from-camera="true">
+              <button class="icon-button button-gray rounded-lg" aria-label="select camera" data-from-camera="true">
                 <span data-from-camera="true">From camera</span>
                 <.remix_icon icon="camera-switch-line" style="padding-inline-start: 5px" class="text-sm" />
               </button>

--- a/lib/livebook_web/live/output/image_input_component.ex
+++ b/lib/livebook_web/live/output/image_input_component.ex
@@ -48,10 +48,25 @@ defmodule LivebookWeb.Output.ImageInputComponent do
       data-format={@format}
       data-fit={@fit}
     >
-      <input type="file" data-input class="hidden" name="value" />
-      <div id={"#{@id}-preview"} phx-update="ignore" data-preview>
-        <div class="text-gray-500">
-          Drag an image file here or click to open file browser
+      <input type="file" data-input class="hidden" name="value" accept="image/*" capture="user" />
+      <div>
+        <div id={"#{@id}-preview"} phx-update="ignore" data-preview>
+          <div class="text-gray-500">
+            Drag an image file here or click to open file browser
+          </div>
+        </div>
+        <div class="flex items-center justify-center text-gray-500" data-from-camera="true" data-camera-select-menu>
+          <.menu id={"#{@id}-camera-select-menu"} position="bottom-left">
+            <:toggle>
+              <button class="icon-button" aria-label="select camera" data-from-camera="true">
+                <span data-from-camera="true">From camera</span>
+                <.remix_icon icon="camera-switch-line" style="padding-inline-start: 5px" class="text-sm" />
+              </button>
+            </:toggle>
+            <:content>
+              <div data-camera-list></div>
+            </:content>
+          </.menu>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Preliminary support for capturing images from a camera.

<img width="445" alt="Screenshot 2022-12-18 at 09 27 32" src="https://user-images.githubusercontent.com/89497197/208290852-0e59a7c1-93e1-4cbb-82c9-3ed5d7306209.png">

Currently, it can switch between different cameras by clicking on the camera icon.

<img width="453" alt="Screenshot 2022-12-18 at 09 29 22" src="https://user-images.githubusercontent.com/89497197/208290903-26338bab-c4bd-4dc4-b5b7-c288d7ab288f.png">

The user needs to click on the preview to capture an image. 

Of course, I'll later add a button to take the photo.

The todo list in my mind includes:
- Probably will also need to add a button to remove the current image, and reset the widget to its initial status.
- Add a button to take a photo.

/cc @josevalim WDYT, and any ideas or suggestions? :)