### PR TITLE
Add section collapse functionality

### DIFF
--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -61,9 +61,13 @@ solely client-side operations.
 }
 
 [data-el-section][data-js-collapsed] [data-el-section-collapse-button],
+[data-el-section]:not([data-js-collapsed])
+  [data-el-section-headline]:not(:hover):not([data-js-focused])
+  [data-el-section-collapse-button],
 [data-el-section]:not([data-js-collapsed]) [data-el-section-expand-button],
-[data-el-section][data-js-collapsed] > .container,
-[data-el-section]:not([data-js-collapsed]) > [data-el-section-subheadline-collapsed] {
+[data-el-section][data-js-collapsed] > [data-el-section-content],
+[data-el-section]:not([data-js-collapsed])
+  > [data-el-section-subheadline-collapsed] {
   @apply hidden;
 }
 

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -60,6 +60,13 @@ solely client-side operations.
   @apply hidden;
 }
 
+[data-el-section][data-js-collapsed] [data-el-section-collapse-button],
+[data-el-section]:not([data-js-collapsed]) [data-el-section-expand-button],
+[data-el-section][data-js-collapsed] > .container,
+[data-el-section]:not([data-js-collapsed]) > [data-el-section-subheadline-collapsed] {
+  @apply hidden;
+}
+
 [data-el-cell][data-js-focused] {
   @apply border-blue-300 border-opacity-100;
 }

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -562,27 +562,9 @@ defmodule LivebookWeb.SessionLive do
   defp sections_list(assigns) do
     ~H"""
     <div class="flex flex-col grow">
-      <div class="flex flex-row">
-        <h3 class="grow self-center uppercase text-sm font-semibold text-gray-500">
-          Sections
-        </h3>
-        <div class="flex items-end space-x-2">
-          <span class="tooltip bottom" data-tooltip="Collapse all sections">
-            <button class="icon-button" aria-label="Collapse all sections">
-              <.remix_icon
-                icon="fullscreen-exit-line"
-                class="text-xl"
-                phx-click="collapse_all_sections"
-              />
-            </button>
-          </span>
-          <span class="tooltip bottom" data-tooltip="Expand all sections">
-            <button class="icon-button" aria-label="Expand all sections">
-              <.remix_icon icon="fullscreen-line" class="text-xl" phx-click="expand_all_sections" />
-            </button>
-          </span>
-        </div>
-      </div>
+      <h3 class="uppercase text-sm font-semibold text-gray-500">
+        Sections
+      </h3>
       <div class="flex flex-col mt-4 space-y-4">
         <div :for={section_item <- @data_view.sections_items} class="flex items-center">
           <button
@@ -869,22 +851,6 @@ defmodule LivebookWeb.SessionLive do
   end
 
   @impl true
-  def handle_event("expand_all_sections", _params, socket) do
-    Enum.each(socket.assigns.data_view.section_views, fn section ->
-      send_update(LivebookWeb.SessionLive.SectionComponent, id: section.id, collapsed?: false)
-    end)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("collapse_all_sections", _params, socket) do
-    Enum.each(socket.assigns.data_view.section_views, fn section ->
-      send_update(LivebookWeb.SessionLive.SectionComponent, id: section.id, collapsed?: true)
-    end)
-
-    {:noreply, socket}
-  end
-
   def handle_event("append_section", %{}, socket) do
     idx = length(socket.private.data.notebook.sections)
     Session.insert_section(socket.assigns.session.pid, idx)

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -562,9 +562,27 @@ defmodule LivebookWeb.SessionLive do
   defp sections_list(assigns) do
     ~H"""
     <div class="flex flex-col grow">
-      <h3 class="uppercase text-sm font-semibold text-gray-500">
-        Sections
-      </h3>
+      <div class="flex flex-row">
+        <h3 class="grow self-center uppercase text-sm font-semibold text-gray-500">
+          Sections
+        </h3>
+        <div class="flex items-end space-x-2">
+          <span class="tooltip bottom" data-tooltip="Collapse all sections">
+            <button class="icon-button" aria-label="Collapse all sections">
+              <.remix_icon
+                icon="fullscreen-exit-line"
+                class="text-xl"
+                phx-click="collapse_all_sections"
+              />
+            </button>
+          </span>
+          <span class="tooltip bottom" data-tooltip="Expand all sections">
+            <button class="icon-button" aria-label="Expand all sections">
+              <.remix_icon icon="fullscreen-line" class="text-xl" phx-click="expand_all_sections" />
+            </button>
+          </span>
+        </div>
+      </div>
       <div class="flex flex-col mt-4 space-y-4">
         <div :for={section_item <- @data_view.sections_items} class="flex items-center">
           <button
@@ -851,6 +869,22 @@ defmodule LivebookWeb.SessionLive do
   end
 
   @impl true
