### PR TITLE
Add support for file input

### DIFF
--- a/assets/js/hooks/audio_input.js
+++ b/assets/js/hooks/audio_input.js
@@ -187,11 +187,9 @@ const AudioInput = {
 
   pushAudio(audioInfo) {
     this.pushEventTo(this.props.phxTarget, "change", {
-      value: {
-        data: bufferToBase64(this.encodeAudio(audioInfo)),
-        num_channels: audioInfo.numChannels,
-        sampling_rate: audioInfo.samplingRate,
-      },
+      data: bufferToBase64(this.encodeAudio(audioInfo)),
+      num_channels: audioInfo.numChannels,
+      sampling_rate: audioInfo.samplingRate,
     });
   },
 

--- a/assets/js/hooks/image_input.js
+++ b/assets/js/hooks/image_input.js
@@ -265,11 +265,9 @@ const ImageInput = {
 
   pushImage(canvas) {
     this.pushEventTo(this.props.phxTarget, "change", {
-      value: {
-        data: canvasToBase64(canvas, this.props.format),
-        height: canvas.height,
-        width: canvas.width,
-      },
+      data: canvasToBase64(canvas, this.props.format),
+      height: canvas.height,
+      width: canvas.width,
     });
   },
 

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -84,4 +84,10 @@ defmodule Livebook.Notebook.Cell do
   """
   @spec setup_cell_id() :: id()
   def setup_cell_id(), do: @setup_cell_id
+
+  @doc """
+  Checks if the given term is a file input value (info map).
+  """
+  defguard is_file_input_value(value)
+           when is_map_key(value, :path) and is_map_key(value, :client_name)
 end

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -417,6 +417,25 @@ defprotocol Livebook.Runtime do
   def read_file(runtime, path)
 
   @doc """
+  Transfers file at `path` to the runtime.
+
+  This operation is asynchronous and `callback` is called with the
+  path of the transferred file (on the runtime host) once the transfer
+  is complete.
+
+  If the runtime is on the same host as the caller, the implementation
+  may simply use `path`.
+  """
+  @spec transfer_file(t(), String.t(), String.t(), (path :: String.t() | nil -> any())) :: :ok
+  def transfer_file(runtime, path, file_id, callback)
+
+  @doc """
+  Cleans up resources allocated with `transfer_file/4`, if any.
+  """
+  @spec revoke_file(t(), String.t()) :: :ok
+  def revoke_file(runtime, file_id)
+
+  @doc """
   Starts a smart cell of the given kind.
 
   `kind` must point to an available `t:smart_cell_definition/0`, which

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -115,6 +115,14 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
+  def transfer_file(runtime, path, file_id, callback) do
+    RuntimeServer.transfer_file(runtime.server_pid, path, file_id, callback)
+  end
+
+  def revoke_file(runtime, file_id) do
+    RuntimeServer.revoke_file(runtime.server_pid, file_id)
+  end
+
   def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
     RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -278,6 +278,14 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
+  def transfer_file(runtime, path, file_id, callback) do
+    RuntimeServer.transfer_file(runtime.server_pid, path, file_id, callback)
+  end
+
+  def revoke_file(runtime, file_id) do
+    RuntimeServer.revoke_file(runtime.server_pid, file_id)
+  end
+
   def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
     RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -96,6 +96,14 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     RuntimeServer.read_file(runtime.server_pid, path)
   end
 
+  def transfer_file(runtime, path, file_id, callback) do
+    RuntimeServer.transfer_file(runtime.server_pid, path, file_id, callback)
+  end
+
+  def revoke_file(runtime, file_id) do
+    RuntimeServer.revoke_file(runtime.server_pid, file_id)
+  end
+
   def start_smart_cell(runtime, kind, ref, attrs, parent_locators) do
     RuntimeServer.start_smart_cell(runtime.server_pid, kind, ref, attrs, parent_locators)
   end

--- a/lib/livebook/runtime/erl_dist/node_manager.ex
+++ b/lib/livebook/runtime/erl_dist/node_manager.ex
@@ -184,7 +184,10 @@ defmodule Livebook.Runtime.ErlDist.NodeManager do
 
   @impl true
   def handle_call({:start_runtime_server, opts}, _from, state) do
-    opts = Keyword.put_new(opts, :ebin_path, ebin_path(state.tmp_dir))
+    opts =
+      opts
+      |> Keyword.put_new(:ebin_path, ebin_path(state.tmp_dir))
+      |> Keyword.put_new(:tmp_dir, child_tmp_dir(state.tmp_dir))
 
     {:ok, server_pid} =
       DynamicSupervisor.start_child(state.server_supervisor, {ErlDist.RuntimeServer, opts})
@@ -204,6 +207,9 @@ defmodule Livebook.Runtime.ErlDist.NodeManager do
 
   defp ebin_path(nil), do: nil
   defp ebin_path(tmp_dir), do: Path.join(tmp_dir, "ebin")
+
+  defp child_tmp_dir(nil), do: nil
+  defp child_tmp_dir(tmp_dir), do: Path.join(tmp_dir, random_id())
 
   defp random_id() do
     :crypto.strong_rand_bytes(20) |> Base.encode32(case: :lower)

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -213,12 +213,18 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:input, attrs}, %{id: id, input_values: input_values, client_id: client_id}) do
+  defp render_output({:input, attrs}, %{
+         id: id,
+         input_values: input_values,
+         client_id: client_id,
+         session_id: session_id
+       }) do
     live_component(Output.InputComponent,
       id: id,
       attrs: attrs,
       input_values: input_values,
-      client_id: client_id
+      client_id: client_id,
+      session_id: session_id
     )
   end
 

