### PR TITLE
Allow including ERTS in livebook release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -145,7 +145,7 @@ defmodule Livebook.MixProject do
     [
       livebook: [
         include_executables_for: [:unix],
-        include_erts: false,
+        include_erts: System.get_env("LIVEBOOK_RELEASE_INCLUDE_ERTS", false),
         rel_templates_path: "rel/server",
         steps: [:assemble, &remove_cookie/1]
       ],


### PR DESCRIPTION
Hi Livebook team,

when deploying livebook onto servers, it is beneficial to have the option of including ERTS in the release. For example, it allows deploying livebook to servers without having to install Erlang separately.

In my use case, I am building Livebook as an Elixir release with Gitlab CI then deploying it onto virtual machines. To avoid the headache of keeping Erlang up-to-date on many virtual machines and making sure the versions line up across many different Elixir applications, we include ERTS in our Elixir releases and would like to do the same with Livebook.

This PR makes this possible using an environment variable and defaults to the current behavior if unspecified.

Thank you!