### PR TITLE
Refactor secrets form

### DIFF
--- a/lib/livebook/ecto_types/hex_color.ex
+++ b/lib/livebook/ecto_types/hex_color.ex
@@ -2,11 +2,17 @@ defmodule Livebook.EctoTypes.HexColor do
   @moduledoc false
   use Ecto.Type
 
+  @impl true
   def type, do: :string
 
+  @impl true
   def load(value), do: {:ok, value}
+
+  @impl true
+
   def dump(value), do: {:ok, value}
 
+  @impl true
   def cast(value) do
     if valid?(value) do
       {:ok, value}

--- a/lib/livebook/secrets.ex
+++ b/lib/livebook/secrets.ex
@@ -1,8 +1,6 @@
 defmodule Livebook.Secrets do
   @moduledoc false
 
-  import Ecto.Changeset, only: [apply_action: 2, add_error: 3, get_field: 2, put_change: 3]
-
   alias Livebook.Storage
   alias Livebook.Secrets.Secret
 
@@ -50,40 +48,21 @@ defmodule Livebook.Secrets do
   end
 
   @doc """
-  Validates a secret map and either returns a tuple.
-
-  ## Examples
-
-      iex> validate_secret(%{name: "FOO", value: "bar", origin: "session"})
-      {:ok, %Secret{}}
-
-      iex> validate_secret(%{})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  @spec validate_secret(map()) :: {:ok, Secret.t()} | {:error, Ecto.Changeset.t()}
-  def validate_secret(attrs) do
-    %Secret{}
-    |> Secret.changeset(attrs)
-    |> apply_action(:validate)
-  end
-
-  @doc """
   Returns an `%Ecto.Changeset{}` for tracking secret changes.
   """
   @spec change_secret(Secret.t(), map()) :: Ecto.Changeset.t()
   def change_secret(%Secret{} = secret, attrs) do
-    secret
-    |> Secret.changeset(attrs)
-    |> Map.replace!(:action, :validate)
-    |> normalize_origin()
+    Secret.changeset(secret, attrs)
   end
 
-  defp normalize_origin(changeset) do
-    case get_field(changeset, :origin) do
-      {:hub, id} -> put_change(changeset, :origin, "hub-#{id}")
-      _ -> changeset
-    end
+  @doc """
+  Updates secret with the given changes.
+  """
+  @spec update_secret(Secret.t(), map()) :: {:ok, Secret.t()} | {:error, Ecto.Changeset.t()}
+  def update_secret(%Secret{} = secret, attrs) do
+    secret
+    |> Secret.changeset(attrs)
+    |> Ecto.Changeset.apply_action(:update)
   end
 
   @doc """
@@ -94,11 +73,11 @@ defmodule Livebook.Secrets do
   def add_secret_error(%Secret{} = secret, field, message) do
     secret
     |> change_secret(%{})
-    |> add_error(field, message)
+    |> Ecto.Changeset.add_error(field, message)
   end
 
   def add_secret_error(%Ecto.Changeset{} = changeset, field, message) do
-    add_error(changeset, field, message)
+    Ecto.Changeset.add_error(changeset, field, message)
   end
 
   @doc """

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -224,10 +224,11 @@ defmodule LivebookWeb.FormComponents do
 
     ~H"""
     <div phx-feedback-for={@name} class={[@errors != [] && "show-errors"]}>
-      <div class="flex items-center gap-2 text-gray-600">
-        <label :for={{value, description} <- @options}>
+      <div class="flex gap-4 text-gray-600">
+        <label :for={{value, description} <- @options} class="flex items-center gap-2 cursor-pointer">
           <input
             type="radio"
+            class="radio-base"
             name={@name}
             id={@id || @name}
             value={value}

--- a/test/livebook/secrets_test.exs
+++ b/test/livebook/secrets_test.exs
@@ -3,6 +3,7 @@ defmodule Livebook.SecretsTest do
   use Livebook.DataCase
 
   alias Livebook.Secrets
+  alias Livebook.Secrets.Secret
 
   describe "get_secrets/0" do
     test "returns a list of secrets from storage" do
@@ -51,11 +52,11 @@ defmodule Livebook.SecretsTest do
     Secrets.unset_secret("FOO")
   end
 
-  describe "validate_secret/1" do
+  describe "update_secret/2" do
     test "returns a valid secret" do
       attrs = params_for(:secret, name: "FOO", value: "111")
 
-      assert {:ok, secret} = Secrets.validate_secret(attrs)
+      assert {:ok, secret} = Secrets.update_secret(%Secret{}, attrs)
       assert attrs.name == secret.name
       assert attrs.value == secret.value
       assert attrs.origin == secret.origin
@@ -63,11 +64,11 @@ defmodule Livebook.SecretsTest do
 
     test "returns changeset error" do
       attrs = params_for(:secret, name: nil, value: "111")
-      assert {:error, changeset} = Secrets.validate_secret(attrs)
+      assert {:error, changeset} = Secrets.update_secret(%Secret{}, attrs)
       assert "can't be blank" in errors_on(changeset).name
 
       attrs = params_for(:secret, name: "@inavalid", value: "111")
-      assert {:error, changeset} = Secrets.validate_secret(attrs)
+      assert {:error, changeset} = Secrets.update_secret(%Secret{}, attrs)
 
       assert "should contain only alphanumeric characters and underscore" in errors_on(changeset).name
     end


### PR DESCRIPTION
Currently the secret form shows errors on dead render, which is visible on refresh. To avoid that we want to apply `:validate` action against the changeset only on change, not initially.

Also, on re-renders the form would clear (e.g. periodic memory usage updates cause some parts of the page to re-render), so I fixed that.

I also refactored the origin handling, so we encode/decode into string representation only when sending the data and I think it ended up simplifying things :)