### PR TITLE
Hub fixes

### DIFF
--- a/lib/livebook/hubs/enterprise_client.ex
+++ b/lib/livebook/hubs/enterprise_client.ex
@@ -5,7 +5,7 @@ defmodule Livebook.Hubs.EnterpriseClient do
   alias Livebook.Hubs.Broadcasts
   alias Livebook.Hubs.Enterprise
   alias Livebook.Secrets.Secret
-  alias Livebook.WebSocket.Server
+  alias Livebook.WebSocket.ClientConnection
 
   @registry Livebook.HubsRegistry
 
@@ -33,7 +33,7 @@ defmodule Livebook.Hubs.EnterpriseClient do
   """
   @spec send_request(pid(), WebSocket.proto()) :: {atom(), term()}
   def send_request(pid, %_struct{} = data) do
-    Server.send_request(GenServer.call(pid, :get_server), data)
+    ClientConnection.send_request(GenServer.call(pid, :get_server), data)
   end
 
   @doc """
@@ -60,7 +60,7 @@ defmodule Livebook.Hubs.EnterpriseClient do
   @impl true
   def init(%Enterprise{url: url, token: token} = enterprise) do
     headers = [{"X-Auth-Token", token}]
-    {:ok, pid} = Server.start_link(self(), url, headers)
+    {:ok, pid} = ClientConnection.start_link(self(), url, headers)
 
     {:ok, %__MODULE__{hub: enterprise, server: pid}}
   end

--- a/lib/livebook/hubs/enterprise_client.ex
+++ b/lib/livebook/hubs/enterprise_client.ex
@@ -25,8 +25,7 @@ defmodule Livebook.Hubs.EnterpriseClient do
   @spec stop(pid()) :: :ok
   def stop(pid) do
     pid |> GenServer.call(:get_server) |> GenServer.stop()
-
-    :ok
+    GenServer.stop(pid)
   end
 
   @doc """

--- a/lib/livebook/hubs/enterprise_client.ex
+++ b/lib/livebook/hubs/enterprise_client.ex
@@ -49,11 +49,10 @@ defmodule Livebook.Hubs.EnterpriseClient do
   """
   @spec connected?(String.t()) :: boolean()
   def connected?(id) do
-    try do
-      GenServer.call(registry_name(id), :connected?)
-    catch
-      :exit, _ -> false
-    end
+    GenServer.call(registry_name(id), :connected?)
+  catch
+    :exit, _ ->
+      false
   end
 
   ## GenServer callbacks

--- a/lib/livebook/web_socket/client.ex
+++ b/lib/livebook/web_socket/client.ex
@@ -10,16 +10,6 @@ defmodule Livebook.WebSocket.Client do
   @type frame :: Mint.WebSocket.frame() | Mint.WebSocket.shorthand_frame()
   @type ref :: Mint.Types.request_ref()
 
-  defmodule Response do
-    defstruct [:status, :headers, body: []]
-
-    @type t :: %__MODULE__{
-            body: list(Livebook.WebSocket.Response.t()),
-            status: Mint.Types.status() | nil,
-            headers: Mint.Types.headers() | nil
-          }
-  end
-
   defguard is_frame(value) when value in [:close, :ping] or elem(value, 0) == :binary
 
   @doc """

--- a/lib/livebook/web_socket/client.ex
+++ b/lib/livebook/web_socket/client.ex
@@ -31,8 +31,7 @@ defmodule Livebook.WebSocket.Client do
           | {:server_error, list(binary())}
   def connect(url, headers \\ []) do
     uri = URI.parse(url)
-    http_scheme = parse_http_scheme(uri)
-    ws_scheme = parse_ws_scheme(uri)
+    {http_scheme, ws_scheme} = parse_scheme(uri)
     state = %{status: nil, headers: [], body: []}
 
     with {:ok, conn} <- Mint.HTTP.connect(http_scheme, uri.host, uri.port),
@@ -43,11 +42,8 @@ defmodule Livebook.WebSocket.Client do
     end
   end
 
-  defp parse_http_scheme(uri) when uri.scheme in ["http", "ws"], do: :http
-  defp parse_http_scheme(uri) when uri.scheme in ["https", "wss"], do: :https
-
-  defp parse_ws_scheme(uri) when uri.scheme in ["http", "ws"], do: :ws
-  defp parse_ws_scheme(uri) when uri.scheme in ["https", "wss"], do: :wss
+  defp parse_scheme(uri) when uri.scheme in ["http", "ws"], do: {:http, :ws}
+  defp parse_scheme(uri) when uri.scheme in ["https", "wss"], do: {:https, :wss}
 
   defp receive_upgrade(conn, ref, state) do
     with {:ok, conn} <- Mint.HTTP.set_mode(conn, :passive),

--- a/lib/livebook/web_socket/client_connection.ex
+++ b/lib/livebook/web_socket/client_connection.ex
@@ -1,4 +1,4 @@
-defmodule Livebook.WebSocket.Server do
+defmodule Livebook.WebSocket.ClientConnection do
   @moduledoc false
   use Connection
 
@@ -13,7 +13,7 @@ defmodule Livebook.WebSocket.Server do
   defstruct [:url, :listener, :headers, :http_conn, :websocket, :ref, id: 0, reply: %{}]
 
   @doc """
