### PR TITLE
Remove policy checks and update empty frame text

### DIFF
--- a/lib/livebook_web/live/hooks/policy_hook.ex
+++ b/lib/livebook_web/live/hooks/policy_hook.ex
@@ -1,7 +1,0 @@
-defmodule LivebookWeb.PolicyHook do
-  import Phoenix.Component
-
-  def on_mount(:private, _params, _session, socket) do
-    {:cont, socket |> assign(:policy, %{read: true, execute: true, edit: true})}
-  end
-end

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -75,7 +75,7 @@ defmodule LivebookWeb.Output.FrameComponent do
     <div id={"frame-output-#{@id}"}>
       <%= if @output_count == 0 do %>
         <div class="text-gray-300 p-4 rounded-lg border border-gray-200">
-          Empty output frame
+          Nothing here
         </div>
       <% else %>
         <div id={"frame-outputs-#{@id}-#{@counter}"} phx-update="append">

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -75,7 +75,7 @@ defmodule LivebookWeb.Output.FrameComponent do
     <div id={"frame-output-#{@id}"}>
       <%= if @output_count == 0 do %>
         <div class="text-gray-300 p-4 rounded-lg border border-gray-200">
-          Nothing here
+          Nothing here...
         </div>
       <% else %>
         <div id={"frame-outputs-#{@id}-#{@counter}"} phx-update="append">

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -50,8 +50,7 @@ defmodule LivebookWeb.Router do
     get "/sessions/:id/assets/:hash/*file_parts", SessionController, :show_asset
   end
 
-  live_session :default,
-    on_mount: [LivebookWeb.AuthHook, LivebookWeb.UserHook, {LivebookWeb.PolicyHook, :private}] do
+  live_session :default, on_mount: [LivebookWeb.AuthHook, LivebookWeb.UserHook] do
     scope "/", LivebookWeb do
       pipe_through [:browser, :auth]
 


### PR DESCRIPTION
We decided to remove the policy checks, since we currently don't use them and we are focusing on alternative sharing variants for notebooks.

Also changes the empty frame text to a more friendly version:

![image](https://user-images.githubusercontent.com/17034772/217065184-b2abf4ce-da51-4f92-b7df-f86199a1aec3.png)