### PR TITLE
Fix typo in presentation view shortcut label

### DIFF
--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -94,7 +94,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["c"], desc: "Expand/collapse section"},
       %{seq: ["C"], desc: "Expand/collapse all sections"},
       %{seq: ["v", "z"], desc: "Toggle code zen view"},
-      %{seq: ["v", "p"], desc: "Toggle presentation view]"},
+      %{seq: ["v", "p"], desc: "Toggle presentation view"},
       %{seq: ["d", "d"], desc: "Delete cell", basic: true},
       %{seq: ["e", "e"], desc: "Evaluate cell"},
       %{seq: ["e", "s"], desc: "Evaluate section"},


### PR DESCRIPTION
Fixes a small typo introduced in https://github.com/livebook-dev/livebook/commit/e7f8ee8ca8093cfb2a7a0c346ffd6170e6e3ad00 