### PR TITLE
Fix attribute replacement in storage

### DIFF
--- a/lib/livebook/storage.ex
+++ b/lib/livebook/storage.ex
@@ -239,8 +239,11 @@ defmodule Livebook.Storage do
   defp delete_keys(table, namespace, entity_id, keys) do
     match_head = {{namespace, entity_id}, :"$1", :_, :_}
 
-    guards = Enum.map(keys, &{:==, :"$1", &1})
+    guard =
+      keys
+      |> Enum.map(&{:==, :"$1", &1})
+      |> Enum.reduce(&{:orelse, &1, &2})
 
-    :ets.select_delete(table, [{match_head, guards, [true]}])
+    :ets.select_delete(table, [{match_head, [guard], [true]}])
   end
 end

--- a/test/livebook/storage_test.exs
+++ b/test/livebook/storage_test.exs
@@ -33,6 +33,8 @@ defmodule Livebook.StorageTest do
                 key2: "val2",
                 key3: "val3"
               }} = Storage.fetch(:insert, "replace")
+
+      assert {:ok, "updated_val1"} = Storage.fetch_key(:insert, "replace", :key1)
     end
   end
 


### PR DESCRIPTION
Currently every update using `Livebook.Storage.insert` would insert new values, but keep the old ones around. Everything worked fine because we convert to map in `fetch`.