+  def handle_event("expand_all_sections", _params, socket) do
+    Enum.each(socket.assigns.data_view.section_views, fn section ->
+      send_update(LivebookWeb.SessionLive.SectionComponent, id: section.id, collapsed?: false)
+    end)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("collapse_all_sections", _params, socket) do
+    Enum.each(socket.assigns.data_view.section_views, fn section ->
+      send_update(LivebookWeb.SessionLive.SectionComponent, id: section.id, collapsed?: true)
+    end)
+
+    {:noreply, socket}
+  end
+
   def handle_event("append_section", %{}, socket) do
     idx = length(socket.private.data.notebook.sections)
     Session.insert_section(socket.assigns.session.pid, idx)

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -156,7 +156,8 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         class="mt-1 flex items-end space-x-1 text-sm font-semibold italic text-gray-800"
         data-el-section-subheadline-collapsed
       >
-        <%= Enum.count(@section_view.cell_views) %> cells hidden
+        <%= count = Enum.count(@section_view.cell_views)
+        if count == 1, do: "1 cell hidden", else: "#{count} cells hidden" %>
       </h3>
       <div class="container">
         <div class="flex flex-col space-y-1">

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -1,6 +1,8 @@
 defmodule LivebookWeb.SessionLive.SectionComponent do
   use LivebookWeb, :live_component
 
+  alias Phoenix.LiveView.JS
+
   def render(assigns) do
     ~H"""
     <section data-el-section data-section-id={@section_view.id}>
@@ -13,6 +15,32 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         data-on-value-change="set_section_name"
         data-metadata={@section_view.id}
       >
+        <span class="tooltip top" data-tooltip="Collapse section" data-el-section-collapse-button>
+          <button class="icon-button" aria-label="collapse section">
+            <.remix_icon
+              icon="arrow-drop-down-line"
+              class="text-xl"
+              phx-click={
+                JS.set_attribute({"data-js-collapsed", ""},
+                  to: "section[data-section-id=#{@section_view.id}]"
+                )
+              }
+            />
+          </button>
+        </span>
+        <span class="tooltip top" data-tooltip="Expand section" data-el-section-expand-button>
+          <button class="icon-button" aria-label="expand section">
+            <.remix_icon
+              icon="arrow-drop-right-line"
+              class="text-xl"
+              phx-click={
+                JS.remove_attribute("data-js-collapsed",
+                  to: "section[data-section-id=#{@section_view.id}]"
+                )
+              }
+            />
+          </button>
+        </span>
         <h2
           class="grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border border-transparent whitespace-pre-wrap cursor-text"
           tabindex="0"
@@ -122,6 +150,13 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
           />
         </span>
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
+      </h3>
+
+      <h3
+        class="mt-1 flex items-end space-x-1 text-sm font-semibold italic text-gray-800"
+        data-el-section-subheadline-collapsed
+      >
+        <%= Enum.count(@section_view.cell_views) %> cells hidden
       </h3>
       <div class="container">
         <div class="flex flex-col space-y-1">

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -6,36 +6,8 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
   def render(assigns) do
     ~H"""
     <section data-el-section data-section-id={@section_view.id}>
-      <div class="absolute -left-1 mt-1">
-        <span class="tooltip top" data-tooltip="Collapse section" data-el-section-collapse-button>
-          <button class="icon-button" aria-label="collapse section">
-            <.remix_icon
-              icon="arrow-drop-down-line"
-              class="text-xl"
-              phx-click={
-                JS.set_attribute({"data-js-collapsed", ""},
-                  to: "section[data-section-id=\"#{@section_view.id}\"]"
-                )
-              }
-            />
-          </button>
-        </span>
-        <span class="tooltip top" data-tooltip="Expand section" data-el-section-expand-button>
-          <button class="icon-button" aria-label="expand section">
-            <.remix_icon
-              icon="arrow-drop-right-line"
-              class="text-xl"
-              phx-click={
-                JS.remove_attribute("data-js-collapsed",
-                  to: "section[data-section-id=\"#{@section_view.id}\"]"
-                )
-              }
-            />
-          </button>
-        </span>
-      </div>
       <div
-        class="flex space-x-4 items-center"
+        class="flex items-center relative"
         data-el-section-headline
         id={@section_view.id}
         data-focusable-id={@section_view.id}
@@ -43,6 +15,32 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         data-on-value-change="set_section_name"
         data-metadata={@section_view.id}
       >
