### PR TITLE
Make high contrast mode use a high contrast light editor

### DIFF
--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -6,7 +6,11 @@
   }
 
   body[data-editor-theme="highContrast"] .bg-editor {
-    background-color: #060708;
+    background-color: #fafafa;
+  }
+
+  body[data-editor-theme="highContrast"] .monaco-editor .line-numbers.active-line-number {
+    color: #304254;
   }
 
   .text-editor {

--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -13,6 +13,37 @@
     color: #304254;
   }
 
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-0 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-1 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-2 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-3 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-4 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-5 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-6 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-7 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-8 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-9 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-10 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-11 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-12 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-13 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-14 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-15 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-16 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-17 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-18 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-19 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-20 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-21 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-22 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-23 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-24 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-25 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-26 {color: #005999;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-27 {color: #615200;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-28 {color: #92268E;}
+  body[data-editor-theme="highContrast"] .monaco-editor .bracket-highlighting-29 {color: #005999;}
+
   .text-editor {
     color: #c4cad6;
   }

--- a/assets/js/hooks/cell_editor/live_editor/theme.js
+++ b/assets/js/hooks/cell_editor/live_editor/theme.js
@@ -17,7 +17,7 @@ const hcColors = {
   default: "#304254",
   lightRed: "#E45649",
   blue: "#4078F2",
-  gray: "#8c92a3",
+  gray: "#707177",
   green: "#50A14F",
   purple: "#A626A4",
   red: "#CA1243",
@@ -134,7 +134,7 @@ const highContrast = {
 
   colors: {
     "editor.background": "#fafafa",
-    "editor.foreground": colors.default,
+    "editor.foreground": hcColors.default,
     "editorLineNumber.foreground": "#9D9D9F",
     "editorCursor.foreground": "#526FFF",
     "editor.selectionBackground": "#E5E5E6",

--- a/assets/js/hooks/cell_editor/live_editor/theme.js
+++ b/assets/js/hooks/cell_editor/live_editor/theme.js
@@ -15,14 +15,14 @@ const colors = {
 
 const hcColors = {
   default: "#304254",
-  lightRed: "#E45649",
-  blue: "#4078F2",
+  lightRed: "#A42419",
+  blue: "#0E49C8",
   gray: "#707177",
-  green: "#50A14F",
-  purple: "#A626A4",
-  red: "#CA1243",
-  teal: "#0184BC",
-  peach: "#986801",
+  green: "#2E602E",
+  purple: "#912291",
+  red: "#a90f38",
+  teal: "#01597E",
+  peach: "#745001",
 };
 
 const background = { default: "#282c34", highContrast: "#fafafa" };

--- a/assets/js/hooks/cell_editor/live_editor/theme.js
+++ b/assets/js/hooks/cell_editor/live_editor/theme.js
@@ -13,7 +13,19 @@ const colors = {
   peach: "#d19a66",
 };
 
-const background = { default: "#282c34", highContrast: "#060708" };
+const hcColors = {
+  default: "#304254",
+  lightRed: "#E45649",
+  blue: "#4078F2",
+  gray: "#8c92a3",
+  green: "#50A14F",
+  purple: "#A626A4",
+  red: "#CA1243",
+  teal: "#0184BC",
+  peach: "#986801",
+};
+
+const background = { default: "#282c34", highContrast: "#fafafa" };
 
 const theme = {
   base: "vs-dark",
@@ -77,10 +89,64 @@ const theme = {
 };
 
 const highContrast = {
-  ...theme,
+  base: "vs-dark",
+  inherit: false,
+  rules: [
+    { token: "", foreground: hcColors.default },
+    { token: "variable", foreground: hcColors.lightRed },
+    { token: "constant", foreground: hcColors.blue },
+    { token: "constant.character.escape", foreground: hcColors.blue },
+    { token: "comment", foreground: hcColors.gray },
+    { token: "number", foreground: hcColors.blue },
+    { token: "regexp", foreground: hcColors.lightRed },
+    { token: "type", foreground: hcColors.lightRed },
+    { token: "string", foreground: hcColors.green },
+    { token: "keyword", foreground: hcColors.purple },
+    { token: "operator", foreground: hcColors.peach },
+    { token: "delimiter.bracket.embed", foreground: hcColors.red },
+    { token: "sigil", foreground: hcColors.teal },
+    { token: "function", foreground: hcColors.blue },
+    { token: "function.call", foreground: hcColors.default },
+
+    // Markdown specific
+    { token: "emphasis", fontStyle: "italic" },
+    { token: "strong", fontStyle: "bold" },
+    { token: "keyword.md", foreground: hcColors.lightRed },
+    { token: "keyword.table", foreground: hcColors.lightRed },
+    { token: "string.link.md", foreground: hcColors.blue },
+    { token: "variable.md", foreground: hcColors.teal },
+    { token: "string.md", foreground: hcColors.default },
+    { token: "variable.source.md", foreground: hcColors.default },
+
+    // XML specific
+    { token: "tag", foreground: hcColors.lightRed },
+    { token: "metatag", foreground: hcColors.lightRed },
+    { token: "attribute.name", foreground: hcColors.peach },
+    { token: "attribute.value", foreground: hcColors.green },
+
+    // JSON specific
+    { token: "string.key", foreground: hcColors.lightRed },
+    { token: "keyword.json", foreground: hcColors.blue },
+
+    // SQL specific
+    { token: "operator.sql", foreground: hcColors.purple },
+  ],
+
   colors: {
-    ...theme.colors,
-    "editor.background": background.highContrast,
+    "editor.background": "#fafafa",
+    "editor.foreground": colors.default,
+    "editorLineNumber.foreground": "#9D9D9F",
+    "editorCursor.foreground": "#526FFF",
+    "editor.selectionBackground": "#E5E5E6",
+    "editor.findMatchHighlightBackground": "#526FFF33",
+    "editorSuggestWidget.background": "#EAEAEB",
+    "editorSuggestWidget.border": "#DBDBDC",
+    "editorSuggestWidget.selectedBackground": "#FFFFFF",
+    "input.background": "#FFFFFF",
+    "input.border": "#DBDBDC",
+
+    "editorBracketMatch.border": "#fafafa",
+    "editorBracketMatch.background": "#e5e5e6",
   },
 };
 


### PR DESCRIPTION
See https://github.com/livebook-dev/livebook/issues/238

I've taken the basic color scheme from [Atom One Light](https://marketplace.visualstudio.com/items?itemName=akamud.vscode-theme-onelight) but when checking contrast ratios, a lot of them were marginal. So in order to stay in line with the idea of having a "high contrast" version, I've pushed the syntax highlighting colors down to be at 7:1 or a bit above. 

![image](https://user-images.githubusercontent.com/84811/222627570-28a97b20-4f90-46c9-880b-093322261701.png)
