### PR TITLE
Rework file input to consider multiple clients

### DIFF
--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -89,5 +89,5 @@ defmodule Livebook.Notebook.Cell do
   Checks if the given term is a file input value (info map).
   """
   defguard is_file_input_value(value)
-           when is_map_key(value, :path) and is_map_key(value, :client_name)
+           when is_map_key(value, :file_id) and is_map_key(value, :client_name)
 end

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -268,6 +268,23 @@ defprotocol Livebook.Runtime do
   """
   @type editor :: %{language: String.t(), placement: :bottom | :top, source: String.t()}
 
+  @typedoc """
+  An opaque file identifier.
+
+  Such identifier can be obtained from a file input, for example.
+
+  The runtime may ask for the file by sending a request:
+
+    * `{:runtime_file_lookup, reply_to, file_id}`
+
+  to which the runtime owner is supposed to reply with
+  `{:runtime_file_lookup_reply, reply}` where `reply` is either
+  `{:ok, path}` or `:error` if no matching file can be found. Note
+  that `path` should be accessible within the runtime and can be
+  obtained using `transfer_file/4`.
+  """
+  @type file_id :: String.t()
+
   @doc """
   Returns relevant information about the runtime.
 

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -24,6 +24,7 @@ defmodule LivebookWeb.Output do
           id: "output-#{idx}",
           socket: @socket,
           session_id: @session_id,
+          session_pid: @session_pid,
           input_values: @input_values,
           client_id: @client_id
         }) %>
@@ -80,6 +81,7 @@ defmodule LivebookWeb.Output do
   defp render_output({:frame, outputs, _info}, %{
          id: id,
          session_id: session_id,
+         session_pid: session_pid,
          input_values: input_values,
          client_id: client_id
        }) do
@@ -87,6 +89,7 @@ defmodule LivebookWeb.Output do
       id: id,
       outputs: outputs,
       session_id: session_id,
+      session_pid: session_pid,
       input_values: input_values,
       client_id: client_id
     )
@@ -216,27 +219,29 @@ defmodule LivebookWeb.Output do
   defp render_output({:input, attrs}, %{
          id: id,
          input_values: input_values,
-         client_id: client_id,
-         session_id: session_id
+         session_pid: session_pid,
+         client_id: client_id
        }) do
     live_component(Output.InputComponent,
       id: id,
       attrs: attrs,
       input_values: input_values,
-      client_id: client_id,
-      session_id: session_id
+      session_pid: session_pid,
+      client_id: client_id
     )
   end
 
   defp render_output({:control, attrs}, %{
          id: id,
          input_values: input_values,
+         session_pid: session_pid,
          client_id: client_id
        }) do
     live_component(Output.ControlComponent,
       id: id,
       attrs: attrs,
       input_values: input_values,
+      session_pid: session_pid,
       client_id: client_id
     )
   end

--- a/lib/livebook_web/live/output/control_component.ex
+++ b/lib/livebook_web/live/output/control_component.ex
@@ -55,6 +55,7 @@ defmodule LivebookWeb.Output.ControlComponent do
         id={@id}
         attrs={@attrs}
         input_values={@input_values}
+        session_pid={@session_pid}
         client_id={@client_id}
       />
     </div>

--- a/lib/livebook_web/live/output/control_form_component.ex
+++ b/lib/livebook_web/live/output/control_form_component.ex
@@ -42,6 +42,8 @@ defmodule LivebookWeb.Output.ControlFormComponent do
           id={"#{@id}-#{input_attrs.id}"}
           attrs={input_attrs}
           input_values={@input_values}
+          session_pid={@session_pid}
+          client_id={@client_id}
           local={true}
         />
       <% end %>

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -84,6 +84,7 @@ defmodule LivebookWeb.Output.FrameComponent do
             dom_id_map={@persistent_id_map}
             socket={@socket}
             session_id={@session_id}
+            session_pid={@session_pid}
             input_values={@input_values}
             client_id={@client_id}
           />

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -77,7 +77,9 @@ defmodule LivebookWeb.Output.InputComponent do
         value={@value}
         accept={@attrs.accept}
         input_id={@attrs.id}
-        session_id={@session_id}
+        session_pid={@session_pid}
+        client_id={@client_id}
+        local={@local}
       />
     </div>
     """

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -270,6 +270,7 @@ defmodule LivebookWeb.SessionLive do
               module={LivebookWeb.SessionLive.CellComponent}
               id={@data_view.setup_cell_view.id}
               session_id={@session.id}
