### PR TITLE
Fix smart cell indicator when source changes on start

### DIFF
--- a/lib/livebook/delta.ex
+++ b/lib/livebook/delta.ex
@@ -115,13 +115,19 @@ defmodule Livebook.Delta do
   def trim(delta) do
     case List.last(delta.ops) do
       {:retain, _} ->
-        Map.update!(delta, :ops, fn ops ->
-          ops |> Enum.reverse() |> tl() |> Enum.reverse()
-        end)
+        Map.update!(delta, :ops, &List.delete_at(&1, -1))
 
       _ ->
         delta
     end
+  end
+
+  @doc """
+  Checks if the delta has no changes.
+  """
+  @spec empty?(t()) :: boolean()
+  def empty?(delta) do
+    trim(delta).ops == []
   end
 
   @doc """

--- a/lib/livebook/delta.ex
+++ b/lib/livebook/delta.ex
@@ -24,6 +24,11 @@ defmodule Livebook.Delta do
   alias Livebook.Delta
   alias Livebook.Delta.{Operation, Transformation}
 
+  @typedoc """
+  Delta carries a list of consecutive operations.
+
+  Note that we keep the operations in reversed order for efficiency.
+  """
   @type t :: %Delta{ops: list(Operation.t())}
 
   @doc """
@@ -73,12 +78,7 @@ defmodule Livebook.Delta do
   """
   @spec append(t(), Operation.t()) :: t()
   def append(delta, op) do
-    Map.update!(delta, :ops, fn ops ->
-      ops
-      |> Enum.reverse()
-      |> compact(op)
-      |> Enum.reverse()
-    end)
+    Map.update!(delta, :ops, &compact(&1, op))
   end
 
   defp compact(ops, {:insert, ""}), do: ops
@@ -110,17 +110,8 @@ defmodule Livebook.Delta do
   Removes trailing retain operations from the given delta.
   """
   @spec trim(t()) :: t()
-  def trim(%Delta{ops: []} = delta), do: delta
-
-  def trim(delta) do
-    case List.last(delta.ops) do
-      {:retain, _} ->
-        Map.update!(delta, :ops, &List.delete_at(&1, -1))
-
-      _ ->
-        delta
-    end
-  end
+  def trim(%Delta{ops: [{:retain, _} | ops]} = delta), do: %{delta | ops: ops}
+  def trim(delta), do: delta
 
   @doc """
   Checks if the delta has no changes.
@@ -131,19 +122,29 @@ defmodule Livebook.Delta do
   end
 
   @doc """
+  Returns data operations in the order in which they apply.
+  """
+  @spec operations(t()) :: list(Operation.t())
+  def operations(delta) do
+    Enum.reverse(delta.ops)
+  end
+
+  @doc """
   Converts the given delta to a compact representation,
   suitable for sending over the network.
 
   ## Examples
 
-      iex> delta = %Livebook.Delta{ops: [retain: 2, insert: "hey", delete: 3]}
+      iex> delta = Delta.new([retain: 2, insert: "hey", delete: 3])
       iex> Livebook.Delta.to_compressed(delta)
       [2, "hey", -3]
 
   """
   @spec to_compressed(t()) :: list(Operation.compressed_t())
   def to_compressed(delta) do
-    Enum.map(delta.ops, &Operation.to_compressed/1)
+    delta.ops
+    |> Enum.reverse()
+    |> Enum.map(&Operation.to_compressed/1)
   end
 
   @doc """
@@ -151,15 +152,19 @@ defmodule Livebook.Delta do
 
   ## Examples
 
-      iex> Livebook.Delta.from_compressed([2, "hey", -3])
-      %Livebook.Delta{ops: [retain: 2, insert: "hey", delete: 3]}
+      iex> delta = Livebook.Delta.from_compressed([2, "hey", -3])
+      iex> Livebook.Delta.operations(delta)
+      [retain: 2, insert: "hey", delete: 3]
 
   """
   @spec from_compressed(list(Operation.compressed_t())) :: t()
   def from_compressed(list) do
-    list
-    |> Enum.map(&Operation.from_compressed/1)
-    |> new()
+    ops =
+      list
+      |> Enum.map(&Operation.from_compressed/1)
+      |> Enum.reverse()
+
+    %Delta{ops: ops}
   end
 
   defdelegate transform(left, right, priority), to: Transformation

--- a/lib/livebook/delta/transformation.ex
+++ b/lib/livebook/delta/transformation.ex
@@ -36,7 +36,7 @@ defmodule Livebook.Delta.Transformation do
   """
   @spec transform(Delta.t(), Delta.t(), priority()) :: Delta.t()
   def transform(left, right, priority) do
-    do_transform(left.ops, right.ops, priority, Delta.new())
+    do_transform(Delta.operations(left), Delta.operations(right), priority, Delta.new())
     |> Delta.trim()
   end
 

--- a/lib/livebook/js_interop.ex
+++ b/lib/livebook/js_interop.ex
@@ -20,7 +20,8 @@ defmodule Livebook.JSInterop do
   def apply_delta_to_string(delta, string) do
     code_units = string_to_utf16_code_units(string)
 
