### PR TITLE
fix import button disappear in small screens

### DIFF
--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -43,10 +43,15 @@ defmodule LivebookWeb.HomeLive do
       saved_hubs={@saved_hubs}
     >
       <:topbar_action>
-        <a aria-label="new-notebook" class="flex items-center cursor-pointer" phx-click="new">
-          <.remix_icon icon="add-line" />
-          <span class="pl-2">New notebook</span>
-        </a>
+        <div class="flex space-x-2">
+          <%= live_patch("Import",
+            to: Routes.home_path(@socket, :import, "url"),
+            class: "button-base button-outlined-gray whitespace-nowrap"
+          ) %>
+          <button class="button-base button-blue" phx-click="new">
+            New notebook
+          </button>
+        </div>
       </:topbar_action>
       <.update_notification version={@new_version} instructions_url={@update_instructions_url} />
       <.memory_notification memory={@memory} app_service_url={@app_service_url} />

--- a/lib/livebook_web/live/layout_helpers.ex
+++ b/lib/livebook_web/live/layout_helpers.ex
@@ -39,12 +39,14 @@ defmodule LivebookWeb.LayoutHelpers do
             </button>
           </div>
 
-          <div class="text-gray-400 hover:text-gray-600 focus:text-gray-600">
+          <div>
             <%= if @topbar_action == [] do %>
-              <%= live_redirect to: Routes.home_path(@socket, :page), class: "flex items-center", aria: [label: "go to home"] do %>
-                <.remix_icon icon="home-6-line" />
-                <span class="pl-2">Home</span>
-              <% end %>
+              <div class="text-gray-400 hover:text-gray-600 focus:text-gray-600">
+                <%= live_redirect to: Routes.home_path(@socket, :page), class: "flex items-center", aria: [label: "go to home"] do %>
+                  <.remix_icon icon="home-6-line" />
+                  <span class="pl-2">Home</span>
+                <% end %>
+              </div>
             <% else %>
               <%= render_slot(@topbar_action) %>
             <% end %>


### PR DESCRIPTION
Ref: https://github.com/livebook-dev/livebook/issues/1632

Here's how it currently looks after making the changes:
![image](https://user-images.githubusercontent.com/54525741/212529508-c04b3b25-95e6-47b7-ab7c-92cf0f6eadf7.png)

There will be another follow-up PR that will fix the import modal styling for thin windows.