### PR TITLE
Link outside iframe when Livebook has no access to cookies

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2,7 +2,7 @@
   /* Buttons */
 
   .button-base {
-    @apply px-5 py-2 rounded-lg border border-transparent font-medium text-sm whitespace-nowrap;
+    @apply inline-flex px-5 py-2 rounded-lg border border-transparent font-medium text-sm whitespace-nowrap;
   }
 
   .button-blue {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -66,9 +66,7 @@ function connect() {
 // option enabled, which is the default. Without cookies access, the session
 // is not stored, so CSRF tokens are invalid. Consequently, LV keeps reloading
 // the page, as we try to connect the socket with invalid token. To work around
-// this we need to ask to explicitly grant access to cookies, as outlined in (1).
-//
-// (1): https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API
+// this we tell the user to open Livebook outside the iframe.
 
 if (document.hasStorageAccess) {
   document.hasStorageAccess().then((hasStorageAccess) => {
@@ -85,28 +83,21 @@ if (document.hasStorageAccess) {
             </div>
             <div class="mt-3 text-sm text-gray-300">
               It looks like Livebook does not have access to cookies. This usually happens when
-              it runs in an iframe. To make the app functional you need to grant Livebook access
-              to its cookies explicitly.
+              it runs in an iframe. To make sure the app is fully functional open it in a new
+              tab directly.
             </div>
             <div>
-              <button id="grant-access" class="mt-6 button-base button-blue">
-                Grant access
-              </button>
+              <a id="open-app" class="mt-6 button-base button-blue" target="_blank">
+                Open app
+              </a>
             </div>
           </div>
         </div>
       `;
 
+      overlayEl.querySelector("#open-app").href = window.location;
+
       document.body.appendChild(overlayEl);
-
-      const grantAccessButtonEl = overlayEl.querySelector("#grant-access");
-
-      grantAccessButtonEl.addEventListener("click", (event) => {
-        document
-          .requestStorageAccess()
-          .then(() => window.location.reload())
-          .catch(() => console.log("Access to storage denied"));
-      });
     }
   });
 } else {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -86,8 +86,8 @@ if (document.hasStorageAccess) {
               it runs in an iframe. To make sure the app is fully functional open it in a new
               tab directly.
             </div>
-            <div>
-              <a id="open-app" class="mt-6 button-base button-blue" target="_blank">
+            <div class="mt-6">
+              <a id="open-app" class="button-base button-blue" target="_blank">
                 Open app
               </a>
             </div>


### PR DESCRIPTION
Follow up to #1862. Turns out that `document.requestStorageAccess()` may not always resolve successfully, one of the prerequisites is `allow-storage-access-by-user-activation` on the iframe, but there are more. A simpler solution we came up with is linking to the iframe source, so that the user opens Livebook outside the iframe.