-    delta.ops
+    delta
+    |> Delta.operations()
     |> apply_to_code_units(code_units)
     |> utf16_code_units_to_string()
   end

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1861,6 +1861,18 @@ defmodule Livebook.Session do
   defp after_operation(
          state,
          _prev_state,
+         {:smart_cell_started, _client_id, cell_id, delta, _chunks, _js_view, _editor}
+       ) do
+    if delta != Delta.new() do
+      hydrate_cell_source_digest(state, cell_id, :primary)
+    end
+
+    state
+  end
+
+  defp after_operation(
+         state,
+         _prev_state,
          {:update_smart_cell, _client_id, cell_id, _attrs, _delta, _chunks, _reevaluate}
        ) do
     hydrate_cell_source_digest(state, cell_id, :primary)

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1863,7 +1863,7 @@ defmodule Livebook.Session do
          _prev_state,
          {:smart_cell_started, _client_id, cell_id, delta, _chunks, _js_view, _editor}
        ) do
-    if delta != Delta.new() do
+    unless Delta.empty?(delta) do
       hydrate_cell_source_digest(state, cell_id, :primary)
     end
 

--- a/test/livebook/delta_test.exs
+++ b/test/livebook/delta_test.exs
@@ -8,39 +8,39 @@ defmodule Livebook.DeltaTest do
 
   describe "append/2" do
     test "ignores empty operations" do
-      assert Delta.append(Delta.new(), {:insert, ""}) == %Delta{ops: []}
-      assert Delta.append(Delta.new(), {:retain, 0}) == %Delta{ops: []}
-      assert Delta.append(Delta.new(), {:delete, 0}) == %Delta{ops: []}
+      assert Delta.new() |> Delta.append({:insert, ""}) |> Delta.operations() == []
+      assert Delta.new() |> Delta.append({:retain, 0}) |> Delta.operations() == []
+      assert Delta.new() |> Delta.append({:delete, 0}) |> Delta.operations() == []
     end
 
     test "given empty delta just appends the operation" do
       delta = Delta.new()
       op = Operation.insert("cats")
-      assert Delta.append(delta, op) == %Delta{ops: [insert: "cats"]}
+      assert delta |> Delta.append(op) |> Delta.operations() == [insert: "cats"]
     end
 
     test "merges consecutive inserts" do
       delta = Delta.new() |> Delta.insert("cats")
       op = Operation.insert(" rule")
-      assert Delta.append(delta, op) == %Delta{ops: [insert: "cats rule"]}
+      assert delta |> Delta.append(op) |> Delta.operations() == [insert: "cats rule"]
     end
 
     test "merges consecutive retains" do
       delta = Delta.new() |> Delta.retain(2)
       op = Operation.retain(2)
-      assert Delta.append(delta, op) == %Delta{ops: [retain: 4]}
+      assert delta |> Delta.append(op) |> Delta.operations() == [retain: 4]
     end
 
     test "merges consecutive delete" do
       delta = Delta.new() |> Delta.delete(2)
       op = Operation.delete(2)
-      assert Delta.append(delta, op) == %Delta{ops: [delete: 4]}
+      assert delta |> Delta.append(op) |> Delta.operations() == [delete: 4]
     end
 
     test "given insert appended after delete, swaps the operations" do
       delta = Delta.new() |> Delta.delete(2)
       op = Operation.insert("cats")
-      assert Delta.append(delta, op) == %Delta{ops: [insert: "cats", delete: 2]}
+      assert delta |> Delta.append(op) |> Delta.operations() == [insert: "cats", delete: 2]
     end
   end
 end

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -944,7 +944,7 @@ defmodule Livebook.SessionTest do
     end
 
     test "pings the smart cell before evaluation to await all incoming messages" do
-      smart_cell = %{Notebook.Cell.new(:smart) | kind: "text", source: "1"}
+      smart_cell = %{Notebook.Cell.new(:smart) | kind: "text", source: ""}
       notebook = %{Notebook.new() | sections: [%{Notebook.Section.new() | cells: [smart_cell]}]}
       session = start_session(notebook: notebook)
 
@@ -963,6 +963,11 @@ defmodule Livebook.SessionTest do
         {:runtime_smart_cell_started, smart_cell.id,
          %{source: "1", js_view: %{pid: self(), ref: "ref"}, editor: nil}}
       )
+
+      # Sends digest to clients when the source is different
+      cell_id = smart_cell.id
+      new_digest = :erlang.md5("1")
+      assert_receive {:hydrate_cell_source_digest, ^cell_id, :primary, ^new_digest}
 
       Session.queue_cell_evaluation(session.pid, smart_cell.id)
 


### PR DESCRIPTION
Currently there's an edge case where the smart cell generates source that differs from Livebook formatting. When a notebook is saved we format the Elixir cell, then once the notebook is open and the smart cell starts, the source is updated to match the smart cell again, so we need to hydrate LV source digest in that case too. Apart from formatting, the source could change when the user opens the notebook and bumps smart cell version (so the generated source may differ).