+        <div class="absolute left-0 top-0 bottom-0 transform -translate-x-full w-10 flex justify-end items-center pr-2">
+          <button
+            class="icon-button"
+            aria-label="collapse section"
+            data-el-section-collapse-button
+            phx-click={
+              JS.set_attribute({"data-js-collapsed", ""},
+                to: ~s/section[data-section-id="#{@section_view.id}"]/
+              )
+            }
+          >
+            <.remix_icon icon="arrow-down-s-line" class="text-xl" />
+          </button>
+          <button
+            class="icon-button"
+            aria-label="expand section"
+            data-el-section-expand-button
+            phx-click={
+              JS.remove_attribute("data-js-collapsed",
+                to: ~s/section[data-section-id="#{@section_view.id}"]/
+              )
+            }
+          >
+            <.remix_icon icon="arrow-right-s-line" class="text-xl" />
+          </button>
+        </div>
         <h2
           class="grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border border-transparent whitespace-pre-wrap cursor-text"
           tabindex="0"
@@ -52,7 +50,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
           phx-no-format
         ><%= @section_view.name %></h2>
         <div
-          class="flex space-x-2 items-center"
+          class="ml-4 flex space-x-2 items-center"
           data-el-section-actions
           role="toolbar"
           aria-label="section actions"
@@ -154,14 +152,10 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
 
-      <h3
-        class="mt-1 flex items-end space-x-1 text-sm font-semibold italic text-gray-800"
-        data-el-section-subheadline-collapsed
-      >
-        <%= count = Enum.count(@section_view.cell_views)
-        if count == 1, do: "1 cell hidden", else: "#{count} cells hidden" %>
+      <h3 class="mt-2 text-sm text-gray-500" data-el-section-subheadline-collapsed>
+        <%= pluralize(length(@section_view.cell_views), "cell hidden", "cells hidden") %>
       </h3>
-      <div class="container">
+      <div class="container" data-el-section-content>
         <div class="flex flex-col space-y-1">
           <.live_component
             module={LivebookWeb.SessionLive.InsertButtonsComponent}

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -152,7 +152,10 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
 
-      <h3 class="mt-2 text-sm text-gray-500 cursor-default select-none" data-el-section-subheadline-collapsed>
+      <h3
+        class="mt-2 text-sm text-gray-500 cursor-default select-none"
+        data-el-section-subheadline-collapsed
+      >
         <%= pluralize(length(@section_view.cell_views), "cell", "cells") %> collapsed
       </h3>
       <div class="container" data-el-section-content>

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -1,10 +1,6 @@
 defmodule LivebookWeb.SessionLive.SectionComponent do
   use LivebookWeb, :live_component
 
-  def mount(socket) do
-    {:ok, assign(socket, :collapsed?, false)}
-  end
-
   def render(assigns) do
     ~H"""
     <section data-el-section data-section-id={@section_view.id}>
@@ -17,16 +13,6 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         data-on-value-change="set_section_name"
         data-metadata={@section_view.id}
       >
-        <span class="tooltip top" data-tooltip="Toggle section">
-          <button class="icon-button" aria-label="toggle section">
-            <.remix_icon
-              icon={"arrow-drop-#{if @collapsed?, do: "right", else: "down"}-line"}
-              class="text-xl"
-              phx-click="toggle_collapse"
-              phx-target={@myself}
-            />
-          </button>
-        </span>
         <h2
           class="grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border border-transparent whitespace-pre-wrap cursor-text"
           tabindex="0"
@@ -122,7 +108,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
       </div>
       <h3
         :if={@section_view.parent}
-        class="mt-1 ml-12 flex items-end space-x-1 text-sm font-semibold text-gray-800"
+        class="mt-1 flex items-end space-x-1 text-sm font-semibold text-gray-800"
         data-el-section-subheadline
       >
         <span
@@ -137,7 +123,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         </span>
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
-      <div class={["container", @collapsed? && "hidden"]}>
+      <div class="container">
         <div class="flex flex-col space-y-1">
           <.live_component
             module={LivebookWeb.SessionLive.InsertButtonsComponent}
@@ -176,9 +162,5 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
       </div>
     </section>
     """
-  end
-
-  def handle_event("toggle_collapse", _params, socket) do
-    {:noreply, update(socket, :collapsed?, &(not &1))}
   end
 end

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -1,6 +1,10 @@
 defmodule LivebookWeb.SessionLive.SectionComponent do
   use LivebookWeb, :live_component
 
+  def mount(socket) do
+    {:ok, assign(socket, :collapsed?, false)}
+  end
+
   def render(assigns) do
     ~H"""
     <section data-el-section data-section-id={@section_view.id}>
@@ -13,6 +17,16 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         data-on-value-change="set_section_name"
         data-metadata={@section_view.id}
       >
+        <span class="tooltip top" data-tooltip="Toggle section">
+          <button class="icon-button" aria-label="toggle section">
+            <.remix_icon
+              icon={"arrow-drop-#{if @collapsed?, do: "right", else: "down"}-line"}
+              class="text-xl"
+              phx-click="toggle_collapse"
+              phx-target={@myself}
+            />
+          </button>
+        </span>
         <h2
           class="grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border border-transparent whitespace-pre-wrap cursor-text"
           tabindex="0"
@@ -108,7 +122,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
       </div>
       <h3
         :if={@section_view.parent}
-        class="mt-1 flex items-end space-x-1 text-sm font-semibold text-gray-800"
+        class="mt-1 ml-12 flex items-end space-x-1 text-sm font-semibold text-gray-800"
         data-el-section-subheadline
       >
         <span
@@ -123,7 +137,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         </span>
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
-      <div class="container">
+      <div class={["container", @collapsed? && "hidden"]}>
         <div class="flex flex-col space-y-1">
           <.live_component
             module={LivebookWeb.SessionLive.InsertButtonsComponent}
@@ -162,5 +176,9 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
       </div>
     </section>
     """
