### PR TITLE
Make emoji picker easier to close

### DIFF
--- a/assets/js/hooks/emoji_picker.js
+++ b/assets/js/hooks/emoji_picker.js
@@ -10,10 +10,7 @@ const EmojiPicker = {
     const input = this.el.querySelector("[data-emoji-input]");
 
     const picker = createPopup(
-      {
-        showSearch: false,
-        showPreview: false,
-      },
+      { showPreview: false },
       {
         triggerElement: button,
         referenceElement: button,

--- a/assets/js/hooks/emoji_picker.js
+++ b/assets/js/hooks/emoji_picker.js
@@ -1,31 +1,33 @@
-import { createPicker } from "picmo";
+import { createPopup } from "@picmo/popup-picker";
 
 /**
  * A hook for the emoji picker input.
  */
 const EmojiPicker = {
   mounted() {
-    const rootElement = this.el.querySelector("[data-emoji-container]");
+    const button = this.el.querySelector("[data-emoji-button]");
     const preview = this.el.querySelector("[data-emoji-preview]");
     const input = this.el.querySelector("[data-emoji-input]");
-    const button = this.el.querySelector("[data-emoji-button]");
 
-    const pickerOptions = {
-      rootElement,
-      showSearch: false,
-      showPreview: false,
-    };
-
-    const picker = createPicker(pickerOptions);
+    const picker = createPopup(
+      {
+        showSearch: false,
+        showPreview: false,
+      },
+      {
+        triggerElement: button,
+        referenceElement: button,
+        position: "bottom",
+      }
+    );
 
     picker.addEventListener("emoji:select", ({ emoji }) => {
       preview.innerHTML = emoji;
       input.value = emoji;
-      rootElement.classList.toggle("hidden");
     });
 
     button.addEventListener("click", (_) => {
-      rootElement.classList.toggle("hidden");
+      picker.toggle();
     });
   },
 };

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -8,6 +8,7 @@
         "@fontsource/inter": "^4.2.2",
         "@fontsource/jetbrains-mono": "^4.2.2",
         "@fontsource/red-hat-text": "^4.2.2",
+        "@picmo/popup-picker": "^5.7.6",
         "babel-loader": "^9.1.0",
         "crypto-js": "^4.0.0",
         "css-minimizer-webpack-plugin": "^4.0.0",
@@ -1683,6 +1684,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.2.1"
+      }
+    },
     "node_modules/@fontsource/inter": {
       "version": "4.5.14",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.14.tgz",
@@ -2420,6 +2434,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@picmo/popup-picker": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@picmo/popup-picker/-/popup-picker-5.7.6.tgz",
+      "integrity": "sha512-rXA20BwTnDhBymgwHCqazz/dLgqmKNCwZp5gp/t4CULTfUXwVBoqK66YM3UHCftAyeNDE/zBN5Uh24oyY47iBA==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/joeattardi"
+      },
+      "peerDependencies": {
+        "picmo": "^5.7.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -8555,9 +8583,9 @@
       "link": true
     },
     "node_modules/picmo": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/picmo/-/picmo-5.7.2.tgz",
-      "integrity": "sha512-A7c5O8x1Xwq11KBYFY93+GIbHnw9PVz35HaWWHn/dgT08GA67M6cXKjjwzLnEAyXSdxXKrEk8/gPyTs+ibzWfQ==",
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/picmo/-/picmo-5.7.6.tgz",
+      "integrity": "sha512-QceahBiHfj95v9kPbWf1MGI0dYXU3vA+UZiEGop9ZrCd8m2rJ66z0UlzlDpCOZckkjFKr2zwZGm+ZQWE5FnztQ==",
       "dependencies": {
         "emojibase": "^6.1.0"
       },
@@ -11993,6 +12021,19 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
     },
+    "@floating-ui/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "requires": {
+        "@floating-ui/core": "^1.2.1"
+      }
+    },
     "@fontsource/inter": {
       "version": "4.5.14",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.14.tgz",
@@ -12546,6 +12587,14 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@picmo/popup-picker": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@picmo/popup-picker/-/popup-picker-5.7.6.tgz",
+      "integrity": "sha512-rXA20BwTnDhBymgwHCqazz/dLgqmKNCwZp5gp/t4CULTfUXwVBoqK66YM3UHCftAyeNDE/zBN5Uh24oyY47iBA==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
       }
     },
     "@sinclair/typebox": {
@@ -16924,9 +16973,9 @@
       "version": "file:../deps/phoenix_live_view"
     },
     "picmo": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/picmo/-/picmo-5.7.2.tgz",
-      "integrity": "sha512-A7c5O8x1Xwq11KBYFY93+GIbHnw9PVz35HaWWHn/dgT08GA67M6cXKjjwzLnEAyXSdxXKrEk8/gPyTs+ibzWfQ==",
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/picmo/-/picmo-5.7.6.tgz",
+      "integrity": "sha512-QceahBiHfj95v9kPbWf1MGI0dYXU3vA+UZiEGop9ZrCd8m2rJ66z0UlzlDpCOZckkjFKr2zwZGm+ZQWE5FnztQ==",
       "requires": {
         "emojibase": "^6.1.0"
       }

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,6 +12,7 @@
     "@fontsource/inter": "^4.2.2",
     "@fontsource/jetbrains-mono": "^4.2.2",
     "@fontsource/red-hat-text": "^4.2.2",
