### PR TITLE
Fix typo from `deplay` to `deploy`

### DIFF
--- a/lib/livebook/notebook/learn/deploy_apps.livemd
+++ b/lib/livebook/notebook/learn/deploy_apps.livemd
@@ -8,7 +8,7 @@ Mix.install([
 
 ## Introduction
 
-In this notebook, we will build and deplay a chat application.
+In this notebook, we will build and deploy a chat application.
 To do so, we will use Livebook's companion library called
 [`kino`](https://github.com/livebook-dev/kino).
 


### PR DESCRIPTION
Just a small change fixing a typo.