### PR TITLE
Improve iframe repositioning when moving sections and cells

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -1054,6 +1054,8 @@ const Session = {
   },
 
   handleCellMoved(cellId) {
+    this.repositionJSViews();
+
     if (this.focusedId === cellId) {
       globalPubSub.broadcast("cells", { type: "cell_moved", cellId });
     }
@@ -1076,6 +1078,8 @@ const Session = {
   },
 
   handleSectionMoved(sectionId) {
+    this.repositionJSViews();
+
     const section = this.getSectionById(sectionId);
     smoothlyScrollToElement(section);
   },
@@ -1152,6 +1156,10 @@ const Session = {
         selection: event.selection,
       });
     }
+  },
+
+  repositionJSViews() {
+    globalPubSub.broadcast("js_views", { type: "reposition" });
   },
 
   /**


### PR DESCRIPTION
So far we used `IntersectionObserver` to detect when iframe placeholder moves (as a result of cell/section being moved), as during movement an element is briefly removed from DOM and the intersection becomes 0%. However, when moving sections, the observer triggers only for elements in one section, since only one needs to be removed. Interestingly it still works fine on cell movement.

A more robust solution is triggering the reposition whenever we know section/cell is moved and we can do that with a global DOM event.