### PR TITLE
Focus the packge search input on mount

### DIFF
--- a/lib/livebook_web/live/session_live/package_search_live.ex
+++ b/lib/livebook_web/live/session_live/package_search_live.ex
@@ -43,6 +43,7 @@ defmodule LivebookWeb.SessionLive.PackageSearchLive do
           autocomplete="off"
           spellcheck="false"
           autofocus
+          phx-mounted={JS.focus()}
         />
       </form>
       <div class={


### PR DESCRIPTION
Focus the packge search input on mount, to avoid typing in underlying code cell.

Without this behaviour, you'd press the search package button, start typing, and notice you're not typing in the search input field. Then you'd focus the input, search a package, try to add it, and see it can't be added because you had messed up the underlying code cell that doesn't compile anymore. This annoyed me a few times too may.

Also, I don't think the html attribute `autofocus` is not doing much there, if I understand [this documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus). There is no `<dialog>` tag, and the autofocus behaviour only happens on pageloads. And it should be the only tag with this attribute on the page, which doesn't seem to be the case. I've left it in place, as I'm not sure.