### PR TITLE
Add info about empty Kino outputs

### DIFF
--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -54,8 +54,6 @@ defmodule LivebookWeb.AppLive do
 
   @impl true
   def render(assigns) when assigns.app_authenticated? do
-    IO.inspect(assigns)
-
     ~H"""
     <div class="h-full relative overflow-y-auto px-4 md:px-20" data-el-notebook>
       <div class="w-full max-w-screen-lg py-4 mx-auto" data-el-notebook-content>
@@ -122,7 +120,8 @@ defmodule LivebookWeb.AppLive do
             />
           </div>
           <div :if={@data_view.output_views == []} class="info-box">
-            Note: In deployed notebooks, only Kino outputs are rendered. Ensure you use Kino for interactive visualizations and dynamic content.
+            This deployed notebook is empty. Deployed apps only render Kino outputs.
+            Ensure you use Kino for interactive visualizations and dynamic content.
           </div>
         </div>
         <div style="height: 80vh"></div>

--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -54,6 +54,8 @@ defmodule LivebookWeb.AppLive do
 
   @impl true
   def render(assigns) when assigns.app_authenticated? do
+    IO.inspect(assigns)
+
     ~H"""
     <div class="h-full relative overflow-y-auto px-4 md:px-20" data-el-notebook>
       <div class="w-full max-w-screen-lg py-4 mx-auto" data-el-notebook-content>
@@ -118,6 +120,9 @@ defmodule LivebookWeb.AppLive do
               client_id={@client_id}
               input_values={output_view.input_values}
             />
+          </div>
+          <div :if={@data_view.output_views == []} class="info-box">
+            Note: In deployed notebooks, only Kino outputs are rendered. Ensure you use Kino for interactive visualizations and dynamic content.
           </div>
         </div>
         <div style="height: 80vh"></div>

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -1,0 +1,36 @@
+defmodule LivebookWeb.AppLiveTest do
+  use LivebookWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Livebook.Session
+
+  test "render guidance when Kino output is empty", %{conn: conn} do
+    session = start_session()
+
+    Session.subscribe(session.id)
+
+    slug = Livebook.Utils.random_short_id()
+    app_settings = %{Livebook.Notebook.AppSettings.new() | slug: slug}
+    Session.set_app_settings(session.pid, app_settings)
+
+    Session.set_notebook_name(session.pid, "My app #{slug}")
+    Session.deploy_app(session.pid)
+
+    assert_receive {:operation, {:add_app, _, _, _}}
+    assert_receive {:operation, {:set_app_registered, _, _, true}}
+
+    {:ok, view, _} = live(conn, ~p"/apps/#{slug}")
+
+    assert render(view) =~ """
+           This deployed notebook is empty. Deployed apps only render Kino outputs.
+                   Ensure you use Kino for interactive visualizations and dynamic content.\
+           """
+  end
+
+  defp start_session() do
+    {:ok, session} = Livebook.Sessions.create_session()
+    on_exit(fn -> Session.close(session.pid) end)
+    session
+  end
+end

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -22,10 +22,8 @@ defmodule LivebookWeb.AppLiveTest do
 
     {:ok, view, _} = live(conn, ~p"/apps/#{slug}")
 
-    assert render(view) =~ """
-           This deployed notebook is empty. Deployed apps only render Kino outputs.
-                   Ensure you use Kino for interactive visualizations and dynamic content.\
-           """
+    assert render(view) =~
+             "This deployed notebook is empty. Deployed apps only render Kino outputs."
   end
 
   defp start_session() do


### PR DESCRIPTION
via. https://github.com/livebook-dev/livebook/issues/1871

Render a guidance message when no Kino outputs are present.
<img width="1232" alt="image" src="https://user-images.githubusercontent.com/43606066/236692965-336ff6e0-f03c-4f8f-8987-b713af4f2495.png">
