### PR TITLE
Expose the global monaco instance for firenvim extension support

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = (env, options) => {
           "css",
           "javascript",
         ],
+        globalAPI: true,
       }),
     ],
     optimization: {


### PR DESCRIPTION
TLDR: It'll resolve the #715

This Patch will make the Firenvim extension work on the livebook editor. Firenvim extension enables editing text-area using embedded Neovim instance. [See here about Firenvim](https://github.com/glacambre/firenvim)

The Firenvim extension relies on `window.monaco` object, which needs to be exposed globally on the webpack configuration.