### PR TITLE
Modify kino button example to render the button

### DIFF
--- a/lib/livebook/notebook/learn/kino/intro_to_kino.livemd
+++ b/lib/livebook/notebook/learn/kino/intro_to_kino.livemd
@@ -55,8 +55,8 @@ the main way to interact with controls is by listening to their
 events.
 
 ```elixir
-Kino.Control.button("Click me!")
-|> Kino.listen(fn event -> IO.inspect(event) end)
+button = Kino.Control.button("Click me!") |> Kino.render()
+Kino.listen(button, fn event -> IO.inspect(event) end)
 ```
 
 <!-- livebook:{"branch_parent_index":0} -->

--- a/lib/livebook/notebook/learn/kino/intro_to_kino.livemd
+++ b/lib/livebook/notebook/learn/kino/intro_to_kino.livemd
@@ -55,7 +55,10 @@ the main way to interact with controls is by listening to their
 events.
 
 ```elixir
-button = Kino.Control.button("Click me!") |> Kino.render()
+button = Kino.Control.button("Click me!")
+```
+
+```elixir
 Kino.listen(button, fn event -> IO.inspect(event) end)
 ```
 


### PR DESCRIPTION
The current example outputs the result of `Kino.listen` which does not actually render the button the user would click on.

By capturing the button, calling listen on it, and returning the button we render a functional button.

## Before
![image](https://user-images.githubusercontent.com/454563/226490276-55db2c80-af39-479c-a6a0-0f90e9e47c31.png)

## After
![image](https://user-images.githubusercontent.com/454563/226493842-e8802f6a-9e30-4c5c-be99-4e39879c0270.png)


## Alternatives
Modify `Kino.listen` to return the listened control to allow the existing example code to function.
`Kino.animate` seems to do this.