+    "@picmo/popup-picker": "^5.7.6",
     "babel-loader": "^9.1.0",
     "crypto-js": "^4.0.0",
     "css-minimizer-webpack-plugin": "^4.0.0",

--- a/lib/livebook_web/live/form_helpers.ex
+++ b/lib/livebook_web/live/form_helpers.ex
@@ -79,12 +79,7 @@ defmodule LivebookWeb.FormHelpers do
             <.remix_icon icon="emotion-line" class="text-xl" />
           </button>
         </div>
-        <div
-          id={"#{@id}-container"}
-          data-emoji-container
-          class={["absolute hidden", @container_class]}
-        />
-        <%= hidden_input(@form, @field, class: "hidden emoji-picker-input", "data-emoji-input": true) %>
+        <%= hidden_input(@form, @field, class: "hidden emoji-picker-input", data_emoji_input: true) %>
       </div>
     </div>
     """

--- a/lib/livebook_web/live/hub/edit/enterprise_component.ex
+++ b/lib/livebook_web/live/hub/edit/enterprise_component.ex
@@ -36,12 +36,7 @@ defmodule LivebookWeb.Hub.Edit.EnterpriseComponent do
             <div class="grid grid-cols-1 md:grid-cols-1 gap-3">
               <.input_wrapper form={f} field={:hub_emoji} class="flex flex-col space-y-1">
                 <div class="input-label">Emoji</div>
-                <.emoji_input
-                  id="enterprise-emoji-input"
-                  form={f}
-                  field={:hub_emoji}
-                  container_class="mt-10"
-                />
+                <.emoji_input id="enterprise-emoji-input" form={f} field={:hub_emoji} />
               </.input_wrapper>
             </div>
 

--- a/lib/livebook_web/live/hub/edit/fly_component.ex
+++ b/lib/livebook_web/live/hub/edit/fly_component.ex
@@ -77,12 +77,7 @@ defmodule LivebookWeb.Hub.Edit.FlyComponent do
 
               <.input_wrapper form={f} field={:hub_emoji} class="flex flex-col space-y-1">
                 <div class="input-label">Emoji</div>
-                <.emoji_input
-                  id="fly-emoji-input"
-                  form={f}
-                  field={:hub_emoji}
-                  container_class="mt-10"
-                />
+                <.emoji_input id="fly-emoji-input" form={f} field={:hub_emoji} />
               </.input_wrapper>
             </div>
 

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -41,12 +41,7 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
 
               <.input_wrapper form={f} field={:hub_emoji} class="flex flex-col space-y-1">
                 <div class="input-label">Emoji</div>
-                <.emoji_input
-                  id="personal-emoji-input"
-                  form={f}
-                  field={:hub_emoji}
-                  container_class="mt-10"
-                />
+                <.emoji_input id="personal-emoji-input" form={f} field={:hub_emoji} />
               </.input_wrapper>
             </div>
 

--- a/lib/livebook_web/live/hub/new/enterprise_component.ex
+++ b/lib/livebook_web/live/hub/new/enterprise_component.ex
@@ -84,12 +84,7 @@ defmodule LivebookWeb.Hub.New.EnterpriseComponent do
 
             <.input_wrapper form={f} field={:hub_emoji} class="flex relative flex-col space-y-1">
               <div class="input-label">Emoji</div>
-              <.emoji_input
-                id="enterprise-emoji-input"
-                form={f}
-                field={:hub_emoji}
-                container_class="mt-10"
-              />
+              <.emoji_input id="enterprise-emoji-input" form={f} field={:hub_emoji} />
             </.input_wrapper>
           </div>
 

--- a/lib/livebook_web/live/hub/new/fly_component.ex
+++ b/lib/livebook_web/live/hub/new/fly_component.ex
@@ -61,7 +61,7 @@ defmodule LivebookWeb.Hub.New.FlyComponent do
 
             <.input_wrapper form={f} field={:hub_emoji} class="flex relative flex-col space-y-1">
               <div class="input-label">Emoji</div>
-              <.emoji_input id="fly-emoji-input" form={f} field={:hub_emoji} container_class="mt-1" />
+              <.emoji_input id="fly-emoji-input" form={f} field={:hub_emoji} />
             </.input_wrapper>
           </div>
 


### PR DESCRIPTION
Currently the picker can only be closed by clicking on the icon button or selecting an emoji. I integrated `@picmo/popup-picker` that automatically positions a popup and can be closed by background click or escape. Also updated `picmo`, which resolves the issue where the picker is scrolled to the end when opened.

https://user-images.githubusercontent.com/17034772/218731300-3fedbb80-b7f7-4cac-b88c-25870a9b0b72.mov