+              session_pid={@session.pid}
               client_id={@client_id}
               runtime={@data_view.runtime}
               installing?={@data_view.installing?}
@@ -290,6 +291,7 @@ defmodule LivebookWeb.SessionLive do
                 id={section_view.id}
                 index={index}
                 session_id={@session.id}
+                session_pid={@session.pid}
                 client_id={@client_id}
                 runtime={@data_view.runtime}
                 smart_cell_definitions={@data_view.smart_cell_definitions}

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -98,6 +98,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         cell_view={@cell_view}
         socket={@socket}
         session_id={@session_id}
+        session_pid={@session_pid}
         client_id={@client_id}
       />
     </.cell_body>
@@ -147,6 +148,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
           cell_view={@cell_view}
           socket={@socket}
           session_id={@session_id}
+          session_pid={@session_pid}
           client_id={@client_id}
         />
       </div>
@@ -253,6 +255,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         cell_view={@cell_view}
         socket={@socket}
         session_id={@session_id}
+        session_pid={@session_pid}
         client_id={@client_id}
       />
     </.cell_body>
@@ -609,6 +612,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         dom_id_map={%{}}
         socket={@socket}
         session_id={@session_id}
+        session_pid={@session_pid}
         client_id={@client_id}
         input_values={@cell_view.eval.input_values}
       />

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -140,6 +140,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
               module={LivebookWeb.SessionLive.CellComponent}
               id={cell_view.id}
               session_id={@session_id}
+              session_pid={@session_pid}
               client_id={@client_id}
               runtime={@runtime}
               installing?={@installing?}

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -409,15 +409,11 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert %{input_values: %{"input1" => value}} = Session.get_data(session.pid)
 
-      assert File.read!(value.path) == "content"
-      assert value.client_name == "data.txt"
+      assert %{file_id: file_id, client_name: "data.txt"} = value
 
-      # When the input disappears, the file should be removed
-
-      Session.erase_outputs(session.pid)
-      wait_for_session_update(session.pid)
-
-      refute File.exists?(value.path)
+      send(session.pid, {:runtime_file_lookup, self(), file_id})
+      assert_receive {:runtime_file_lookup_reply, {:ok, path}}
+      assert File.read!(path) == "content"
     end
   end
 
@@ -626,7 +622,7 @@ defmodule LivebookWeb.SessionLiveTest do
         "editor_auto_completion" => false
       })
 
-      assert_reply view, %{"ref" => nil}
+      assert_reply(view, %{"ref" => nil})
     end
 
     test "replies with completion reference and then sends asynchronous response",
@@ -648,7 +644,7 @@ defmodule LivebookWeb.SessionLiveTest do
         "editor_auto_completion" => false
       })
 
-      assert_reply view, %{"ref" => ref}
+      assert_reply(view, %{"ref" => ref})
       assert ref != nil
 
       assert_push_event(

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -27,8 +27,13 @@ defmodule Livebook.Runtime.NoopRuntime do
     def handle_intellisense(_, _, _, _), do: make_ref()
 
     def read_file(_, _), do: raise("not implemented")
-    def transfer_file(_, _, _, _), do: raise("not implemented")
-    def revoke_file(_, _), do: raise("not implemented")
+
+    def transfer_file(_runtime, path, _file_id, callback) do
+      callback.(path)
+      :ok
+    end
+
+    def revoke_file(_, _), do: :ok
 
     def start_smart_cell(_, _, _, _, _), do: :ok
     def set_smart_cell_parent_locators(_, _, _), do: :ok


### PR DESCRIPTION
Currently the file input doesn't work properly with kino form, since each upload ends up in the same location, while we want to keep a file for every client. We also don't call runtime file transfer for the async events.

With these changes each uploaded path is unique and:

* for shared input we only keep the latest file and remove it when input is deleted
* for per-client input we keep the latest file for every user and remove it when the client closes the page

In practice we don't remove the file right away, only after 15s, so we give the runtime a bit more time to access it. We also retry if deletion fails, because on Windows it's not possible to remove an opened file.

This also changes the file input value from `%{path: "...", client_name: "..."}` to `%{file_id: "...", client_name: "..."}` and to get the path we need to call `Kino.Input.file_path(file_id)`. This way if we need to transfer the file to the runtime, we do it only once requested. We also don't need to artificially swap `path` in case of the theoretical runtime file transfers.