### PR TITLE
Allow specifying S3 region explicitly

### DIFF
--- a/lib/livebook_web/live/settings_live/add_file_system_component.ex
+++ b/lib/livebook_web/live/settings_live/add_file_system_component.ex
@@ -44,6 +44,13 @@ defmodule LivebookWeb.SettingsLive.AddFileSystemComponent do
             ) %>
           </div>
           <div>
+            <div class="input-label">Region (optional)</div>
+            <%= text_input(f, :region,
+              value: @data["region"],
+              class: "input"
+            ) %>
+          </div>
+          <div>
             <div class="input-label">Access Key ID</div>
             <.with_password_toggle id="access-key-password-toggle">
               <%= text_input(f, :access_key_id,
@@ -97,7 +104,7 @@ defmodule LivebookWeb.SettingsLive.AddFileSystemComponent do
   end
 
   defp empty_data() do
-    %{"bucket_url" => "", "access_key_id" => "", "secret_access_key" => ""}
+    %{"bucket_url" => "", "region" => "", "access_key_id" => "", "secret_access_key" => ""}
   end
 
   defp data_valid?(data) do
@@ -106,6 +113,10 @@ defmodule LivebookWeb.SettingsLive.AddFileSystemComponent do
   end
 
   defp data_to_file_system(data) do
-    FileSystem.S3.new(data["bucket_url"], data["access_key_id"], data["secret_access_key"])
+    region = if(data["region"] != "", do: data["region"])
+
+    FileSystem.S3.new(data["bucket_url"], data["access_key_id"], data["secret_access_key"],
+      region: region
+    )
   end
 end

--- a/test/livebook/file_system/s3_test.exs
+++ b/test/livebook/file_system/s3_test.exs
@@ -14,6 +14,18 @@ defmodule Livebook.FileSystem.S3Test do
       assert %{bucket_url: "https://example.com/mybucket"} =
                S3.new("https://example.com/mybucket/", "key", "secret")
     end
+
+    test "determines region based on the URL by default" do
+      assert %{region: "eu-central-1"} =
+               S3.new("https://s3.eu-central-1.amazonaws.com/mybucket", "key", "secret")
+    end
+
+    test "accepts explicit region as an option" do
+      assert %{region: "auto"} =
+               S3.new("https://s3.eu-central-1.amazonaws.com/mybucket", "key", "secret",
+                 region: "auto"
+               )
+    end
   end
 
   describe "FileSystem.default_path/1" do


### PR DESCRIPTION
Closes #1637.

The bucket URL is usually `*.[region].[rootdomain].com`, so we can infer the region, but that may not be the case for all providers. For example Cloudflare uses `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` and they expect region to be set to `auto`.

This adds an optional field for specifying the region explicitly:

![image](https://user-images.githubusercontent.com/17034772/212060269-e383708b-5701-4293-abce-917432989eb9.png)