### PR TITLE
fix race condition for reevaluating smart cells

### DIFF
--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -465,6 +465,7 @@ defmodule Livebook.Runtime.Evaluator do
 
     metadata = %{
       errored: elem(result, 0) == :error,
+      evaluation_digest: :erlang.md5(code),
       evaluation_time_ms: evaluation_time_ms,
       memory_usage: memory(),
       code_error: code_error,

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -1227,6 +1227,7 @@ defmodule Livebook.Session.Data do
           eval_info
           | status: :ready,
             errored: metadata.errored,
+            evaluation_digest: metadata.evaluation_digest,
             evaluation_time_ms: metadata.evaluation_time_ms,
             identifiers_used: metadata.identifiers_used,
             identifiers_defined: metadata.identifiers_defined,
@@ -1413,7 +1414,8 @@ defmodule Livebook.Session.Data do
               status: :evaluating,
               evaluation_number: eval_info.evaluation_number + 1,
               outputs_batch_number: eval_info.outputs_batch_number + 1,
-              evaluation_digest: info.sources.primary.digest,
+              # Will be set in the evaluator to avoid race conditions
+              evaluation_digest: nil,
               new_bound_to_input_ids: MapSet.new(),
               # Keep the notebook state before evaluation
               data: data,

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -15,9 +15,11 @@ defmodule Livebook.Session.DataTest do
     uses = opts[:uses] || []
     defines = opts[:defines] || %{}
     errored = Keyword.get(opts, :errored, false)
+    code = Keyword.get(opts, :code, "")
 
     %{
       errored: errored,
+      evaluation_digest: :erlang.md5(code),
       evaluation_time_ms: 10,
       identifiers_used: uses,
       identifiers_defined: defines

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -10,6 +10,7 @@ defmodule Livebook.SessionTest do
 
   @eval_meta %{
     errored: false,
+    evaluation_digest: <<212, 29, 140, 217, 143, 0, 178, 4, 233, 128, 9, 152, 236, 248, 66, 126>>,
     evaluation_time_ms: 10,
     identifiers_used: [],
     identifiers_defined: %{}


### PR DESCRIPTION
This fixes the race condition which occurred on Jose's talk on the ElixirConf EU 
![image](https://user-images.githubusercontent.com/11441198/234257410-574efede-5a25-4552-916d-68df1ae12a10.png)

The problem occurs when changing Smart Cells that have the property "reevaluate_on_change" (such as the Data Transform cell). In this case, the evaluation_digest is calculated before the changes are broadcast to the clients.

To fix the issue, I've calculated the digest after the evaluation. I hope this solution makes sense.

P.S. Create talks by you guys :) I hope to join the conference in person next year!