-  Starts a new WebSocket Server connection with given URL and headers.
+  Starts a new WebSocket connection with given URL and headers.
   """
   @spec start_link(pid(), String.t(), Mint.Types.headers()) :: GenServer.on_start()
   def start_link(listener, url, headers \\ []) do

--- a/lib/livebook/web_socket/server.ex
+++ b/lib/livebook/web_socket/server.ex
@@ -15,8 +15,7 @@ defmodule Livebook.WebSocket.Server do
   @doc """
   Starts a new WebSocket Server connection with given URL and headers.
   """
-  @spec start_link(pid(), String.t(), Mint.Types.headers()) ::
-          {:ok, pid()} | {:error, {:already_started, pid()}}
+  @spec start_link(pid(), String.t(), Mint.Types.headers()) :: GenServer.on_start()
   def start_link(listener, url, headers \\ []) do
     Connection.start_link(__MODULE__, {listener, url, headers})
   end
@@ -33,7 +32,7 @@ defmodule Livebook.WebSocket.Server do
 
   @impl true
   def init({listener, url, headers}) do
-    state = struct!(__MODULE__, listener: listener, url: url, headers: headers)
+    state = %__MODULE__{listener: listener, url: url, headers: headers}
     {:connect, :init, state}
   end
 

--- a/lib/livebook_web/live/hub/new/enterprise_component.ex
+++ b/lib/livebook_web/live/hub/new/enterprise_component.ex
@@ -33,7 +33,6 @@ defmodule LivebookWeb.Hub.New.EnterpriseComponent do
         phx-submit="save"
         phx-change="validate"
         phx-target={@myself}
-        phx-debounce="blur"
       >
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <.input_wrapper form={f} field={:url} class="flex flex-col space-y-1">
@@ -42,7 +41,8 @@ defmodule LivebookWeb.Hub.New.EnterpriseComponent do
               class: "input w-full phx-form-error:border-red-300",
               autofocus: true,
               spellcheck: "false",
-              autocomplete: "off"
+              autocomplete: "off",
+              phx_debounce: "blur"
             ) %>
           </.input_wrapper>
 
@@ -52,7 +52,8 @@ defmodule LivebookWeb.Hub.New.EnterpriseComponent do
               value: get_field(@changeset, :token),
               class: "input w-full phx-form-error:border-red-300",
               spellcheck: "false",
-              autocomplete: "off"
+              autocomplete: "off",
+              phx_debounce: "blur"
             ) %>
           </.input_wrapper>
         </div>

--- a/test/support/enterprise_integration_case.ex
+++ b/test/support/enterprise_integration_case.ex
@@ -14,7 +14,10 @@ defmodule Livebook.EnterpriseIntegrationCase do
   end
 
   setup_all do
-    EnterpriseServer.start()
+    case EnterpriseServer.start() do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
 
     {:ok,
      url: EnterpriseServer.url(), token: EnterpriseServer.token(), user: EnterpriseServer.user()}

--- a/test/support/integration/enterprise_server.ex
+++ b/test/support/integration/enterprise_server.ex
@@ -6,6 +6,11 @@ defmodule Livebook.EnterpriseServer do
 
   @name __MODULE__
   @timeout 10_000
+  @default_enterprise_dir "../enterprise"
+
+  def available?() do
+    System.get_env("ENTERPRISE_PATH") != nil or File.exists?(@default_enterprise_dir)
+  end
 
   def start(name \\ @name, opts \\ []) do
     GenServer.start(__MODULE__, opts, name: name)
@@ -46,7 +51,7 @@ defmodule Livebook.EnterpriseServer do
 
   @impl true
   def init(opts) do
-    state = struct(__MODULE__, opts)
+    state = struct!(__MODULE__, opts)
 
     {:ok, %{state | node: enterprise_node()}, {:continue, :start_enterprise}}
   end
@@ -204,7 +209,7 @@ defmodule Livebook.EnterpriseServer do
   end
 
   defp app_dir do
-    System.get_env("ENTERPRISE_PATH", "../enterprise")
+    System.get_env("ENTERPRISE_PATH", @default_enterprise_dir)
   end
 
   defp app_port do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,10 +41,10 @@ Livebook.Storage.insert(:settings, "global", autosave_path: nil)
 
 erl_docs_available? = Code.fetch_docs(:gen_server) != {:error, :chunk_not_found}
 
-enterprise_path = System.get_env("ENTERPRISE_PATH", "../enterprise")
-enterprise_available? = File.exists?(enterprise_path)
-
 ExUnit.start(
   assert_receive_timeout: 1_500,
-  exclude: [erl_docs: erl_docs_available?, enterprise_integration: !enterprise_available?]
+  exclude: [
+    erl_docs: erl_docs_available?,
+    enterprise_integration: not Livebook.EnterpriseServer.available?()
+  ]
 )


### PR DESCRIPTION
- Fix excluding enterprise integration tests

  Before this patch, on `mix test` if we set ENTERPRISE_PATH to a directory that does not exists, we'd silently exclude enterprise tests. Now we'll crash.

- Fix stopping EnterpriseClient server

  Before this patch, we were not actually stopping the server. This was a problem particularly on the EnterpriseComponent where we start_link the client and upon errors stop it (so that when we try again, the server's name is free to take.)

  We were stopping just the WebSocket server with the default reason, :normal, and so we need to explicitly stop the server itself too.

- Fix enterprise component debouncing

  There is also a few potential improvements on the component for the future:

    - Clicking connect without entering anything crashes the component. We should instead show validation error on invalid url (empty, without scheme, etc) or token.

    - After successfully connecting we should most likely disable the connect button. Clicking it again crashes the component.

    - We should be able to connect by filling in the details and pressing enter. (Currently the button is type=button, not type=submit, because after successfully connecting the form also allows setting the emoji.)

- Minor code improvements

- Remove unused Livebook.WebSocket.Request struct

- Rename Livebook.WebSocket.Server to .ClientConnection
