### PR TITLE
Improve cookie access check

### DIFF
--- a/assets/js/lib/user.js
+++ b/assets/js/lib/user.js
@@ -1,4 +1,4 @@
-import { decodeBase64, encodeBase64 } from "./utils";
+import { cookieOptions, decodeBase64, encodeBase64 } from "./utils";
 
 const USER_DATA_COOKIE = "lb:user_data";
 
@@ -40,12 +40,4 @@ function getCookieValue(key) {
 function setCookie(key, value, maxAge) {
   const cookie = `${key}=${value};max-age=${maxAge};path=/${cookieOptions()}`;
   document.cookie = cookie;
-}
-
-function cookieOptions() {
-  if (document.body.hasAttribute("data-within-iframe")) {
-    return ";SameSite=None;Secure";
-  } else {
-    return ";SameSite=Lax";
-  }
 }

--- a/assets/js/lib/utils.js
+++ b/assets/js/lib/utils.js
@@ -235,3 +235,11 @@ export function isFeatureFlagEnabled(feature) {
     return features.split(",").includes(feature);
   }
 }
+
+export function cookieOptions() {
+  if (document.body.hasAttribute("data-within-iframe")) {
+    return ";SameSite=None;Secure";
+  } else {
+    return ";SameSite=Lax";
+  }
+}

--- a/lib/livebook_web/endpoint.ex
+++ b/lib/livebook_web/endpoint.ex
@@ -104,6 +104,14 @@ defmodule LivebookWeb.Endpoint do
     end
   end
 
+  def cookie_options() do
+    if Livebook.Config.within_iframe?() do
+      [same_site: "None", secure: true]
+    else
+      [same_site: "Lax"]
+    end
+  end
+
   # Because we run on localhost, we may accumulate
   # cookies from several other apps. Our header limit
   # is set to 32kB. Once we are 75% of said limit,

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -46,22 +46,10 @@ defmodule LivebookWeb.UserPlug do
       user_data = user_data(User.new())
       encoded = user_data |> Jason.encode!() |> Base.encode64()
 
-      put_resp_cookie(
-        conn,
-        "lb:user_data",
-        encoded,
-        # We disable HttpOnly, so that it can be accessed on the client
-        # and set expiration to 5 years
-        [http_only: false, max_age: 157_680_000] ++ cookie_options()
-      )
-    end
-  end
-
-  defp cookie_options() do
-    if Livebook.Config.within_iframe?() do
-      [same_site: "None", secure: true]
-    else
-      [same_site: "Lax"]
+      # We disable HttpOnly, so that it can be accessed on the client
+      # and set expiration to 5 years
+      opts = [http_only: false, max_age: 157_680_000] ++ LivebookWeb.Endpoint.cookie_options()
+      put_resp_cookie(conn, "lb:user_data", encoded, opts)
     end
   end
 


### PR DESCRIPTION
The `lb:user_data` cookie is only set after successful authentication. Initially I thought about always adding an empty `lb:probe_cookie` cookie, but it looks like if we can just set it on the client and then read to see if it's actually set.