### PR TITLE
Add missing :req dependency for "Maps with MapLibre" example

### DIFF
--- a/lib/livebook/notebook/learn/intro_to_maplibre.livemd
+++ b/lib/livebook/notebook/learn/intro_to_maplibre.livemd
@@ -3,7 +3,8 @@
 ```elixir
 Mix.install([
   {:maplibre, "~> 0.1.3"},
-  {:kino_maplibre, "~> 0.1.7"}
+  {:kino_maplibre, "~> 0.1.7"},
+  {:req, "~> 0.3.0"}
 ])
 ```
 


### PR DESCRIPTION
When running this notebook, it fails with the following error:

```
** (RuntimeError) to use styles from a url you need the :req package.

You can install it by adding

    {:req, "~> 0.3.0"}
...
```