### PR TITLE
Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            BASE_IMAGE=livebook/utils:elixir-cuda11.8
+            BASE_IMAGE=ghcr.io/livebook-dev/utils:elixir-cuda11.8
 
   create_draft_release:
     if: github.ref_type == 'tag'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,16 +69,17 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: livebook/livebook
+          images: ghcr.io/livebook-dev/livebook
           tags: |
             type=semver,pattern={{version}}
             type=edge,branch=main
@@ -103,16 +104,17 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: livebook/livebook
+          images: ghcr.io/livebook-dev/livebook
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
Docker Hub will soon drop free organizations (https://github.com/docker/hub-feedback/issues/2314), so we plan to migrate all images to GitHub Container Registry.

Once merged, this should build `:edge` images. Once this works, we can also migrate old versioned images manually.