### PR TITLE
Check attached node elixir version.

### DIFF
--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -53,7 +53,7 @@ defmodule Livebook.Runtime.Attached do
     end
   end
 
-  @elixir_version_requirement Keyword.fetch!(Livebook.MixProject.project(), :elixir)
+  @elixir_version_requirement Keyword.fetch!(Mix.Project.config(), :elixir)
 
   defp check_attached_node_version(node) do
     attached_node_version = :erpc.call(node, System, :version, [])

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -62,7 +62,7 @@ defmodule Livebook.Runtime.Attached do
       :ok
     else
       {:error,
-       "the node uses Elixir #{attached_node_version}, but #{@elixir_version_requirement} is required"
+       "the node uses Elixir #{attached_node_version}, but #{@elixir_version_requirement} is required"}
     end
   end
 

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -39,17 +39,31 @@ defmodule Livebook.Runtime.Attached do
     # Set cookie for connecting to this specific node
     Node.set_cookie(node, cookie)
 
-    case Node.ping(node) do
-      :pong ->
-        server_pid =
-          Livebook.Runtime.ErlDist.initialize(node,
-            node_manager_opts: [parent_node: node(), capture_orphan_logs: false]
-          )
+    with :pong <- Node.ping(node),
+         :ok <- check_attached_node_version(node) do
+      server_pid =
+        Livebook.Runtime.ErlDist.initialize(node,
+          node_manager_opts: [parent_node: node(), capture_orphan_logs: false]
+        )
 
-        {:ok, %{runtime | node: node, server_pid: server_pid}}
+      {:ok, %{runtime | node: node, server_pid: server_pid}}
+    else
+      :pang -> {:error, "node #{inspect(node)} is unreachable"}
+      {:error, msg} -> {:error, msg}
+    end
+  end
 
-      :pang ->
-        {:error, "node #{inspect(node)} is unreachable"}
+  @elixir_version_requirement Keyword.fetch!(Livebook.MixProject.project(), :elixir)
+
+  defp check_attached_node_version(node) do
+    attached_node_version = :erpc.call(node, System, :version, [])
+
+    if Version.match?(attached_node_version, @elixir_version_requirement) do
+      :ok
+    else
+      {:error,
+       "elixir version requirement of node #{inspect(node)} isn't satisfied " <>
+         "(required #{@elixir_version_requirement} but was #{attached_node_version})"}
     end
   end
 

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -62,8 +62,7 @@ defmodule Livebook.Runtime.Attached do
       :ok
     else
       {:error,
-       "elixir version requirement of node #{inspect(node)} isn't satisfied " <>
-         "(required #{@elixir_version_requirement} but was #{attached_node_version})"}
+       "the node uses Elixir #{attached_node_version}, but #{@elixir_version_requirement} is required"
     end
   end
 


### PR DESCRIPTION
The attached node should have a minimum elixir version, to avoid problems at runtime.
For example, Livebook version `0.8` introduced a dependency on `Code.eval_quoted_with_env/4` which is new since elixir 1.14.2.

Example output for a node with a too low version:

![Scherm­afbeelding 2023-01-23 om 15 22 11](https://user-images.githubusercontent.com/43893333/214063143-0d91db01-5599-4c15-b8e6-3c58582a2d7b.png)

