### PR TITLE
Render inline math in on-hover docs

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -402,7 +402,13 @@ class LiveEditor {
             // We mutate the DOM, so we use a flag to ignore events
             // that we triggered ourselves
             if (!this.hoverContentProcessed) {
-              renderMathInElement(this.hoverContentEl);
+              renderMathInElement(this.hoverContentEl, {
+                delimiters: [
+                  { left: "$$", right: "$$", display: true },
+                  { left: "$", right: "$", display: false },
+                ],
+                throwOnError: false,
+              });
               this.hoverContentProcessed = true;
             }
           }).observe(this.hoverContentEl, { childList: true });


### PR DESCRIPTION
As of #1566 we render math in on-hover docs, but the default configuration doesn't handle single dollars for inline math.