### PR TITLE
Small changes

### DIFF
--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -102,6 +102,9 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
     ~H"""
     <div id={@id} class="flex flex-col space-y-4">
       <div class="flex flex-col space-y-4">
+        <.no_entries :if={@secrets == []}>
+          No secrets in this Hub yet.
+        </.no_entries>
         <div
           :for={secret <- @secrets}
           class="flex items-center justify-between border border-gray-200 rounded-lg p-4"
@@ -111,7 +114,7 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
       </div>
       <div class="flex">
         <.link patch={@new_secret_path} class="button-base button-blue" id="add-secret">
-          Add new secret
+          Add secret
         </.link>
       </div>
     </div>

--- a/lib/livebook_web/live/hub/secret_form_component.ex
+++ b/lib/livebook_web/live/hub/secret_form_component.ex
@@ -43,7 +43,7 @@ defmodule LivebookWeb.Hub.SecretFormComponent do
               autofocus={@secret_name == nil}
               spellcheck="false"
               autocomplete="off"
-              phx-debounce="blur"
+              phx-debounce
               class="uppercase"
             />
             <.text_field
@@ -52,7 +52,7 @@ defmodule LivebookWeb.Hub.SecretFormComponent do
               autofocus={@secret_name != nil}
               spellcheck="false"
               autocomplete="off"
-              phx-debounce="blur"
+              phx-debounce
             />
             <.hidden_field field={f[:hub_id]} value={@hub.id} />
             <div class="flex space-x-2">

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -70,7 +70,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
               autocomplete="off"
             >
               <div class="flex flex-col space-y-4">
-                <.text_field field={f[:slug]} label="Slug" spellcheck="false" phx-debounce="blur" />
+                <.text_field field={f[:slug]} label="Slug" spellcheck="false" phx-debounce />
                 <div class="flex flex-col space-y-1">
                   <.checkbox_field
                     field={f[:access_type]}
@@ -79,7 +79,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
                     unchecked_value="public"
                   />
                   <%= if Ecto.Changeset.get_field(@changeset, :access_type) == :protected do %>
-                    <.password_field field={f[:password]} spellcheck="false" phx-debounce="blur" />
+                    <.password_field field={f[:password]} spellcheck="false" phx-debounce />
                   <% end %>
                 </div>
                 <.checkbox_field field={f[:show_source]} label="Show source" />

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -100,7 +100,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
               autofocus={@prefill_secret_name == nil}
               spellcheck="false"
               autocomplete="off"
-              phx-debounce="blur"
+              phx-debounce
               class="uppercase"
             />
             <.text_field
@@ -109,7 +109,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
               autofocus={@prefill_secret_name != nil}
               spellcheck="false"
               autocomplete="off"
-              phx-debounce="blur"
+              phx-debounce
             />
             <.radio_field
               field={f[:hub_id]}


### PR DESCRIPTION
* Show "no entries" banner when there are no secrets in hub
* Use default debounce of 100 on secret and app inputs