### PR TITLE
the naming of data Transform Cell + some grammar

### DIFF
--- a/lib/livebook/notebook/learn/intro_to_explorer.livemd
+++ b/lib/livebook/notebook/learn/intro_to_explorer.livemd
@@ -53,7 +53,7 @@ Explorer.Datasets.fossil_fuels()
 
 <!-- livebook:{"branch_parent_index":0} -->
 
-## The smart Data transform cell
+## The Data transform smart cell
 
 The DataTable lets us quickly view the raw data, without modifying it,
 while the Data transform cell allows us to transform it, creating insightful

--- a/lib/livebook/notebook/learn/intro_to_explorer.livemd
+++ b/lib/livebook/notebook/learn/intro_to_explorer.livemd
@@ -34,7 +34,7 @@ All set, let's go.
 
 ## Quick introduction to Explorer and DataTable
 
-Shortly, Explorer is the DataFrame library for Elixir. It brings the
+In short, Explorer is the DataFrame library for Elixir. It brings the
 essential data analysis, exploration, and transformation tools to the
 Elixir ecosystem, while the integration provided by KinoExplorer makes
 it effortless to visualize and interact with data through the DataTable.
@@ -53,10 +53,10 @@ Explorer.Datasets.fossil_fuels()
 
 <!-- livebook:{"branch_parent_index":0} -->
 
-## The Data transform smart cell
+## The smart data Transform Cell
 
-The DataTable let us to quickly view the raw data, without modifying it,
-while the Data transform cell allows us to transform it creating insightful
+The DataTable lets us quickly view the raw data, without modifying it,
+while the data Transform Cell allows us to transform it, creating insightful
 and flexible data pipelines and seeing the results on the fly.
 
 Before we explore its features, we need some data to work with.
@@ -92,9 +92,9 @@ weekdays =
   |> DF.pivot_wider("team", "hour")
 ```
 
-Let's break down what happened in the previous Data transform cell.
+Let's break down what happened in the previous data Transform Cell.
 
-Currently, the Data transform cell supports several operations, such as `sorting`,
+Currently, the data Transform Cell supports several operations, such as `sorting`,
 `filter`, `pivot_wider`, and more. Each operation has its own colored card and
 you can move the cards to reorder the operations and see the changes in real time.
 

--- a/lib/livebook/notebook/learn/intro_to_explorer.livemd
+++ b/lib/livebook/notebook/learn/intro_to_explorer.livemd
@@ -53,10 +53,10 @@ Explorer.Datasets.fossil_fuels()
 
 <!-- livebook:{"branch_parent_index":0} -->
 
-## The smart data Transform Cell
+## The smart Data transform cell
 
 The DataTable lets us quickly view the raw data, without modifying it,
-while the data Transform Cell allows us to transform it, creating insightful
+while the Data transform cell allows us to transform it, creating insightful
 and flexible data pipelines and seeing the results on the fly.
 
 Before we explore its features, we need some data to work with.
@@ -92,9 +92,9 @@ weekdays =
   |> DF.pivot_wider("team", "hour")
 ```
 
-Let's break down what happened in the previous data Transform Cell.
+Let's break down what happened in the previous Data transform cell.
 
-Currently, the data Transform Cell supports several operations, such as `sorting`,
+Currently, the Data transform cell supports several operations, such as `sorting`,
 `filter`, `pivot_wider`, and more. Each operation has its own colored card and
 you can move the cards to reorder the operations and see the changes in real time.
 


### PR DESCRIPTION
IMO Data transform cell should be one of: data Transform Cell or Data Transform Cell or even data transform cell. I say this since if you capitalise Data, it assumes that Data has been declared now as something special, and so needs a name (or apriori, in this document or elsewhere). But it is the Transform Cell that is infact special in this context. Later in the document you have Smart Cells. This makes sense to me as the set of cells which have smart properties. And you have Chart cell - which I can judge to be the short-style name of Chart-configuration cell. i.e. it is an auxiliary activity upon the main stuff, the data. But, in the context of this document, Data is confusing.  Anyhow, I chose one of these i.e. The smart data Transform Cell

In the near future = shortly;    TL;DR = in short