### PR TITLE
Show app URLs as relative

### DIFF
--- a/lib/livebook_web.ex
+++ b/lib/livebook_web.ex
@@ -80,6 +80,10 @@ defmodule LivebookWeb do
         endpoint: LivebookWeb.Endpoint,
         router: LivebookWeb.Router,
         statics: LivebookWeb.static_paths()
+
+      # We don't know the hostname Livebook runs on, so we don't use
+      # absolute URL helpers
+      import Phoenix.VerifiedRoutes, only: :sigils
     end
   end
 

--- a/lib/livebook_web/live/apps_live.ex
+++ b/lib/livebook_web/live/apps_live.ex
@@ -89,8 +89,8 @@ defmodule LivebookWeb.AppsLive do
         <div class="flex-1 grow-[2]">
           <.labeled_text label="URL">
             <%= if @session.app_info.registered do %>
-              <a href={url(~p"/apps/#{@session.app_info.slug}")} target="_blank">
-                <%= url(~p"/apps/#{@session.app_info.slug}") %>
+              <a href={~p"/apps/#{@session.app_info.slug}"} target="_blank">
+                <%= ~p"/apps/#{@session.app_info.slug}" %>
               </a>
             <% else %>
               -

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -112,8 +112,8 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
               </.labeled_text>
               <.labeled_text label="URL" one_line>
                 <%= if app.registered do %>
-                  <a href={url(~p"/apps/#{app.settings.slug}")} target="_blank">
-                    <%= url(~p"/apps/#{app.settings.slug}") %>
+                  <a href={~p"/apps/#{app.settings.slug}"} target="_blank">
+                    <%= ~p"/apps/#{app.settings.slug}" %>
                   </a>
                 <% else %>
                   -


### PR DESCRIPTION
If livebook doesn't run on localhost, we don't know the host, so for local app deployments we can just show the path instead.