### PR TITLE
Fix erlang module docs in Intellisense

### DIFF
--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -628,7 +628,7 @@ defmodule Livebook.Intellisense do
     render_line_break() |> append_inline(iodata) |> build_md(ast)
   end
 
-  defp build_md(iodata, [{:p, _, content} | ast]) do
+  defp build_md(iodata, [{tag, _, content} | ast]) when tag in [:p, :div] do
     render_paragraph(content) |> append_block(iodata) |> build_md(ast)
   end
 

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1251,6 +1251,9 @@ defmodule Livebook.IntellisenseTest do
 
       assert %{contents: [file_read]} = Intellisense.get_details(":file.read()", 8, context)
       assert file_read =~ "Typical error reasons:"
+
+      assert %{contents: [crypto]} = Intellisense.get_details(":crypto", 5, context)
+      assert crypto =~ "This module provides a set of cryptographic functions."
     end
 
     @tag :erl_docs


### PR DESCRIPTION
Currently the docs for some erlang module produce an error because of an unhandled `:div` tag:

```elixir
15:21:34.507 [error] Task #PID<0.158.0> started from #PID<0.138.0> terminating
** (FunctionClauseError) no function clause matching in Livebook.Intellisense.build_md/2
    lib/livebook/intellisense.ex:605: Livebook.Intellisense.build_md([[[[[[], "\n", "This module provides a set of cryptographic functions.", "\n"], "\n", [["* **Hash functions**", "\n", "", "\n", "  * **SHA1, SHA2**", "\n", "", "\n", "    [Secure Hash Standard [FIPS PUB 180-4]](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)", "\n", "", "\n", "  * **SHA3**", "\n", "", "\n", "    [SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions [FIPS PUB 202]](https://www.nist.gov/publications/sha-3-standard-permutation-based-hash-and-extendable-output-functions?pub_id=919061)", "\n", "", "\n", "  * **BLAKE2**", "\n", "", "\n", "    [BLAKE2 — fast secure hashing](https://blake2.net/)", "\n", "", "\n", "  * **MD5**", "\n", "", "\n", "    [The MD5 Message Digest Algorithm [RFC 1321]](http://www.ietf.org/rfc/rfc1321.txt)", "\n", "", "\n", "  * **MD4**", "\n", "", "\n", "    [The MD4 Message Digest Algorithm [RFC 1320]](http://www.ietf.org/rfc/rfc1320.txt)"], "\n\n", ["* **MACs - Message Authentication Codes**", "\n", "", "\n", "  * **Hmac functions**", "\n", "", "\n", "    [Keyed-Hashing for Message Authentication [RFC 2104]](http://www.ietf.org/rfc/rfc2104.txt)", "\n", "", "\n", "  * **Cmac functions**", "\n", "", "\n", "    [The AES-CMAC Algorithm [RFC 4493]](http://www.ietf.org/rfc/rfc4493.txt)", "\n", "", "\n", "  * **POLY1305**", "\n", "", "\n", "    [ChaCha20 and Poly1305 for IETF Protocols [RFC 7539]](http://www.ietf.org/rfc/rfc7539.txt)"], "\n\n", ["* **Symmetric Ciphers**", "\n", "", "\n", "  * **DES, 3DES and AES**", "\n", "", "\n", "    [Block Cipher Techniques [NIST]](https://csrc.nist.gov/projects/block-cipher-techniques)", "\n", "", "\n", "  * **Blowfish**", "\n", "", "\n", "    [Fast Software Encryption, Cambridge Security Workshop Proceedings (December 1993), Springer-Verlag, 1994, pp. 191-204.](https://www.schneier.com/academic/archives/1994/09/description_of_a_new.html)", "\n", "", "\n", "  * **Chacha20**", "\n", "", "\n", "    [ChaCha20 and Poly1305 for IETF Protocols [RFC 7539]](http://www.ietf.org/rfc/rfc7539.txt)", "\n", "", "\n", "  * **Chacha20_poly1305**", "\n", "", "\n", "    [ChaCha20 and Poly1305 for IETF Protocols [RFC 7539]](http://www.ietf.org/rfc/rfc7539.txt)"], "\n\n", ["* **Modes**", "\n", "", "\n", "  * **ECB, CBC, CFB, OFB and CTR**", "\n", "", "\n", "    [Recommendation for Block Cipher Modes of Operation: Methods and Techniques [NIST SP 800-38A]](https://csrc.nist.gov/publications/detail/sp/800-38a/final)", "\n", "", "\n", "  * **GCM**", "\n", "", "\n", "    [Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC [NIST SP 800-38D]](https://csrc.nist.gov/publications/detail/sp/800-38d/final)", "\n", "", "\n", "  * **CCM**", "\n", "", "\n", "    [Recommendation for Block Cipher Modes of Operation: The CCM Mode for Authentication and Confidentiality [NIST SP 800-38C]](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38c.pdf)"], "\n\n", ["* **Asymmetric Ciphers - Public Key Techniques**", "\n", "", "\n", "  * **RSA**", "\n", "", "\n", "    [PKCS #1: RSA Cryptography Specifications [RFC 3447]](http://www.ietf.org/rfc/rfc3447.txt)", "\n", "", "\n", "  * **DSS**", "\n", "", "\n", "    [Digital Signature Standard (DSS) [FIPS 186-4]](https://csrc.nist.gov/publications/detail/fips/186/4/final)", "\n", "", "\n", "  * **ECDSA**", "\n", "", "\n", "    [Elliptic Curve Digital Signature Algorithm [ECDSA]](http://csrc.nist.gov/groups/STM/cavp/documents/dss2/ecdsa2vs.pdf)", "\n", "", "\n", "  * **SRP**", "\n", "", "\n", "    [The SRP Authentication and Key Exchange System [RFC 2945]](http://www.ietf.org/rfc/rfc2945.txt)"]], "\n"], "\n", [["> ", "**NOTE**"], "\n", ["> ", ""], "\n", ["> ", "The actual supported algorithms and features depends on their availability in the actual libcrypto used. See the [crypto (App)](crypto:crypto_app) about dependencies."], "\n", ["> ", ""], "\n", ["> ", "Enabling FIPS mode will also disable algorithms and features."]], "\n"], "\n", "The [CRYPTO User's Guide](crypto:index) has more information on FIPS, Engines and Algorithm Details like key lengths.", "\n"], "\n", ["##", " ", [[], "Exceptions"]], "\n"], [{:div, [ghlink: "maint/lib/crypto/doc/src/crypto.xml#L550"], [{:h3, [], ["Atoms - the older style"]}, {:a, [id: "error_old"], []}, {:p, [], ["The exception ", {:code, [], ["error:badarg"]}, " signifies that one or more arguments are of wrong data type, or are otherwise badly formed."]}, {:p, [], ["The exception ", {:code, [], ["error:notsup"]}, " signifies that the algorithm is known but is not supported by current underlying libcrypto or explicitly disabled when building that."]}, {:p, [], ["For a list of supported algorithms, see ", {:a, [href: "crypto:crypto#supports/1", rel: "https://erlang.org/doc/link/seemfa"], ["supports(ciphers)"]}, "."]}]}, {:div, [ghlink: "maint/lib/crypto/doc/src/crypto.xml#L563"], [{:h3, [], ["3-tuples - the new style"]}, {:a, [id: "error_3tup"], []}, {:p, [], ["The exception is:"]}, {:pre, [], [{:code, [], ["error:{Tag, C_FileInfo, Description}\n\nTag = badarg | notsup | error\nC_FileInfo = term()    % Usually only useful for the OTP maintainer\nDescription = string() % Clear text, sometimes only useful for the OTP maintainer\n      "]}]}, {:p, [], ["The exception tags are:"]}, {:dl, [], [{:dt, [], [{:code, [], ["badarg"]}]}, {:dd, [], [{:p, [], ["Signifies that one or more arguments are of wrong data type or are otherwise badly formed."]}]}, {:dt, [], [{:code, [], ["notsup"]}]}, {:dd, [], [{:p, [], ["Signifies that the algorithm is known but is not supported by current underlying libcrypto or explicitly disabled when building that one."]}]}, {:dt, [], [{:code, [], ["error"]}]}, {:dd, [], [{:p, [], ["An error condition that should not occur, for example a memory allocation failed or the underlying cryptolib returned an error code, for example ", {:code, [], ["\"Can't initialize context, step 1\""]}, ". Those text usually needs searching the C-code to be understood."]}]}]}, {:p, [], ["Usually there are more information in the call stack about which argument caused the exception and what the values where."]}, {:p, [], ["To catch the exception, use for example:"]}, {:pre, [], [{:code, [], ["try crypto:crypto_init(Ciph, Key, IV, true)\n    catch\n        error:{Tag, _C_FileInfo, Description} ->\n            do_something(......)\n         .....\nend\n\t"]}]}]}])
    lib/livebook/intellisense.ex:598: Livebook.Intellisense.erlang_html_to_md/1
    lib/livebook/intellisense.ex:434: Livebook.Intellisense.format_details_item/1
    (elixir 1.14.2) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    lib/livebook/intellisense.ex:404: Livebook.Intellisense.get_details/3
    lib/livebook/runtime/erl_dist/runtime_server.ex:500: anonymous fn/4 in Livebook.Runtime.ErlDist.RuntimeServer.handle_cast/2
    (elixir 1.14.2) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: #Function<11.108606753/0 in Livebook.Runtime.ErlDist.RuntimeServer.handle_cast/2>
    Args: []
```

I changed the `build_md/2` function to handle the `:div` tag the same as a `:p` tag.

Edit:
This is how it is looking in the livebook after hovering over the `:crypto` part.
<img width="930" alt="Screenshot 2023-02-21 at 15 26 27" src="https://user-images.githubusercontent.com/792046/220371949-0e85289d-c41d-47f0-beb9-f5c097af3312.png">

