### PR TITLE
Typing env and secret name automatically uppercases

### DIFF
--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -14,6 +14,7 @@ defmodule LivebookWeb.FormComponents do
   attr :value, :any
   attr :errors, :list, default: []
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form"
+  attr :class, :string, default: nil
 
   attr :rest, :global, include: ~w(autocomplete readonly disabled)
 
@@ -27,7 +28,7 @@ defmodule LivebookWeb.FormComponents do
         name={@name}
         id={@id || @name}
         value={Phoenix.HTML.Form.normalize_value("text", @value)}
-        class="input"
+        class={["input", @class]}
         {@rest}
       />
     </.field_wrapper>

--- a/lib/livebook_web/live/env_var_component.ex
+++ b/lib/livebook_web/live/env_var_component.ex
@@ -45,6 +45,7 @@ defmodule LivebookWeb.EnvVarComponent do
             field={f[:name]}
             label="Name (alphanumeric and underscore)"
             autofocus={@operation == :new}
+            class="uppercase"
           />
           <.text_field field={f[:value]} label="Value" autofocus={@operation == :edit} />
           <.hidden_field field={f[:operation]} value={@operation} />

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -98,6 +98,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
               spellcheck="false"
               autocomplete="off"
               phx-debounce="blur"
+              class="uppercase"
             />
             <.text_field
               field={f[:value]}


### PR DESCRIPTION
We of course already do upcasing on the backend.

Demo:

https://user-images.githubusercontent.com/76071/221842936-5ad40c0d-e363-4500-a047-10b2a8ba488d.mov

Btw there are two minor bugs here still:

1. When opening the modal for the first time, there's no autofocus on the name
2. The secret modal has "Select secret" title, it should be "New Secret" on that occasion.

I'll tackle these in separate PRs soon. :)