### PR TITLE
Support setting node name/sname using environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ The following environment variables configure Livebook:
   * LIVEBOOK_APP_SERVICE_URL - sets the application url to manage this
     Livebook instance within the cloud provider platform.
 
+  * LIVEBOOK_NAME - sets the node name for running Livebook in a cluster.
+    Note that only this or LIVEBOOK_SNAME can be set.
+
+  * LIVEBOOK_SNAME - sets the node shortname for running Livebook in a cluster.
+    Note that only this or LIVEBOOK_NAME can be set.
+
   * LIVEBOOK_COOKIE - sets the cookie for running Livebook in a cluster.
     Defaults to a random string that is generated on boot.
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,8 @@ The following environment variables configure Livebook:
   * LIVEBOOK_APP_SERVICE_URL - sets the application url to manage this
     Livebook instance within the cloud provider platform.
 
-  * LIVEBOOK_NODE - sets the node name for running Livebook in a cluster. Note that
-    this sets RELEASE_NODE if present when creating a release.
-
-  * LIVEBOOK_DISTRIBUTION - sets the node distribution for running Livebook in a
-    cluster. Must be "name" (long names) or "sname" (short names). Note that this
-    sets RELEASE_DISTRIBUTION if present when creating a release. Defaults to "sname".
+  * LIVEBOOK_BASE_URL_PATH - sets the base url path the web application is served on.
+    Useful when deploying behind a reverse proxy.
 
   * LIVEBOOK_COOKIE - sets the cookie for running Livebook in a cluster.
     Defaults to a random string that is generated on boot.
@@ -181,6 +177,10 @@ The following environment variables configure Livebook:
     when none is started explicitly for the given notebook. Must be either
     "standalone" (Elixir standalone), "attached:NODE:COOKIE" (Attached node)
     or "embedded" (Embedded). Defaults to "standalone".
+
+  * LIVEBOOK_DISTRIBUTION - sets the node distribution for running Livebook in a
+    cluster. Must be "name" (long names) or "sname" (short names). Note that this
+    sets RELEASE_DISTRIBUTION if present when creating a release. Defaults to "sname".
 
   * LIVEBOOK_FORCE_SSL_HOST - sets a host to redirect to if the request is not over HTTP.
     Note it does not apply when accessing Livebook via localhost. Defaults to nil.
@@ -199,8 +199,8 @@ The following environment variables configure Livebook:
   * LIVEBOOK_IP - sets the ip address to start the web application on.
     Must be a valid IPv4 or IPv6 address.
 
-  * LIVEBOOK_BASE_URL_PATH - sets the base url path the web application is served on.
-    Useful when deploying behind a reverse proxy.
+  * LIVEBOOK_NODE - sets the node name for running Livebook in a cluster. Note that
+    this sets RELEASE_NODE if present when creating a release.
 
   * LIVEBOOK_PASSWORD - sets a password that must be used to access Livebook.
     Must be at least 12 characters. Defaults to token authentication.

--- a/README.md
+++ b/README.md
@@ -164,11 +164,12 @@ The following environment variables configure Livebook:
   * LIVEBOOK_APP_SERVICE_URL - sets the application url to manage this
     Livebook instance within the cloud provider platform.
 
-  * LIVEBOOK_NAME - sets the node name for running Livebook in a cluster.
-    Note that only this or LIVEBOOK_SNAME can be set.
+  * LIVEBOOK_NODE - sets the node name for running Livebook in a cluster. Note that
+    this sets RELEASE_NODE if present when creating a release.
 
-  * LIVEBOOK_SNAME - sets the node shortname for running Livebook in a cluster.
-    Note that only this or LIVEBOOK_NAME can be set.
+  * LIVEBOOK_DISTRIBUTION - sets the node distribution for running Livebook in a
+    cluster. Must be "name" (long names) or "sname" (short names). Note that this
+    sets RELEASE_DISTRIBUTION if present when creating a release. Defaults to "sname".
 
   * LIVEBOOK_COOKIE - sets the cookie for running Livebook in a cluster.
     Defaults to a random string that is generated on boot.
@@ -229,11 +230,6 @@ The following environment variables configure Livebook:
     must run with HTTPS.
 
 <!-- Environment variables -->
