### PR TITLE
Use shorter name for doctests module

### DIFF
--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -154,7 +154,7 @@ defmodule Livebook.Intellisense.Docs do
         true
 
       {:docs_v1, _, _, _, _, _, docs} ->
-        Enum.filter(docs, &match?({_, _, _, %{}, _}, &1)) != []
+        Enum.any?(docs, &match?({_, _, _, %{}, _}, &1))
 
       _ ->
         false

--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -143,4 +143,21 @@ defmodule Livebook.Intellisense.Docs do
   # loads elixir.beam, so we explicitly list it.
   defp ensure_loaded?(Elixir), do: false
   defp ensure_loaded?(module), do: Code.ensure_loaded?(module)
+
+  @doc """
+  Checks if the module has any documentation.
+  """
+  @spec any_docs?(module()) :: boolean()
+  def any_docs?(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, %{}, _, _} ->
+        true
+
+      {:docs_v1, _, _, _, _, _, docs} ->
+        Enum.filter(docs, &match?({_, _, _, %{}, _}, &1)) != []
+
+      _ ->
+        false
+    end
+  end
 end

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -456,7 +456,9 @@ defmodule Livebook.Runtime.Evaluator do
       end
 
     if ebin_path() do
-      Livebook.Runtime.Evaluator.Doctests.run(new_context.env.context_modules)
+      new_context.env.context_modules
+      |> Enum.filter(&Livebook.Intellisense.Docs.any_docs?/1)
+      |> Livebook.Runtime.Evaluator.Doctests.run()
     end
 
     state = put_context(state, ref, new_context)

--- a/lib/livebook/runtime/evaluator/doctests.ex
+++ b/lib/livebook/runtime/evaluator/doctests.ex
@@ -36,7 +36,8 @@ defmodule Livebook.Runtime.Evaluator.Doctests do
   end
 
   defp define_test_module(modules) do
-    name = Module.concat([LivebookDoctest | modules])
+    id = :erlang.phash2(modules)
+    name = Module.concat([LivebookDoctest, "TestModule#{id}"])
 
     try do
       defmodule name do

--- a/lib/livebook/runtime/evaluator/doctests.ex
+++ b/lib/livebook/runtime/evaluator/doctests.ex
@@ -45,7 +45,7 @@ defmodule Livebook.Runtime.Evaluator.Doctests do
         |> String.replace_prefix("Elixir.", "")
       end)
       |> :erlang.md5()
-      |> Base.encode64()
+      |> Base.encode32(padding: false)
 
     name = Module.concat([LivebookDoctest, "TestModule#{id}"])
 

--- a/lib/livebook/runtime/evaluator/doctests.ex
+++ b/lib/livebook/runtime/evaluator/doctests.ex
@@ -36,7 +36,17 @@ defmodule Livebook.Runtime.Evaluator.Doctests do
   end
 
   defp define_test_module(modules) do
-    id = :erlang.phash2(modules)
+    id =
+      modules
+      |> Enum.sort()
+      |> Enum.map_join("-", fn module ->
+        module
+        |> Atom.to_string()
+        |> String.replace_prefix("Elixir.", "")
+      end)
+      |> :erlang.md5()
+      |> Base.encode64()
+
     name = Module.concat([LivebookDoctest, "TestModule#{id}"])
 
     try do

--- a/test/livebook/hubs/docs_test.exs
+++ b/test/livebook/hubs/docs_test.exs
@@ -1,0 +1,13 @@
+defmodule Livebook.Intellisense.DocsTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Intellisense.Docs
+
+  test "any_docs?/1" do
+    refute Docs.any_docs?(Livebook.TestModules.Docs.Without)
+    refute Docs.any_docs?(Livebook.TestModules.Docs.ModuleHidden)
+    refute Docs.any_docs?(Livebook.TestModules.Docs.FunctionHidden)
+    assert Docs.any_docs?(Livebook.TestModules.Docs.Module)
+    assert Docs.any_docs?(Livebook.TestModules.Docs.Function)
+  end
+end

--- a/test/support/test_modules/docs.ex
+++ b/test/support/test_modules/docs.ex
@@ -1,0 +1,20 @@
+defmodule Livebook.TestModules.Docs.Without do
+end
+
+defmodule Livebook.TestModules.Docs.ModuleHidden do
+  @moduledoc false
+end
+
+defmodule Livebook.TestModules.Docs.Module do
+  @moduledoc "Hello."
+end
+
+defmodule Livebook.TestModules.Docs.FunctionHidden do
+  @doc false
+  def hello(), do: "hello"
+end
+
+defmodule Livebook.TestModules.Docs.Function do
+  @doc "Hello."
+  def hello(), do: "hello"
+end


### PR DESCRIPTION
Closes #1872.

We use `Module.concat([LivebookDoctest | modules])` as the doctest module name. If a cell defines a lot of modules this overflows the maximum atom length, so instead we can hash to make it short (but still deterministic, so that we don't generate atoms randomly).