### PR TITLE
Bump Monaco Editor

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -16,7 +16,7 @@
         "hyperlist": "^1.0.0",
         "jest": "^29.1.2",
         "mermaid": "^9.1.3",
-        "monaco-editor": "0.33.0",
+        "monaco-editor": "^0.35.0",
         "morphdom": "^2.6.1",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
@@ -8261,9 +8261,9 @@
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "node_modules/monaco-editor": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
-      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.35.0.tgz",
+      "integrity": "sha512-BJfkAZ0EJ7JgrgWzqjfBNP9hPSS8NlfECEDMEIIiozV2UaPq22yeuOjgbd3TwMh3anH0krWZirXZfn8KUSxiOA=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.0.1",
@@ -16706,9 +16706,9 @@
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "monaco-editor": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
-      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.35.0.tgz",
+      "integrity": "sha512-BJfkAZ0EJ7JgrgWzqjfBNP9hPSS8NlfECEDMEIIiozV2UaPq22yeuOjgbd3TwMh3anH0krWZirXZfn8KUSxiOA=="
     },
     "monaco-editor-webpack-plugin": {
       "version": "7.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,7 +20,7 @@
     "hyperlist": "^1.0.0",
     "jest": "^29.1.2",
     "mermaid": "^9.1.3",
-    "monaco-editor": "0.33.0",
+    "monaco-editor": "^0.35.0",
     "morphdom": "^2.6.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",


### PR DESCRIPTION
Closes #1567.

We pinned the version because of #1470, but it's fixed in the new release. It also includes the Elixir syntax patches.

One of the classes from vscode repo is no longer exported, so I adjusted the monkey patch accordingly.