### PR TITLE
Fix displaying error dialog and logging errors

### DIFF
--- a/elixirkit/demo/rel/dotnet/Demo.cs
+++ b/elixirkit/demo/rel/dotnet/Demo.cs
@@ -2,22 +2,27 @@ class Demo
 {
     public static void Main()
     {
-        ElixirKit.API.Start(name: "demo");
-        ElixirKit.API.Publish("log", "Hello from C#!");
-
-        ElixirKit.API.Subscribe((name, data) =>
-        {
-            switch (name)
+        ElixirKit.API.Start(
+            name: "demo",
+            ready: () =>
             {
-                case "log":
-                    Console.WriteLine($"[client] {data}");
-                    break;
+                ElixirKit.API.Publish("log", "Hello from C#!");
 
-                default:
-                    throw new Exception($"unknown event {name}");
+                ElixirKit.API.Subscribe((name, data) =>
+                {
+                    switch (name)
+                    {
+                        case "log":
+                            Console.WriteLine($"[client] {data}");
+                            break;
+
+                        default:
+                            throw new Exception($"unknown event {name}");
+                    }
+                });
             }
-        });
+        );
 
-        ElixirKit.API.WaitForExit();
+        System.Console.WriteLine($"{ElixirKit.API.WaitForExit()}");
     }
 }

--- a/elixirkit/demo/rel/swift/Sources/Demo/Demo.swift
+++ b/elixirkit/demo/rel/swift/Sources/Demo/Demo.swift
@@ -10,17 +10,21 @@ struct Demo {
             exit(signal)
         }
 
-        ElixirKit.API.start(name: "demo")
-        ElixirKit.API.publish("log", "Hello from Swift!")
+        ElixirKit.API.start(
+            name: "demo",
+            readyHandler: {
+                ElixirKit.API.publish("log", "Hello from Swift!")
 
-        ElixirKit.API.addObserver(queue: .main) { (name, data) in
-            switch name {
-            case "log":
-                print("[client] " + data)
-            default:
-                fatalError("unknown event \(name)")
+                ElixirKit.API.addObserver(queue: .main) { (name, data) in
+                    switch name {
+                    case "log":
+                        print("[client] " + data)
+                    default:
+                        fatalError("unknown event \(name)")
+                    }
+                }
             }
-        }
+        )
 
         ElixirKit.API.waitUntilExit()
     }

--- a/elixirkit/demo/rel/winforms/Demo.cs
+++ b/elixirkit/demo/rel/winforms/Demo.cs
@@ -7,30 +7,35 @@ static class DemoMain
     {
         if (ElixirKit.API.IsMainInstance("com.example.Demo"))
         {
-            ElixirKit.API.Start(name: "demo", exited: (exitCode) =>
-            {
-                Application.Exit();
-            });
+            ElixirKit.API.Start(
+                name: "demo",
+                ready: () =>
+                {
+                    ElixirKit.API.Publish("log", "Hello from Windows Forms!");
+
+                    ElixirKit.API.Subscribe((name, data) =>
+                    {
+                        switch (name)
+                        {
+                            case "log":
+                                Console.WriteLine($"[client] {data}");
+                                break;
+
+                            default:
+                                throw new Exception($"unknown event {name}");
+                        }
+                    });
+                },
+                exited: (exitCode) =>
+                {
+                    Application.Exit();
+                }
+            );
 
             Application.ApplicationExit += (sender, args) =>
             {
                 ElixirKit.API.Stop();
             };
-
-            ElixirKit.API.Publish("log", "Hello from Windows Forms!");
-
-            ElixirKit.API.Subscribe((name, data) =>
-            {
-                switch (name)
-                {
-                    case "log":
-                        Console.WriteLine($"[client] {data}");
-                        break;
-
-                    default:
-                        throw new Exception($"unknown event {name}");
-                }
-            });
 
             ApplicationConfiguration.Initialize();
             Application.Run(new DemoForm());

--- a/rel/app/windows/Livebook.cs
+++ b/rel/app/windows/Livebook.cs
@@ -88,27 +88,28 @@ class LivebookApp : ApplicationContext
         ElixirKit.API.Start(
             name: "app",
             logPath: logPath,
+            ready: () => {
+                ElixirKit.API.Subscribe((name, data) =>
+                {
+                    switch (name)
+                    {
+                        case "url":
+                            copyURLButton.Enabled = true;
+                            this.url = data;
+                            break;
+
+                        default:
+                            throw new Exception($"unknown event {name}");
+                    }
+                });
+
+                ElixirKit.API.Publish("open", url);
+            },
             exited: (exitCode) =>
             {
                 Application.Exit();
             }
         );
-
-        ElixirKit.API.Subscribe((name, data) =>
-        {
-            switch (name)
-            {
-                case "url":
-                    copyURLButton.Enabled = true;
-                    this.url = data;
-                    break;
-
-                default:
-                    throw new Exception($"unknown event {name}");
-            }
-        });
-
-        ElixirKit.API.Publish("open", url);
     }
 
     private void threadExit(object? sender, EventArgs e)


### PR DESCRIPTION
Introducing server-client communication broke error handling because waiting on the server socket blocked the main thread. This change makes ElixirKit.API.start non-blocking and adds `readyHandler:`/`ready:` hooks.

Closes #1809.