### PR TITLE
Load JS view iframe only once in viewport

### DIFF
--- a/assets/js/lib/utils.js
+++ b/assets/js/lib/utils.js
@@ -21,6 +21,10 @@ export function isElementHidden(element) {
   return element.offsetParent === null;
 }
 
+export function isElementVisibleInViewport(element) {
+  return !isElementHidden(element) && isElementInViewport(element);
+}
+
 export function clamp(n, x, y) {
   return Math.min(Math.max(n, x), y);
 }


### PR DESCRIPTION
Closes https://github.com/livebook-dev/kino/issues/230.

This is actually a fairly massive optimisation for notebooks with numerous iframes. For example, when navigating to the notebook with VegaLite examples (already evaluated), loading all the iframes and rendering all the plots is quite some work (it also takes 350+ requests, though those are generally cached). With this optimisation we load the charts as the user scrolls.