-
-If running Livebook as a Docker image or an Elixir release, [the environment
-variables used by Elixir releases are also available](
-https://hexdocs.pm/mix/Mix.Tasks.Release.html#module-environment-variables).
-The notables ones are `RELEASE_NODE` and `RELEASE_DISTRIBUTION`.
 
 If running Livebook via the command line, run `livebook server --help` to see
 all CLI-specific options.

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -160,6 +160,10 @@ defmodule Livebook do
              Livebook.Config.cookie!("RELEASE_COOKIE") ||
              Livebook.Utils.random_cookie()
 
+    if node = Livebook.Config.node!({"LIVEBOOK_NAME", "LIVEBOOK_SNAME"}) do
+      config :livebook, :node, node
+    end
+
     if app_service_name = Livebook.Config.app_service_name!("LIVEBOOK_APP_SERVICE_NAME") do
       config :livebook, :app_service_name, app_service_name
 

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -160,7 +160,7 @@ defmodule Livebook do
              Livebook.Config.cookie!("RELEASE_COOKIE") ||
              Livebook.Utils.random_cookie()
 
-    if node = Livebook.Config.node!({"LIVEBOOK_NAME", "LIVEBOOK_SNAME"}) do
+    if node = Livebook.Config.node!("LIVEBOOK_NODE", "LIVEBOOK_DISTRIBUTION") do
       config :livebook, :node, node
     end
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -292,21 +292,21 @@ defmodule Livebook.Config do
   end
 
   @doc """
-  Parses a long or short node name from env.
+  Parses node and distribution type from env.
   """
-  def node!({longname_env, shortname_env}) do
-    case {System.get_env(longname_env), System.get_env(shortname_env)} do
-      {nil, nil} ->
+  def node!(node_env, distribution_env) do
+    case {System.get_env(node_env), System.get_env(distribution_env, "sname")} do
+      {nil, _} ->
         nil
 
-      {longname, nil} ->
-        {:longnames, String.to_atom(longname)}
+      {name, "name"} ->
+        {:longnames, String.to_atom(name)}
 
-      {nil, shortname} ->
-        {:shortnames, String.to_atom(shortname)}
+      {sname, "sname"} ->
+        {:shortnames, String.to_atom(sname)}
 
-      _ ->
-        abort!("#{longname_env} and #{shortname_env} are mutually exclusive, please specify only one of them")
+      {_, other} ->
+        abort!(~s(#{distribution_env} must be one of "name" or "sname", got "#{other}"))
     end
   end
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -292,6 +292,25 @@ defmodule Livebook.Config do
   end
 
   @doc """
+  Parses a long or short node name from env.
+  """
+  def node!({longname_env, shortname_env}) do
+    case {System.get_env(longname_env), System.get_env(shortname_env)} do
+      {nil, nil} ->
+        nil
+
+      {longname, nil} ->
+        {:longnames, String.to_atom(longname)}
+
+      {nil, shortname} ->
+        {:shortnames, String.to_atom(shortname)}
+
+      _ ->
+        abort!("#{longname_env} and #{shortname_env} are mutually exclusive, please specify only one of them")
+    end
+  end
+
+  @doc """
   Parses and validates the password from env.
   """
   def password!(env) do

--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,7 @@ defmodule Livebook.MixProject do
   defp releases do
     [
       livebook: [
-        include_executables_for: [:unix],
+        include_executables_for: [:unix, :windows],
         include_erts: false,
         rel_templates_path: "rel/server",
         steps: [:assemble, &remove_cookie/1]

--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -1,4 +1,6 @@
+if defined LIVEBOOK_NODE set RELEASE_NODE="!LIVEBOOK_NODE!"
 if not defined RELEASE_NODE set RELEASE_NODE=livebook_server
+if defined LIVEBOOK_DISTRIBUTION set RELEASE_DISTRIBUTION="!LIVEBOOK_DISTRIBUTION!"
 set RELEASE_MODE=interactive
 
 set cookie_path="!RELEASE_ROOT!\releases\COOKIE"

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -1,4 +1,5 @@
-export RELEASE_NODE="${RELEASE_NODE:-livebook_server}"
+export RELEASE_NODE=${LIVEBOOK_NODE:-${RELEASE_NODE:-livebook_server}}
+export RELEASE_DISTRIBUTION=${LIVEBOOK_DISTRIBUTION:-${RELEASE_DISTRIBUTION:-sname}}
 export RELEASE_MODE=interactive
 
 cookie_path="${RELEASE_ROOT}/releases/COOKIE"

--- a/test/livebook/config_test.exs
+++ b/test/livebook/config_test.exs
@@ -1,0 +1,40 @@
+defmodule Livebook.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Config
+
+  describe "node!/1" do
+    test "parses a longname from env" do
+      with_env([TEST_LIVEBOOK_NAME: "test@::1"], fn ->
+        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) ==
+                 {:longnames, :"test@::1"}
+      end)
+    end
+
+    test "parses a shortname from env" do
+      with_env([TEST_LIVEBOOK_SNAME: "test"], fn ->
+        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) == {:shortnames, :test}
+      end)
+    end
+
+    test "returns nil if neither longname nor shortname are in env" do
+      with_env([TEST_LIVEBOOK_NAME: nil, TEST_LIVEBOOK_SNAME: nil], fn ->
+        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) == nil
+      end)
+    end
+  end
+
+  defp with_env(env_vars, fun) do
+    existing =
+      Enum.map(env_vars, fn {env, _value} ->
+        {env, env |> to_string() |> System.get_env()}
+      end)
+
+    try do
+      System.put_env(env_vars)
+      fun.()
+    after
+      System.put_env(existing)
+    end
+  end
+end

--- a/test/livebook/config_test.exs
+++ b/test/livebook/config_test.exs
@@ -4,22 +4,30 @@ defmodule Livebook.ConfigTest do
   alias Livebook.Config
 
   describe "node!/1" do
-    test "parses a longname from env" do
-      with_env([TEST_LIVEBOOK_NAME: "test@::1"], fn ->
-        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) ==
+    test "parses longnames" do
+      with_env([TEST_LIVEBOOK_NODE: "test@::1", TEST_LIVEBOOK_DISTRIBUTION: "name"], fn ->
+        assert Config.node!("TEST_LIVEBOOK_NODE", "TEST_LIVEBOOK_DISTRIBUTION") ==
                  {:longnames, :"test@::1"}
       end)
     end
 
-    test "parses a shortname from env" do
-      with_env([TEST_LIVEBOOK_SNAME: "test"], fn ->
-        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) == {:shortnames, :test}
+    test "parses shortnames" do
+      with_env([TEST_LIVEBOOK_NODE: "test", TEST_LIVEBOOK_DISTRIBUTION: "sname"], fn ->
+        assert Config.node!("TEST_LIVEBOOK_NODE", "TEST_LIVEBOOK_DISTRIBUTION") ==
+                 {:shortnames, :test}
       end)
     end
 
-    test "returns nil if neither longname nor shortname are in env" do
-      with_env([TEST_LIVEBOOK_NAME: nil, TEST_LIVEBOOK_SNAME: nil], fn ->
-        assert Config.node!({"TEST_LIVEBOOK_NAME", "TEST_LIVEBOOK_SNAME"}) == nil
+    test "parses shortnames by default" do
+      with_env([TEST_LIVEBOOK_NODE: "test", TEST_LIVEBOOK_DISTRIBUTION: nil], fn ->
+        assert Config.node!("TEST_LIVEBOOK_NODE", "TEST_LIVEBOOK_DISTRIBUTION") ==
+                 {:shortnames, :test}
+      end)
+    end
+
+    test "returns nil if node is not set" do
+      with_env([TEST_LIVEBOOK_NODE: nil, TEST_LIVEBOOK_DISTRIBUTION: "name"], fn ->
+        assert Config.node!("TEST_LIVEBOOK_NODE", "TEST_LIVEBOOK_DISTRIBUTION") == nil
       end)
     end
   end


### PR DESCRIPTION
This PR adds support for setting the Livebook node long or short name using `LIVEBOOK_NAME`/`LIVEBOOK_SNAME` in addition to the existing `--name`/`--sname` flags.

It also didn't look like config options were being explicitly tested, so I added a `config_test.exs`. However, `abort!` calls `System.halt/1`, which I'm not sure is "catchable", so I don't have a test case for when both env vars are set.

One thing I considered is that perhaps a warning, instead of `abort!`, should be issued if both env vars are present, since unlike flags, you don't necessarily have full control over the environment. Perhaps it makes more sense to just prioritize longname over shortname if they're both present and print a warning explaining as much?