### PR TITLE
Fix assets fetching for client-specific outputs

### DIFF
--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -49,7 +49,7 @@ defmodule Livebook.Notebook.Cell do
   def evaluable?(_cell), do: false
 
   @doc """
-  Extracts all inputs from the given output.
+  Extracts all inputs from the given indexed output.
   """
   @spec find_inputs_in_output(indexed_output()) :: list(input_attrs :: map())
   def find_inputs_in_output(output)
@@ -67,6 +67,20 @@ defmodule Livebook.Notebook.Cell do
   end
 
   def find_inputs_in_output(_output), do: []
+
+  @doc """
+  Extract all asset infos from the given non-indexed output.
+  """
+  @spec find_assets_in_output(Livebook.Runtime.output()) :: list(asset_info :: map())
+  def find_assets_in_output(output)
+
+  def find_assets_in_output({:js, %{js_view: %{assets: assets_info}}}), do: [assets_info]
+
+  def find_assets_in_output({type, outputs, _}) when type in [:frame, :tabs, :grid] do
+    Enum.flat_map(outputs, &find_assets_in_output/1)
+  end
+
+  def find_assets_in_output(_), do: []
 
   @setup_cell_id "setup"
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -473,7 +473,7 @@ defmodule LivebookWeb.SessionLiveTest do
       refute content =~ "In frame"
     end
 
-    test "client specific output is sent only to one target", %{conn: conn, session: session} do
+    test "client-specific output is sent only to one target", %{conn: conn, session: session} do
       user1 = build(:user, name: "Jake Peralta")
       {_, client_id} = Session.register_client(session.pid, self(), user1)
 

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -29,7 +29,7 @@ defmodule Livebook.Runtime.NoopRuntime do
     def read_file(_, path) do
       case File.read(path) do
         {:ok, binary} -> {:ok, binary}
-        {:error, reason} -> "failed to read the file, got: #{inspect(reason)}"
+        {:error, reason} -> {:error, "failed to read the file, got: #{inspect(reason)}"}
       end
     end
 

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -26,7 +26,12 @@ defmodule Livebook.Runtime.NoopRuntime do
     def drop_container(_, _), do: :ok
     def handle_intellisense(_, _, _, _), do: make_ref()
 
-    def read_file(_, _), do: raise("not implemented")
+    def read_file(_, path) do
+      case File.read(path) do
+        {:ok, binary} -> {:ok, binary}
+        {:error, reason} -> "failed to read the file, got: #{inspect(reason)}"
+      end
+    end
 
     def transfer_file(_runtime, path, _file_id, callback) do
       callback.(path)


### PR DESCRIPTION
When fetching assets for JS outputs, we ask the session to copy the assets with the given hash. The session finds assets info (including archive path) within the notebook, based on the hash. However, the session doesn't keep track of the client-specific outputs (frame contents that go into a particular LV), so it can't resolve the hash when asked for the assets.

To fix this we specifically track assets that each of the clients uses and garbage collect when they leave.