### PR TITLE
Flush frame outputs from state

### DIFF
--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -3,7 +3,8 @@ defmodule LivebookWeb.Output.FrameComponent do
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, counter: 0, output_count: 0, persistent_id_map: %{})}
+    {:ok, assign(socket, counter: 0, output_count: 0, persistent_id_map: %{}),
+     temporary_assigns: [outputs: []]}
   end
 
   @impl true
@@ -56,7 +57,7 @@ defmodule LivebookWeb.Output.FrameComponent do
 
         :append ->
           socket
-          |> update(:outputs, &(outputs ++ &1))
+          |> assign(:outputs, outputs)
           |> update(:output_count, &(length(outputs) + &1))
       end
 


### PR DESCRIPTION
Currently this fails:

```elixir
Kino.Frame.append(frame, Kino.Input.text("hello"))
Kino.Frame.append(frame, "ok")
```

We don't prune inputs and when appending, the frame component would accumulate duplicated outputs and crash because of duplicate ids.