+  end
+
+  def handle_event("toggle_collapse", _params, socket) do
+    {:noreply, update(socket, :collapsed?, &(not &1))}
   end
 end

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -22,7 +22,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
               class="text-xl"
               phx-click={
                 JS.set_attribute({"data-js-collapsed", ""},
-                  to: "section[data-section-id=#{@section_view.id}]"
+                  to: "section[data-section-id=\"#{@section_view.id}\"]"
                 )
               }
             />
@@ -35,7 +35,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
               class="text-xl"
               phx-click={
                 JS.remove_attribute("data-js-collapsed",
-                  to: "section[data-section-id=#{@section_view.id}]"
+                  to: "section[data-section-id=\"#{@section_view.id}\"]"
                 )
               }
             />

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -137,7 +137,14 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         </span>
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
-      <div class={["container", @collapsed? && "hidden"]}>
+      <h3
+        :if={@collapsed?}
+        class="mt-1 ml-12 flex tiems-end space-x-1 text-sm font-semibold text-gray-800"
+        data-el-section-subheadline
+      >
+        <%= Enum.count(@section_view.cell_views) %> cells hidden
+      </h3>
+      <div class={["container", "ml-12", @collapsed? && "hidden"]}>
         <div class="flex flex-col space-y-1">
           <.live_component
             module={LivebookWeb.SessionLive.InsertButtonsComponent}

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -6,15 +6,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
   def render(assigns) do
     ~H"""
     <section data-el-section data-section-id={@section_view.id}>
-      <div
-        class="flex space-x-4 items-center"
-        data-el-section-headline
-        id={@section_view.id}
-        data-focusable-id={@section_view.id}
-        phx-hook="Headline"
-        data-on-value-change="set_section_name"
-        data-metadata={@section_view.id}
-      >
+      <div class="absolute -left-1 mt-1">
         <span class="tooltip top" data-tooltip="Collapse section" data-el-section-collapse-button>
           <button class="icon-button" aria-label="collapse section">
             <.remix_icon
@@ -41,6 +33,16 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
             />
           </button>
         </span>
+      </div>
+      <div
+        class="flex space-x-4 items-center"
+        data-el-section-headline
+        id={@section_view.id}
+        data-focusable-id={@section_view.id}
+        phx-hook="Headline"
+        data-on-value-change="set_section_name"
+        data-metadata={@section_view.id}
+      >
         <h2
           class="grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border border-transparent whitespace-pre-wrap cursor-text"
           tabindex="0"

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -137,14 +137,7 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         </span>
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
-      <h3
-        :if={@collapsed?}
-        class="mt-1 ml-12 flex tiems-end space-x-1 text-sm font-semibold text-gray-800"
-        data-el-section-subheadline
-      >
-        <%= Enum.count(@section_view.cell_views) %> cells hidden
-      </h3>
-      <div class={["container", "ml-12", @collapsed? && "hidden"]}>
+      <div class={["container", @collapsed? && "hidden"]}>
         <div class="flex flex-col space-y-1">
           <.live_component
             module={LivebookWeb.SessionLive.InsertButtonsComponent}

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -152,8 +152,8 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
         <span class="leading-none">from ”<%= @section_view.parent.name %>”</span>
       </h3>
 
-      <h3 class="mt-2 text-sm text-gray-500" data-el-section-subheadline-collapsed>
-        <%= pluralize(length(@section_view.cell_views), "cell hidden", "cells hidden") %>
+      <h3 class="mt-2 text-sm text-gray-500 cursor-default select-none" data-el-section-subheadline-collapsed>
+        <%= pluralize(length(@section_view.cell_views), "cell", "cells") %> collapsed
       </h3>
       <div class="container" data-el-section-content>
         <div class="flex flex-col space-y-1">


### PR DESCRIPTION
WIP #1686

[screen_recording_livebook_collapse_section.webm](https://user-images.githubusercontent.com/11441198/224491112-611101b7-2748-422e-a12f-16d4972bb56f.webm)

Is this heading in the right direction?
Not sure about the "Expand all" and "Collapse all" buttons..