### PR TITLE
Remove bottom border from last running session in running session list

### DIFF
--- a/lib/livebook_web/live/home_live/session_list_component.ex
+++ b/lib/livebook_web/live/home_live/session_list_component.ex
@@ -107,7 +107,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
     <div class="flex flex-col" role="group" aria-label="running sessions list">
       <div
         :for={session <- @sessions}
-        class="py-4 flex items-center border-b border-gray-300"
+        class="py-4 flex items-center border-b last:border-b-0 border-gray-300"
         data-test-session-id={session.id}
       >
         <div id={"#{session.id}-checkbox"} phx-update="ignore">


### PR DESCRIPTION
Small visual improvement:

**Before**
![image](https://github.com/livebook-dev/livebook/assets/3637265/5011e0d4-13b5-4d89-a54f-41a88ff4792f)

**After**
![image](https://github.com/livebook-dev/livebook/assets/3637265/e3859e1f-965e-46bf-b0cb-8b31516a215e)
