### PR TITLE
Make the error status clickable on failed deployments

### DIFF
--- a/lib/livebook_web/live/app_helpers.ex
+++ b/lib/livebook_web/live/app_helpers.ex
@@ -39,10 +39,10 @@ defmodule LivebookWeb.AppHelpers do
 
   defp app_status_indicator(assigns) do
     ~H"""
-    <div class="flex items-center space-x-2">
-      <div :if={@text}><%= @text %></div>
+    <span class="flex items-center space-x-2">
+      <span :if={@text}><%= @text %></span>
       <.status_indicator variant={@variant} />
-    </div>
+    </span>
     """
   end
 end

--- a/lib/livebook_web/live/apps_live.ex
+++ b/lib/livebook_web/live/apps_live.ex
@@ -78,7 +78,14 @@ defmodule LivebookWeb.AppsLive do
       <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-8 w-full max-w-2xl">
         <div class="flex-1">
           <.labeled_text label="Status">
-            <.app_status status={@session.app_info.status} />
+            <a
+              class="inline-block"
+              aria-label="debug app"
+              href={@session.app_info.status == :error && ~p"/sessions/#{@session.id}"}
+              target="_blank"
+            >
+              <.app_status status={@session.app_info.status} />
+            </a>
           </.labeled_text>
         </div>
         <div class="flex-1">

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -119,7 +119,14 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
           <div :for={app <- @apps} class="border border-gray-200 rounded-lg">
             <div class="p-4 flex flex-col space-y-3">
               <.labeled_text label="Status">
-                <.app_status status={app.status} />
+                <a
+                  class="inline-block"
+                  aria-label="debug app"
+                  href={app.status == :error && ~p"/sessions/#{app.session_id}"}
+                  target="_blank"
+                >
+                  <.app_status status={app.status} />
+                </a>
               </.labeled_text>
               <.labeled_text label="URL" one_line>
                 <%= if app.registered do %>


### PR DESCRIPTION
I choose to not make it always clickable because someone could click the status and think it is the actual deployed notebook.

Closes #1853.