--- a/lib/livebook_web/live/output/audio_input_component.ex
+++ b/lib/livebook_web/live/output/audio_input_component.ex
@@ -42,7 +42,7 @@ defmodule LivebookWeb.Output.AudioInputComponent do
       phx-hook="AudioInput"
       phx-update="ignore"
       data-id={@id}
-      data-phx-target={@target}
+      data-phx-target={@myself}
       data-format={@format}
       data-sampling-rate={@sampling_rate}
       data-endianness={@endianness}
@@ -85,5 +85,23 @@ defmodule LivebookWeb.Output.AudioInputComponent do
       </div>
     </div>
     """
+  end
+
+  @impl true
+  def handle_event("change", params, socket) do
+    value = %{
+      data: Base.decode64!(params["data"]),
+      num_channels: params["num_channels"],
+      sampling_rate: params["sampling_rate"],
+      format: socket.assigns.format
+    }
+
+    send_update(LivebookWeb.Output.InputComponent,
+      id: socket.assigns.input_component_id,
+      event: :change,
+      value: value
+    )
+
+    {:noreply, socket}
   end
 end

--- a/lib/livebook_web/live/output/file_input_component.ex
+++ b/lib/livebook_web/live/output/file_input_component.ex
@@ -1,0 +1,96 @@
+defmodule LivebookWeb.Output.FileInputComponent do
+  use LivebookWeb, :live_component
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, initialized: false)}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket = assign(socket, assigns)
+
+    socket =
+      if socket.assigns.initialized do
+        socket
+      else
+        socket
+        |> allow_upload(:file,
+          accept: socket.assigns.accept,
+          max_entries: 1,
+          progress: &handle_progress/3,
+          auto_upload: true
+        )
+        |> assign(initialized: true)
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <form id={"#{@id}-root"} phx-change="validate" phx-target={@myself}>
+      <label
+        class="inline-flex flex-col gap-4 p-4 border-2 border-dashed border-gray-200 rounded-lg cursor-pointer"
+        phx-drop-target={@uploads.file.ref}
+        phx-hook="Dropzone"
+        id="upload-file-dropzone"
+      >
+        <div class="flex justify-center text-gray-500">
+          <%= if @value do %>
+            <%= @value.client_name %>
+          <% else %>
+            Click to select a file or drag a local file here
+          <% end %>
+        </div>
+        <.live_file_input upload={@uploads.file} class="hidden" />
+      </label>
+    </form>
+    """
+  end
+
+  @impl true
+  def handle_event("validate", %{}, socket) do
+    {:noreply, socket}
+  end
+
+  defp handle_progress(:file, entry, socket) do
+    if entry.done? do
+      socket
+      |> consume_uploaded_entries(:file, fn %{path: path}, entry ->
+        destination_path =
+          Livebook.Session.local_file_input_path(
+            socket.assigns.session_id,
+            socket.assigns.input_id
+          )
+
+        destination_path |> Path.dirname() |> File.mkdir_p!()
+        File.cp!(path, destination_path)
+
+        {:ok, {destination_path, entry.client_name}}
+      end)
+      |> case do
+        [{path, client_name}] ->
+          # The path is always the same, so we include a random version
+          # to reflect a new value
+          value = %{
+            path: path,
+            client_name: client_name,
+            version: Livebook.Utils.random_short_id()
+          }
+
+          send_update(LivebookWeb.Output.InputComponent,
+            id: socket.assigns.input_component_id,
+            event: :change,
+            value: value
+          )
+
+        [] ->
+          :ok
+      end
+    end
+
+    {:noreply, socket}
+  end
+end

--- a/lib/livebook_web/live/output/image_input_component.ex
+++ b/lib/livebook_web/live/output/image_input_component.ex
@@ -42,7 +42,7 @@ defmodule LivebookWeb.Output.ImageInputComponent do
       phx-hook="ImageInput"
       phx-update="ignore"
       data-id={@id}
-      data-phx-target={@target}
+      data-phx-target={@myself}
       data-height={@height}
       data-width={@width}
       data-format={@format}
@@ -94,5 +94,23 @@ defmodule LivebookWeb.Output.ImageInputComponent do
       </div>
     </div>
     """
+  end
+
+  @impl true
+  def handle_event("change", params, socket) do
+    value = %{
+      data: Base.decode64!(params["data"]),
+      height: params["height"],
+      width: params["width"],
+      format: socket.assigns.format
+    }
+
+    send_update(LivebookWeb.Output.InputComponent,
+      id: socket.assigns.input_component_id,
+      event: :change,
+      value: value
+    )
+
+    {:noreply, socket}
   end
 end

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -27,6 +27,9 @@ defmodule Livebook.Runtime.NoopRuntime do
     def handle_intellisense(_, _, _, _), do: make_ref()
 
     def read_file(_, _), do: raise("not implemented")
+    def transfer_file(_, _, _, _), do: raise("not implemented")
+    def revoke_file(_, _), do: raise("not implemented")
+
     def start_smart_cell(_, _, _, _, _), do: :ok
     def set_smart_cell_parent_locators(_, _, _), do: :ok
     def stop_smart_cell(_, _), do: :ok


### PR DESCRIPTION
https://user-images.githubusercontent.com/17034772/210635325-a82faace-354e-4fa0-9d44-af613c1c02f4.mp4

### Details

We move the uploaded file to the session temporary directory. Then, when the input is read, we pass the file path. If the runtime is on a different host (could be the case with the Attached runtime), we copy the file to the runtime host and use that path for the input value. Note that in such case we copy only once, on subsequent input reads we check file md5 and don't copy unnecessarily.

Session temporary directory is cleaned when the session is closed. Similarly the runtime temporary directory is cleaned by `NodeManager` before it terminates (which it already does for the ebin directory). Additionally we eagerly remove files when the the input is removed.