### PR TITLE
Add support for multi-instance apps

### DIFF
--- a/lib/livebook/app.ex
+++ b/lib/livebook/app.ex
@@ -1,0 +1,386 @@
+defmodule Livebook.App do
+  @moduledoc false
+
+  # Process corresponding to a deployed app, orchestrating app sessions.
+  #
+  # An app process is identified by a user-defined slug, which also
+  # determines its URL. The process starts when the first notebook is
+  # deployed under this slug. Subsequent notebook deployments for the
+  # same slug are handled by the process directly.
+  #
+  # App is configured via `%Livebook.Notebook.AppSettings{}` in the
+  # deployed notebook. Attributes specifying app-level behaviour are
+  # always taken from the most recently deployed notebook (e.g. access
+  # type, automatic shutdown, deployment strategy).
+
+  defstruct [:slug, :pid, :version, :notebook_name, :public?, :sessions]
+
+  @type t :: %{
+          slug: slug(),
+          pid: pid(),
+          version: pos_integer(),
+          notebook_name: String.t(),
+          public?: boolean(),
+          sessions: list(app_session())
+        }
+
+  @type slug :: String.t()
+
+  @type app_session :: %{
+          id: Livebook.Utils.id(),
+          pid: pid(),
+          version: pos_integer(),
+          created_at: DateTime.t(),
+          app_status: Livebook.Session.Data.app_status(),
+          client_count: non_neg_integer()
+        }
+
+  use GenServer, restart: :temporary
+
+  @auto_shutdown_inactivity_ms %{inactive_5s: 5_000, inactive_1m: 60_000, inactive_1h: 3600_000}
+
+  @doc """
+  Starts an apps process.
+
+  ## Options
+
+    * `:notebook` (required) - the notebook for initial deployment
+
+    * `:auto_shutdown_inactivity_ms` - mapping from
+      `t:Livebook.Notebook.AppSettings.auto_shutdown_type/0` to the
+      number of inactivity milliseconds after which automatic shutdown
+      should be triggered. This can be used in tests to artificially
+      shorten reaction time
+
+  """
+  @spec start_link(keyword()) :: {:ok, pid} | {:error, any()}
+  def start_link(opts) do
+    notebook = Keyword.fetch!(opts, :notebook)
+
+    auto_shutdown_inactivity_ms =
+      Keyword.get(opts, :auto_shutdown_inactivity_ms, @auto_shutdown_inactivity_ms)
+
+    GenServer.start_link(__MODULE__, {notebook, auto_shutdown_inactivity_ms})
+  end
+
+  @doc """
+  Gets app information.
+  """
+  @spec get_by_pid(pid()) :: t()
+  def get_by_pid(pid) do
+    GenServer.call(pid, :describe_self)
+  end
+
+  @doc """
+  Gets app settings.
+
+  Note that the settings are always taken from the most recently
+  deployed notebook.
+  """
+  @spec get_settings(pid()) :: Livebook.Notebook.AppSettings.t()
+  def get_settings(pid) do
+    GenServer.call(pid, :get_settings)
+  end
+
+  @doc """
+  Returns an app session id.
+
+  For multi-session app, this always creates a new session.
+
+  For single-session app, this returns an existing session if one
+  exists, otherwise creating a new one. If zero-downtime deployment
+  is enabled, an old session may be returned unless the new session
+  is fully executed.
+  """
+  @spec get_session_id(pid()) :: Livebook.Session.id()
+  def get_session_id(pid) do
+    GenServer.call(pid, :get_session_id)
+  end
+
+  @doc """
+  Deploys a new notebook into the app.
+  """
+  @spec deploy(pid(), Livebook.Notebook.t()) :: :ok
+  def deploy(pid, notebook) do
+    GenServer.cast(pid, {:deploy, notebook})
+  end
+
+  @doc """
+  Closes the app.
+
+  This operation results in all app sessions being closed as well.
+  """
+  def close(pid) do
+    GenServer.call(pid, :close)
+  end
+
+  @doc """
+  Subscribes to app messages.
+
+  ## Messages
+
+    * `{:app_updated, app}`
+
+  """
+  @spec subscribe(slug()) :: :ok | {:error, term()}
+  def subscribe(slug) do
+    Phoenix.PubSub.subscribe(Livebook.PubSub, "apps:#{slug}")
+  end
+
+  @doc """
+  Unsubscribes from app messages.
+  """
+  @spec unsubscribe(slug()) :: :ok | {:error, term()}
+  def unsubscribe(slug) do
+    Phoenix.PubSub.subscribe(Livebook.PubSub, "apps:#{slug}")
+  end
+
+  @impl true
+  def init({notebook, auto_shutdown_inactivity_ms}) do
+    {:ok,
+     %{
+       version: 1,
+       notebook: notebook,
+       sessions: [],
+       auto_shutdown_inactivity_ms: auto_shutdown_inactivity_ms,
+       inactivities: %{}
+     }
+     |> start_eagerly()}
+  end
+
+  @impl true
+  def handle_call(:describe_self, _from, state) do
+    {:reply, self_from_state(state), state}
+  end
+
+  def handle_call(:get_session_id, _from, state) do
+    {session_id, state} =
+      case {state.notebook.app_settings.multi_session, single_session_app_session(state)} do
+        {false, %{} = app_session} ->
+          {app_session.id, state}
+
+        _ ->
+          {:ok, app_session} = start_app_session(state)
+
+          state =
+            state
+            |> add_app_session(app_session)
+            |> notify_update()
+
+          {app_session.id, state}
+      end
+
+    {:reply, session_id, state}
+  end
+
+  def handle_call(:get_settings, _from, state) do
+    {:reply, state.notebook.app_settings, state}
+  end
+
+  def handle_call(:close, _from, state) do
+    {:stop, :shutdown, :ok, state}
+  end
+
+  @impl true
+  def handle_cast({:deploy, notebook}, state) do
+    true = notebook.app_settings.slug == state.notebook.app_settings.slug
+
+    {:noreply,
+     %{state | notebook: notebook, version: state.version + 1}
+     |> start_eagerly()
+     |> reschedule_shutdowns()
+     |> shutdown_old_versions()
+     |> notify_update()}
+  end
+
+  @impl true
+  def handle_info({:app_status_changed, session_id, status}, state) do
+    state = update_app_session(state, session_id, &%{&1 | app_status: status})
+    {:noreply, state |> shutdown_old_versions() |> notify_update()}
+  end
+
+  def handle_info({:app_client_count_changed, session_id, client_count}, state) do
+    any_clients? = client_count > 0
+
+    state =
+      if any_clients? do
+        untrack_inactivity(state, session_id)
+      else
+        track_inactivity(state, session_id)
+      end
+
+    state = update_app_session(state, session_id, &%{&1 | client_count: client_count})
+
+    {:noreply, notify_update(state)}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    app_session = Enum.find(state.sessions, &(&1.pid == pid))
+    state = update_in(state.sessions, &(&1 -- [app_session]))
+    state = untrack_inactivity(state, app_session.id)
+    {:noreply, notify_update(state)}
+  end
+
+  def handle_info({:inactive_timeout, session_id}, state) do
+    app_session = Enum.find(state.sessions, &(&1.id == session_id))
+    shutdown_session(app_session)
+    {:noreply, state}
+  end
+
+  defp self_from_state(state) do
+    %{
+      slug: state.notebook.app_settings.slug,
+      pid: self(),
+      version: state.version,
+      notebook_name: state.notebook.name,
+      public?: state.notebook.app_settings.access_type == :public,
+      sessions: state.sessions
+    }
+  end
+
+  defp single_session_app_session(state) do
+    app_session = Enum.find(state.sessions, &(&1.version == state.version))
+
+    if app_session do
+      if state.notebook.app_settings.zero_downtime and app_session.app_status != :executed do
+        Enum.find(state.sessions, &(&1.app_status == :executed))
+      end || app_session
+    end
+  end
+
+  defp start_eagerly(state) when state.notebook.app_settings.multi_session, do: state
+
+  defp start_eagerly(state) do
+    if temporary_sessions?(state.notebook.app_settings) do
+      state
+    else
+      {:ok, app_session} = start_app_session(state)
+      add_app_session(state, app_session)
+    end
+  end
+
+  defp start_app_session(state) do
+    opts = [notebook: state.notebook, mode: :app, app_pid: self()]
+
+    case Livebook.Sessions.create_session(opts) do
+      {:ok, session} ->
+        app_session = %{
+          id: session.id,
+          pid: session.pid,
+          version: state.version,
+          created_at: session.created_at,
+          app_status: :executing,
+          client_count: 0
+        }
+
+        Process.monitor(session.pid)
+
+        {:ok, app_session}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp add_app_session(state, app_session) do
+    state = update_in(state.sessions, &[app_session | &1])
+    track_inactivity(state, app_session.id)
+  end
+
+  defp update_app_session(state, session_id, fun) do
+    update_in(state.sessions, fn sessions ->
+      Enum.map(sessions, fn
+        %{id: ^session_id} = session -> fun.(session)
+        session -> session
+      end)
+    end)
+  end
+
+  defp track_inactivity(state, session_id) do
+    timer_ref =
+      if timer_ms = shutdown_after_ms(state) do
+        Process.send_after(self(), {:inactive_timeout, session_id}, timer_ms)
+      end
+
+    put_in(state.inactivities[session_id], %{since: DateTime.utc_now(), timer_ref: timer_ref})
+  end
+
+  defp untrack_inactivity(state, session_id) do
+    {inactivity, state} = pop_in(state.inactivities[session_id])
+
+    if timer_ref = inactivity[:timer_ref] do
+      Process.cancel_timer(timer_ref)
+    end
+
+    state
+  end
+
+  defp shutdown_after_ms(state) do
+    state.auto_shutdown_inactivity_ms[state.notebook.app_settings.auto_shutdown_type]
+  end
+
+  defp temporary_sessions?(app_settings) do
+    app_settings.auto_shutdown_type in [:inactive_5s, :inactive_1m, :inactive_1h]
+  end
+
+  defp reschedule_shutdowns(state) do
+    now = DateTime.utc_now()
+
+    timer_ms = shutdown_after_ms(state)
+
+    inactivities =
+      Map.new(state.inactivities, fn {session_id, inactivity} ->
+        if timer_ref = inactivity.timer_ref do
+          Process.cancel_timer(timer_ref)
+        end
+
+        timer_ref =
+          if timer_ms do
+            inactivity_ms = DateTime.diff(now, inactivity.since, :millisecond)
+            adjusted_timer_ms = max(timer_ms - inactivity_ms, 0)
+            Process.send_after(self(), {:inactive_timeout, session_id}, adjusted_timer_ms)
+          end
+
+        inactivity = put_in(inactivity.timer_ref, timer_ref)
+
+        {session_id, inactivity}
+      end)
+
+    %{state | inactivities: inactivities}
+  end
+
+  defp shutdown_old_versions(state)
+       when state.notebook.app_settings.auto_shutdown_type == :new_version do
+    single_session_app_session =
+      unless state.notebook.app_settings.multi_session do
+        single_session_app_session(state)
+      end
+
+    for app_session <- state.sessions,
+        app_session != single_session_app_session,
+        app_session.version < state.version do
+      shutdown_session(app_session)
+    end
+
+    state
+  end
+
+  defp shutdown_old_versions(state), do: state
+
+  defp shutdown_session(app_session) do
+    if Livebook.Session.Data.app_active?(app_session.app_status) do
+      Livebook.Session.app_shutdown(app_session.pid)
+    end
+  end
+
+  defp notify_update(state) do
+    app = self_from_state(state)
+    Livebook.Apps.update_app(app)
+    broadcast_message(state.notebook.app_settings.slug, {:app_updated, app})
+    state
+  end
+
+  defp broadcast_message(slug, message) do
+    Phoenix.PubSub.broadcast(Livebook.PubSub, "apps:#{slug}", message)
+  end
+end

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -28,6 +28,8 @@ defmodule Livebook.Application do
         Livebook.NotebookManager,
         # Start the tracker server on this node
         {Livebook.Tracker, pubsub_server: Livebook.PubSub},
+        # Start the supervisor dynamically managing apps
+        {DynamicSupervisor, name: Livebook.AppSupervisor, strategy: :one_for_one},
         # Start the supervisor dynamically managing sessions
         {DynamicSupervisor, name: Livebook.SessionSupervisor, strategy: :one_for_one},
         # Start the server responsible for associating files with sessions

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -86,7 +86,16 @@ defmodule Livebook.LiveMarkdown.Export do
   end
 
   defp app_settings_metadata(app_settings) do
-    keys = [:slug, :access_type, :show_source, :output_type]
+    keys = [
+      :slug,
+      :multi_session,
+      :zero_downtime,
+      :auto_session_startup,
+      :auto_shutdown_type,
+      :access_type,
+      :show_source,
+      :output_type
+    ]
 
     put_unless_default(
       %{},

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -90,8 +90,8 @@ defmodule Livebook.LiveMarkdown.Export do
       :slug,
       :multi_session,
       :zero_downtime,
-      :auto_session_startup,
-      :auto_shutdown_type,
+      :show_existing_sessions,
+      :auto_shutdown_ms,
       :access_type,
       :show_source,
       :output_type

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -410,12 +410,11 @@ defmodule Livebook.LiveMarkdown.Import do
       {"zero_downtime", zero_downtime}, attrs ->
         Map.put(attrs, :zero_downtime, zero_downtime)
 
-      {"auto_session_startup", auto_session_startup}, attrs ->
-        Map.put(attrs, :auto_session_startup, auto_session_startup)
+      {"show_existing_sessions", show_existing_sessions}, attrs ->
+        Map.put(attrs, :show_existing_sessions, show_existing_sessions)
 
-      {"auto_shutdown_type", auto_shutdown_type}, attrs
-      when auto_shutdown_type in ~w(never inactive_5s inactive_1m inactive_1h new_version) ->
-        Map.put(attrs, :auto_shutdown_type, String.to_atom(auto_shutdown_type))
+      {"auto_shutdown_ms", auto_shutdown_ms}, attrs ->
+        Map.put(attrs, :auto_shutdown_ms, auto_shutdown_ms)
 
       {"access_type", access_type}, attrs when access_type in ["public", "protected"] ->
         Map.put(attrs, :access_type, String.to_atom(access_type))

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -404,11 +404,24 @@ defmodule Livebook.LiveMarkdown.Import do
       {"slug", slug}, attrs ->
         Map.put(attrs, :slug, slug)
 
-      {"show_source", show_source}, attrs ->
-        Map.put(attrs, :show_source, show_source)
+      {"multi_session", multi_session}, attrs ->
+        Map.put(attrs, :multi_session, multi_session)
+
+      {"zero_downtime", zero_downtime}, attrs ->
+        Map.put(attrs, :zero_downtime, zero_downtime)
+
+      {"auto_session_startup", auto_session_startup}, attrs ->
+        Map.put(attrs, :auto_session_startup, auto_session_startup)
+
+      {"auto_shutdown_type", auto_shutdown_type}, attrs
+      when auto_shutdown_type in ~w(never inactive_5s inactive_1m inactive_1h new_version) ->
+        Map.put(attrs, :auto_shutdown_type, String.to_atom(auto_shutdown_type))
 
       {"access_type", access_type}, attrs when access_type in ["public", "protected"] ->
         Map.put(attrs, :access_type, String.to_atom(access_type))
+
+      {"show_source", show_source}, attrs ->
+        Map.put(attrs, :show_source, show_source)
 
       {"output_type", output_type}, attrs when output_type in ["all", "rich"] ->
         Map.put(attrs, :output_type, String.to_atom(output_type))

--- a/lib/livebook/notebook/app_settings.ex
+++ b/lib/livebook/notebook/app_settings.ex
@@ -7,17 +7,30 @@ defmodule Livebook.Notebook.AppSettings do
 
   @type t :: %__MODULE__{
           slug: String.t() | nil,
+          multi_session: boolean(),
+          zero_downtime: boolean(),
+          auto_session_startup: boolean(),
+          auto_shutdown_type: auto_shutdown_type(),
           access_type: access_type(),
           password: String.t() | nil,
           show_source: boolean(),
-          output_type: :all | :rich
+          output_type: output_type()
         }
 
+  @type auto_shutdown_type :: :never | :inactive_5s | :inactive_1m | :inactive_1h | :new_version
   @type access_type :: :public | :protected
+  @type output_type :: :all | :rich
 
   @primary_key false
   embedded_schema do
     field :slug, :string
+    field :multi_session, :boolean
+    field :zero_downtime, :boolean
+    field :auto_session_startup, :boolean
+
+    field :auto_shutdown_type, Ecto.Enum,
+      values: [:never, :inactive_5s, :inactive_1m, :inactive_1h, :new_version]
+
     field :access_type, Ecto.Enum, values: [:public, :protected]
     field :password, :string
     field :show_source, :boolean
@@ -31,6 +44,10 @@ defmodule Livebook.Notebook.AppSettings do
   def new() do
     %__MODULE__{
       slug: nil,
+      multi_session: false,
+      zero_downtime: false,
+      auto_session_startup: false,
+      auto_shutdown_type: :new_version,
       access_type: :protected,
       password: generate_password(),
       show_source: false,
@@ -61,12 +78,28 @@ defmodule Livebook.Notebook.AppSettings do
 
   defp changeset(settings, attrs) do
     settings
-    |> cast(attrs, [:slug, :access_type, :show_source, :output_type])
-    |> validate_required([:slug, :access_type, :show_source, :output_type])
+    |> cast(attrs, [
+      :slug,
+      :multi_session,
+      :auto_shutdown_type,
+      :access_type,
+      :show_source,
+      :output_type
+    ])
+    |> validate_required([
+      :slug,
+      :multi_session,
+      :auto_shutdown_type,
+      :access_type,
+      :show_source,
+      :output_type
+    ])
     |> validate_format(:slug, ~r/^[a-zA-Z0-9-]+$/,
       message: "slug can only contain alphanumeric characters and dashes"
     )
     |> cast_access_attrs(attrs)
+    |> cast_mode_specific_attrs(attrs)
+    |> put_defaults()
   end
 
   defp cast_access_attrs(changeset, attrs) do
@@ -79,6 +112,43 @@ defmodule Livebook.Notebook.AppSettings do
 
       _other ->
         changeset
+    end
+  end
+
+  defp cast_mode_specific_attrs(changeset, attrs) do
+    case get_field(changeset, :multi_session) do
+      false ->
+        changeset
+        |> cast(attrs, [:zero_downtime])
+        |> validate_required([:zero_downtime])
+        # Automatic startup is not applicable to single-session apps,
+        # since they have a single session and it is always started
+        # automatically
+        |> put_change(:auto_session_startup, false)
+
+      true ->
+        changeset
+        |> cast(attrs, [:auto_session_startup])
+        |> validate_required([:auto_session_startup])
+        # Zero-downtime deployment is not applicable to multi-session
+        # apps, since they are inherently zero-downtime. We reset to
+        # the default, so we do not persist it unnecessarily
+        |> put_change(:zero_downtime, false)
+    end
+  end
+
+  defp put_defaults(changeset) do
+    case get_change(changeset, :multi_session) do
+      nil ->
+        changeset
+
+      false ->
+        changeset
+        |> put_change(:auto_shutdown_type, :new_version)
+
+      true ->
+        changeset
+        |> put_change(:auto_shutdown_type, :inactive_5s)
     end
   end
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -806,12 +806,12 @@ defmodule Livebook.Session do
   defp schedule_auto_shutdown(state) do
     client_count = map_size(state.data.clients_map)
 
-    case {client_count, state.auto_shutdown_timer_ref, state.auto_shutdown_ms} do
-      {0, nil, auto_shutdown_ms} when auto_shutdown_ms != nil ->
-        timer_ref = Process.send_after(self(), :close, auto_shutdown_ms)
+    case {client_count, state.auto_shutdown_timer_ref} do
+      {0, nil} when state.auto_shutdown_ms != nil ->
+        timer_ref = Process.send_after(self(), :close, state.auto_shutdown_ms)
         %{state | auto_shutdown_timer_ref: timer_ref}
 
-      {client_count, timer_ref, _} when client_count > 0 and timer_ref != nil ->
+      {client_count, timer_ref} when client_count > 0 and timer_ref != nil ->
         if Process.cancel_timer(timer_ref) == false do
           receive do
             :close -> :ok

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -55,8 +55,7 @@ defmodule Livebook.Session do
     :mode,
     :images_dir,
     :created_at,
-    :memory_usage,
-    :app_info
+    :memory_usage
   ]
 
   use GenServer, restart: :temporary
@@ -83,8 +82,7 @@ defmodule Livebook.Session do
           mode: Data.session_mode(),
           images_dir: FileSystem.File.t(),
           created_at: DateTime.t(),
-          memory_usage: memory_usage(),
-          app_info: app_info() | nil
+          memory_usage: memory_usage()
         }
 
   @type state :: %{
@@ -111,13 +109,6 @@ defmodule Livebook.Session do
             runtime: Livebook.Runtime.runtime_memory() | nil,
             system: Livebook.SystemResources.memory()
           }
-
-  @type app_info :: %{
-          slug: String.t(),
-          status: Data.app_status(),
-          registered: boolean(),
-          public?: boolean()
-        }
 
   @typedoc """
   An id assigned to every running session process.
@@ -154,6 +145,8 @@ defmodule Livebook.Session do
 
     * `:mode` - the mode in which the session operates, either `:default`
       or `:app`. Defaults to `:default`
+
+    * `:app_pid` - the parent app process, when in running in `:app` mode
 
   """
   @spec start_link(keyword()) :: {:ok, pid} | {:error, any()}
@@ -203,14 +196,6 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Returns the current app settings.
-  """
-  @spec get_app_settings(pid()) :: Notebook.AppSettings.t()
-  def get_app_settings(pid) do
-    GenServer.call(pid, :get_app_settings, @timeout)
-  end
-
-  @doc """
   Subscribes to session messages.
 
   ## Messages
@@ -225,21 +210,6 @@ defmodule Livebook.Session do
   @spec subscribe(id()) :: :ok | {:error, term()}
   def subscribe(session_id) do
     Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session_id}")
-  end
-
-  @doc """
-  Subscribes to app session messages.
-
-  ## Messages
-
-    * `{:app_status_changed, session_id, status}`
-    * `{:app_registration_changed, session_id, registered}`
-    * `{:app_terminated, session_id}`
-
-  """
-  @spec app_subscribe(id()) :: :ok | {:error, term()}
-  def app_subscribe(session_id) do
-    Phoenix.PubSub.subscribe(Livebook.PubSub, "apps:#{session_id}")
   end
 
   @doc """
@@ -567,7 +537,7 @@ defmodule Livebook.Session do
   @doc """
   Sends a secret addition request to the server.
   """
-  @spec set_secret(pid(), map()) :: :ok
+  @spec set_secret(pid(), Livebook.Secrets.Secret.t()) :: :ok
   def set_secret(pid, secret) do
     GenServer.cast(pid, {:set_secret, self(), secret})
   end
@@ -575,7 +545,7 @@ defmodule Livebook.Session do
   @doc """
   Sends a secret deletion request to the server.
   """
-  @spec unset_secret(pid(), map()) :: :ok
+  @spec unset_secret(pid(), String.t()) :: :ok
   def unset_secret(pid, secret_name) do
     GenServer.cast(pid, {:unset_secret, self(), secret_name})
   end
@@ -687,33 +657,27 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Sends a app build request to the server.
+  Sends an app deactivation request to the server.
+
+  When an app is deactivated, the session is still running, but the
+  app is no longer accessible (and connected clients should be
+  redirected).
   """
-  @spec app_build(pid()) :: :ok
-  def app_build(pid) do
-    GenServer.cast(pid, {:app_build, self()})
+  @spec app_deactivate(pid()) :: :ok
+  def app_deactivate(pid) do
+    GenServer.cast(pid, {:app_deactivate, self()})
   end
 
   @doc """
-  Sends a app shutdown request to the server.
+  Sends an app shutdown request to the server.
 
-  The shutdown is graceful, so the app only terminates once all of the
-  currently connected clients leave.
+  The shutdown is graceful, the app is no longer accessible, but
+  connected clients should not be impacted. Once all clients
+  disconnects the session is automatically closed.
   """
-  @spec app_unregistered(pid()) :: :ok
-  def app_unregistered(pid) do
-    GenServer.cast(pid, {:app_unregistered, self()})
-  end
-
-  @doc """
-  Sends a app stop request to the server.
-
-  This results in the app being unregistered under the given slug,
-  however it is still running.
-  """
-  @spec app_stop(pid()) :: :ok
-  def app_stop(pid) do
-    GenServer.cast(pid, {:app_stop, self()})
+  @spec app_shutdown(pid()) :: :ok
+  def app_shutdown(pid) do
+    GenServer.cast(pid, {:app_shutdown, self()})
   end
 
   ## Callbacks
@@ -743,7 +707,15 @@ defmodule Livebook.Session do
         Livebook.NotebookManager.add_recent_notebook(file, state.data.notebook.name)
       end
 
-      {:ok, state}
+      if app_pid = state.app_pid do
+        Process.monitor(app_pid)
+      end
+
+      if state.data.mode == :app do
+        {:ok, state, {:continue, :app_init}}
+      else
+        {:ok, state}
+      end
     else
       {:error, error} ->
         {:stop, error}
@@ -766,7 +738,9 @@ defmodule Livebook.Session do
         worker_pid: worker_pid,
         registered_file_deletion_delay: opts[:registered_file_deletion_delay] || 15_000,
         registered_files: %{},
-        client_id_with_assets: %{}
+        client_id_with_assets: %{},
+        deployed_app_monitor_ref: nil,
+        app_pid: opts[:app_pid]
       }
 
       {:ok, state}
@@ -824,6 +798,13 @@ defmodule Livebook.Session do
   end
 
   @impl true
+  def handle_continue(:app_init, state) do
+    cell_ids = Data.cell_ids_for_full_evaluation(state.data, [])
+    operation = {:queue_cells_evaluation, @client_id, cell_ids}
+    {:noreply, handle_operation(state, operation)}
+  end
+
+  @impl true
   def handle_call(:describe_self, _from, state) do
     {:reply, self_from_state(state), state}
   end
@@ -872,10 +853,6 @@ defmodule Livebook.Session do
 
   def handle_call(:get_notebook, _from, state) do
     {:reply, state.data.notebook, state}
-  end
-
-  def handle_call(:get_app_settings, _from, state) do
-    {:reply, state.data.notebook.app_settings, state}
   end
 
   def handle_call(:save_sync, _from, state) do
@@ -1217,45 +1194,30 @@ defmodule Livebook.Session do
   def handle_cast({:deploy_app, _client_pid}, state) do
     # In the initial state app settings are empty, hence not valid,
     # so we double-check that we can actually deploy
-    state =
-      if Notebook.AppSettings.valid?(state.data.notebook.app_settings) do
-        opts = [notebook: state.data.notebook, mode: :app]
+    if Notebook.AppSettings.valid?(state.data.notebook.app_settings) do
+      {:ok, pid} = Livebook.Apps.deploy(state.data.notebook)
 
-        case Livebook.Sessions.create_session(opts) do
-          {:ok, session} ->
-            app_subscribe(session.id)
-            app_build(session.pid)
-            operation = {:add_app, @client_id, session.id, session.pid}
-            handle_operation(state, operation)
-
-          {:error, reason} ->
-            broadcast_error(
-              state.session_id,
-              "failed to create app session - #{Exception.format_exit(reason)}"
-            )
-
-            state
-        end
-      else
-        state
+      if ref = state.deployed_app_monitor_ref do
+        Process.demonitor(ref, [:flush])
       end
 
-    {:noreply, state}
+      ref = Process.monitor(pid)
+      state = put_in(state.deployed_app_monitor_ref, ref)
+
+      operation = {:set_deployed_app_slug, @client_id, state.data.notebook.app_settings.slug}
+      {:noreply, handle_operation(state, operation)}
+    else
+      {:noreply, state}
+    end
   end
 
-  def handle_cast({:app_build, _client_pid}, state) do
-    cell_ids = Data.cell_ids_for_full_evaluation(state.data, [])
-    operation = {:queue_cells_evaluation, @client_id, cell_ids}
+  def handle_cast({:app_deactivate, _client_pid}, state) do
+    operation = {:app_deactivate, @client_id}
     {:noreply, handle_operation(state, operation)}
   end
 
-  def handle_cast({:app_unregistered, _client_pid}, state) do
-    operation = {:app_unregistered, @client_id}
-    {:noreply, handle_operation(state, operation)}
-  end
-
-  def handle_cast({:app_stop, _client_pid}, state) do
-    operation = {:app_stop, @client_id}
+  def handle_cast({:app_shutdown, _client_pid}, state) do
+    operation = {:app_shutdown, @client_id}
     {:noreply, handle_operation(state, operation)}
   end
 
@@ -1266,7 +1228,8 @@ defmodule Livebook.Session do
   end
 
   @impl true
-  def handle_info({:DOWN, ref, :process, _, reason}, %{runtime_monitor_ref: ref} = state) do
+  def handle_info({:DOWN, ref, :process, _, reason}, state)
+      when ref == state.runtime_monitor_ref do
     broadcast_error(
       state.session_id,
       "runtime node terminated unexpectedly - #{Exception.format_exit(reason)}"
@@ -1277,6 +1240,19 @@ defmodule Livebook.Session do
      |> handle_operation(
        {:set_runtime, @client_id, Livebook.Runtime.duplicate(state.data.runtime)}
      )}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, _}, state)
+      when ref == state.deployed_app_monitor_ref do
+    {:noreply,
+     %{state | deployed_app_monitor_ref: nil}
+     |> handle_operation({:set_deployed_app_slug, @client_id, nil})}
+  end
+
+  def handle_info({:DOWN, _, :process, pid, _}, state)
+      when state.data.mode == :app and pid == state.app_pid do
+    send(self(), :close)
+    {:noreply, state}
   end
 
   def handle_info({:DOWN, _, :process, pid, _}, state) do
@@ -1518,21 +1494,6 @@ defmodule Livebook.Session do
     {:noreply, state}
   end
 
-  def handle_info({:app_status_changed, session_id, status}, state) do
-    operation = {:set_app_status, @client_id, session_id, status}
-    {:noreply, handle_operation(state, operation)}
-  end
-
-  def handle_info({:app_registration_changed, session_id, registered}, state) do
-    operation = {:set_app_registered, @client_id, session_id, registered}
-    {:noreply, handle_operation(state, operation)}
-  end
-
-  def handle_info({:app_terminated, session_id}, state) do
-    operation = {:delete_app, @client_id, session_id}
-    {:noreply, handle_operation(state, operation)}
-  end
-
   def handle_info(:close, state) do
     before_close(state)
     {:stop, :shutdown, state}
@@ -1569,16 +1530,7 @@ defmodule Livebook.Session do
       mode: state.data.mode,
       images_dir: images_dir_from_state(state),
       created_at: state.created_at,
-      memory_usage: state.memory_usage,
-      app_info:
-        if state.data.mode == :app do
-          %{
-            slug: state.data.notebook.app_settings.slug,
-            status: state.data.app_data.status,
-            registered: state.data.app_data.registered,
-            public?: state.data.notebook.app_settings.access_type == :public
-          }
-        end
+      memory_usage: state.memory_usage
     }
   end
 
@@ -1819,6 +1771,8 @@ defmodule Livebook.Session do
 
     state = put_in(state.client_id_with_assets[client_id], %{})
 
+    app_report_client_count_change(state)
+
     state
   end
 
@@ -1831,6 +1785,8 @@ defmodule Livebook.Session do
 
     state = delete_client_files(state, client_id)
     {_, state} = pop_in(state.client_id_with_assets[client_id])
+
+    app_report_client_count_change(state)
 
     state
   end
@@ -1898,12 +1854,6 @@ defmodule Livebook.Session do
   defp after_operation(state, _prev_state, {:unset_secret, _client_id, secret_name}) do
     if Runtime.connected?(state.data.runtime), do: delete_runtime_secrets(state, [secret_name])
     state
-  end
-
-  defp after_operation(state, _prev_state, {:app_unregistered, _client_id}) do
-    broadcast_app_message(state.session_id, {:app_registration_changed, state.session_id, false})
-
-    notify_update(state)
   end
 
   defp after_operation(state, _prev_state, {:set_notebook_hub, _client_id, _id}) do
@@ -2008,23 +1958,9 @@ defmodule Livebook.Session do
     state
   end
 
-  defp handle_action(state, :app_broadcast_status) do
+  defp handle_action(state, :app_report_status) do
     status = state.data.app_data.status
-    broadcast_app_message(state.session_id, {:app_status_changed, state.session_id, status})
-
-    notify_update(state)
-  end
-
-  defp handle_action(state, :app_register) do
-    Livebook.Apps.register(self(), state.data.notebook.app_settings.slug)
-    broadcast_app_message(state.session_id, {:app_registration_changed, state.session_id, true})
-
-    notify_update(state)
-  end
-
-  defp handle_action(state, :app_unregister) do
-    Livebook.Apps.unregister(self(), state.data.notebook.app_settings.slug)
-    broadcast_app_message(state.session_id, {:app_registration_changed, state.session_id, false})
+    send(state.app_pid, {:app_status_changed, state.session_id, status})
 
     notify_update(state)
   end
@@ -2093,10 +2029,6 @@ defmodule Livebook.Session do
 
   defp broadcast_message(session_id, message) do
     Phoenix.PubSub.broadcast(Livebook.PubSub, "sessions:#{session_id}", message)
-  end
-
-  defp broadcast_app_message(session_id, message) do
-    Phoenix.PubSub.broadcast(Livebook.PubSub, "apps:#{session_id}", message)
   end
 
   defp put_memory_usage(state, runtime) do
@@ -2284,11 +2216,14 @@ defmodule Livebook.Session do
   defp before_close(state) do
     maybe_save_notebook_sync(state)
     broadcast_message(state.session_id, :session_closed)
-
-    if state.data.mode == :app do
-      broadcast_app_message(state.session_id, {:app_terminated, state.session_id})
-    end
   end
+
+  defp app_report_client_count_change(state) when state.data.mode == :app do
+    client_count = map_size(state.data.clients_map)
+    send(state.app_pid, {:app_client_count_changed, state.session_id, client_count})
+  end
+
+  defp app_report_client_count_change(state), do: state
 
   @doc """
   Subscribes the caller to runtime messages under the given topic.

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -34,7 +34,7 @@ defmodule Livebook.Session.Data do
     :secrets,
     :hub_secrets,
     :mode,
-    :apps,
+    :deployed_app_slug,
     :app_data
   ]
 
@@ -60,7 +60,7 @@ defmodule Livebook.Session.Data do
           secrets: secrets(),
           hub_secrets: list(Secret.t()),
           mode: session_mode(),
-          apps: list(app()),
+          deployed_app_slug: String.t() | nil,
           app_data: nil | app_data()
         }
 
@@ -149,19 +149,13 @@ defmodule Livebook.Session.Data do
 
   @type session_mode :: :default | :app
 
-  @type app :: %{
-          session_id: Livebook.Session.id(),
-          session_pid: pid(),
-          settings: Livebook.Notebook.AppSettings.t(),
-          status: app_status(),
-          registered: boolean()
-        }
-
-  @type app_status :: :booting | :running | :error | :shutting_down | :stopped
+  # Note that technically the first state is :initial, but we always
+  # expect app to start evaluating right away, so distinguishing that
+  # state from :executing would not bring any value
+  @type app_status :: :executing | :executed | :error | :shutting_down | :deactivated
 
   @type app_data :: %{
-          status: app_status(),
-          registered: boolean()
+          status: app_status()
         }
 
   # Note that all operations carry the id of whichever client
@@ -218,12 +212,9 @@ defmodule Livebook.Session.Data do
           | {:set_notebook_hub, client_id(), String.t()}
           | {:sync_hub_secrets, client_id()}
           | {:set_app_settings, client_id(), AppSettings.t()}
-          | {:add_app, client_id(), Livebook.Session.id(), pid()}
-          | {:set_app_status, client_id(), Livebook.Session.id(), app_status()}
-          | {:set_app_registered, client_id(), Livebook.Session.id(), boolean()}
-          | {:delete_app, client_id(), Livebook.Session.id()}
-          | {:app_unregistered, client_id()}
-          | {:app_stop, client_id()}
+          | {:set_deployed_app_slug, client_id(), String.t()}
+          | {:app_deactivate, client_id()}
+          | {:app_shutdown, client_id()}
 
   @type action ::
           :connect_runtime
@@ -233,10 +224,9 @@ defmodule Livebook.Session.Data do
           | {:start_smart_cell, Cell.t(), Section.t()}
           | {:set_smart_cell_parents, Cell.t(), Section.t(),
              parent :: {Cell.t(), Section.t()} | nil}
-          | {:broadcast_delta, client_id(), Cell.t(), cell_source_tag(), Delta.t()}
+          | {:report_delta, client_id(), Cell.t(), cell_source_tag(), Delta.t()}
           | {:clean_up_input_values, %{input_id() => term()}}
-          | :app_broadcast_status
-          | :app_register
+          | :app_report_status
           | :app_recover
           | :app_terminate
 
@@ -260,7 +250,7 @@ defmodule Livebook.Session.Data do
 
     app_data =
       if opts[:mode] == :app do
-        %{status: :booting, registered: false}
+        %{status: :executing}
       end
 
     hub = Hubs.fetch_hub!(notebook.hub_id)
@@ -293,7 +283,7 @@ defmodule Livebook.Session.Data do
       secrets: secrets,
       hub_secrets: hub_secrets,
       mode: opts[:mode],
-      apps: [],
+      deployed_app_slug: nil,
       app_data: app_data
     }
 
@@ -893,64 +883,30 @@ defmodule Livebook.Session.Data do
     |> wrap_ok()
   end
 
-  def apply_operation(data, {:add_app, _client_id, session_id, session_pid}) do
+  def apply_operation(data, {:set_deployed_app_slug, _client_id, slug}) do
     data
     |> with_actions()
-    |> add_app(session_id, session_pid)
+    |> set_deployed_app_slug(slug)
     |> wrap_ok()
   end
 
-  def apply_operation(data, {:set_app_status, _client_id, session_id, status}) do
-    with {:ok, app} <- fetch_app_by_session_id(data, session_id) do
-      data
-      |> with_actions()
-      |> set_app_status(app, status)
-      |> wrap_ok()
-    else
-      _ -> :error
-    end
-  end
-
-  def apply_operation(data, {:set_app_registered, _client_id, session_id, registered}) do
-    with {:ok, app} <- fetch_app_by_session_id(data, session_id) do
-      data
-      |> with_actions()
-      |> set_app_registered(app, registered)
-      |> wrap_ok()
-    else
-      _ -> :error
-    end
-  end
-
-  def apply_operation(data, {:delete_app, _client_id, session_id}) do
-    with {:ok, app} <- fetch_app_by_session_id(data, session_id) do
-      data
-      |> with_actions()
-      |> delete_app(app)
-      |> wrap_ok()
-    else
-      _ -> :error
-    end
-  end
-
-  def apply_operation(data, {:app_unregistered, _client_id}) do
-    with :app <- data.mode,
-         true <- data.app_data.registered do
-      data
-      |> with_actions()
-      |> app_unregistered()
-      |> app_maybe_terminate()
-      |> wrap_ok()
-    else
-      _ -> :error
-    end
-  end
-
-  def apply_operation(data, {:app_stop, _client_id}) do
+  def apply_operation(data, {:app_deactivate, _client_id}) do
     with :app <- data.mode do
       data
       |> with_actions()
-      |> app_stop()
+      |> app_deactivate()
+      |> wrap_ok()
+    else
+      _ -> :error
+    end
+  end
+
+  def apply_operation(data, {:app_shutdown, _client_id}) do
+    with :app <- data.mode do
+      data
+      |> with_actions()
+      |> app_shutdown()
+      |> app_maybe_terminate()
       |> wrap_ok()
     else
       _ -> :error
@@ -1591,7 +1547,7 @@ defmodule Livebook.Session.Data do
       info = put_in(info.sources.primary, source_info)
       put_in(info.sources.secondary, new_source_info(editor && editor.source, data.clients_map))
     end)
-    |> add_action({:broadcast_delta, client_id, updated_cell, :primary, delta})
+    |> add_action({:report_delta, client_id, updated_cell, :primary, delta})
   end
 
   defp update_smart_cell({data, _} = data_actions, cell, client_id, attrs, delta, chunks) do
@@ -1610,7 +1566,7 @@ defmodule Livebook.Session.Data do
     |> update_cell_info!(cell.id, fn info ->
       put_in(info.sources.primary, source_info)
     end)
-    |> add_action({:broadcast_delta, client_id, updated_cell, :primary, delta})
+    |> add_action({:report_delta, client_id, updated_cell, :primary, delta})
   end
 
   defp smart_cell_down(data_actions, cell) do
@@ -1760,7 +1716,7 @@ defmodule Livebook.Session.Data do
     data_actions
     |> set!(notebook: Notebook.update_cell(data.notebook, cell.id, fn _ -> updated_cell end))
     |> update_cell_info!(cell.id, &put_in(&1.sources[tag], source_info))
-    |> add_action({:broadcast_delta, client_id, updated_cell, tag, transformed_new_delta})
+    |> add_action({:report_delta, client_id, updated_cell, tag, transformed_new_delta})
   end
 
   # Note: the clients drop cell's source once it's no longer needed
@@ -1834,50 +1790,20 @@ defmodule Livebook.Session.Data do
     set!(data_actions, notebook: %{data.notebook | app_settings: settings})
   end
 
-  defp add_app({data, _} = data_actions, session_id, session_pid) do
-    app = %{
-      session_id: session_id,
-      session_pid: session_pid,
-      settings: data.notebook.app_settings,
-      status: :booting,
-      registered: false
-    }
-
-    set!(data_actions, apps: [app | data.apps])
+  defp set_deployed_app_slug(data_actions, slug) do
+    set!(data_actions, deployed_app_slug: slug)
   end
 
-  defp set_app_status(data_actions, app, status) do
-    update_app!(data_actions, app.session_id, &%{&1 | status: status})
-  end
-
-  defp set_app_registered(data_actions, app, registered) do
-    update_app!(data_actions, app.session_id, &%{&1 | registered: registered})
-  end
-
-  defp delete_app({data, _} = data_actions, app) do
-    apps = Enum.reject(data.apps, &(&1.session_id == app.session_id))
-    set!(data_actions, apps: apps)
-  end
-
-  defp app_unregistered(data_actions) do
+  defp app_deactivate(data_actions) do
     data_actions
-    |> set_app_data!(status: :shutting_down, registered: false)
-    |> add_action(:app_broadcast_status)
+    |> set_app_data!(status: :deactivated)
+    |> add_action(:app_report_status)
   end
 
-  defp app_stop({data, _} = data_actions) do
-    data_actions =
-      data_actions
-      |> set_app_data!(status: :stopped)
-      |> add_action(:app_broadcast_status)
-
-    if data.app_data.registered do
-      data_actions
-      |> set_app_data!(registered: false)
-      |> add_action(:app_unregister)
-    else
-      data_actions
-    end
+  defp app_shutdown(data_actions) do
+    data_actions
+    |> set_app_data!(status: :shutting_down)
+    |> add_action(:app_report_status)
   end
 
   defp app_maybe_terminate({data, _} = data_actions) do
@@ -1885,14 +1811,6 @@ defmodule Livebook.Session.Data do
       add_action(data_actions, :app_terminate)
     else
       data_actions
-    end
-  end
-
-  defp fetch_app_by_session_id(data, session_id) do
-    if app = Enum.find(data.apps, &(&1.session_id == session_id)) do
-      {:ok, app}
-    else
-      :error
     end
   end
 
@@ -2150,16 +2068,6 @@ defmodule Livebook.Session.Data do
 
   defp valid_attrs_for?(struct, attrs) do
     Enum.all?(attrs, fn {key, _} -> Map.has_key?(struct, key) end)
-  end
-
-  defp update_app!({data, _} = data_actions, session_id, fun) do
-    apps =
-      Enum.map(data.apps, fn
-        %{session_id: ^session_id} = app -> fun.(app)
-        app -> app
-      end)
-
-    set!(data_actions, apps: apps)
   end
 
   defp set_app_data!({data, _} = data_actions, changes) do
@@ -2435,19 +2343,19 @@ defmodule Livebook.Session.Data do
        do: data_actions
 
   defp app_compute_status({data, _} = data_actions)
-       when data.app_data.status in [:shutting_down, :stopped],
+       when data.app_data.status in [:shutting_down, :deactivated],
        do: data_actions
 
   defp app_compute_status({data, _} = data_actions) do
     status =
       data.notebook
       |> Notebook.evaluable_cells_with_section()
-      |> Enum.find_value(:running, fn {cell, _section} ->
+      |> Enum.find_value(:executed, fn {cell, _section} ->
         case data.cell_infos[cell.id].eval do
           %{validity: :aborted} -> :error
           %{errored: true} -> :error
-          %{validity: :fresh} -> :booting
-          %{status: :evaluating} -> :booting
+          %{validity: :fresh} -> :executing
+          %{status: :evaluating} -> :executing
           _ -> nil
         end
       end)
@@ -2456,20 +2364,11 @@ defmodule Livebook.Session.Data do
       if data.app_data.status == status do
         data_actions
       else
-        add_action(data_actions, :app_broadcast_status)
+        add_action(data_actions, :app_report_status)
       end
 
     data_actions =
-      if not data.app_data.registered and status == :running do
-        data_actions
-        |> set_app_data!(registered: true)
-        |> add_action(:app_register)
-      else
-        data_actions
-      end
-
-    data_actions =
-      if data.app_data.status == :running and status == :error do
+      if data.app_data.status == :executed and status == :error do
         add_action(data_actions, :app_recover)
       else
         data_actions
@@ -2653,5 +2552,13 @@ defmodule Livebook.Session.Data do
     else
       secret.value
     end
+  end
+
+  @doc """
+  Checks if the app should be accessible and accepts new clients.
+  """
+  @spec app_active?(app_status()) :: boolean()
+  def app_active?(app_status) do
+    app_status not in [:deactivated, :shutting_down]
   end
 end

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -228,7 +228,6 @@ defmodule LivebookWeb.FormComponents do
   attr :errors, :list, default: []
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form"
 
-  attr :disabled, :boolean, default: false
   attr :checked_value, :string, default: "true"
   attr :unchecked_value, :string, default: "false"
 
@@ -243,7 +242,7 @@ defmodule LivebookWeb.FormComponents do
         <input type="hidden" value={@unchecked_value} name={@name} />
         <input
           type="checkbox"
-          class="checkbox"
+          class="checkbox shrink-0"
           value={@checked_value}
           name={@name}
           id={@id || @name}
@@ -282,6 +281,55 @@ defmodule LivebookWeb.FormComponents do
           <input
             type="radio"
             class="radio"
+            name={@name}
+            value={value}
+            checked={to_string(@value) == value}
+            {@rest}
+          />
+          <span><%= description %></span>
+        </label>
+      </div>
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders radio inputs presented with label and error messages presented
+  as button group.
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :errors, :list, default: []
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form"
+
+  attr :options, :list, default: [], doc: "a list of `{value, description}` tuples"
+  attr :full_width, :boolean, default: false
+
+  attr :rest, :global
+
+  def radio_button_group_field(assigns) do
+    assigns = assigns_from_field(assigns)
+
+    ~H"""
+    <div phx-feedback-for={@name} class={[@errors != [] && "show-errors"]}>
+      <.label :if={@label} for={@id}><%= @label %></.label>
+      <div class="flex">
+        <label
+          :for={{value, description} <- @options}
+          class={[
+            @full_width && "flex-grow text-center",
+            "px-3 py-2 first:rounded-l-lg last:rounded-r-lg font-medium text-sm whitespace-nowrap cursor-pointer",
+            "border border-r-0 last:border-r border-gray-500 text-gray-500 hover:bg-gray-100 focus:bg-gray-100",
+            to_string(@value) == value &&
+              "bg-gray-500 text-gray-50 hover:bg-gray-500 focus:bg-gray-500"
+          ]}
+        >
+          <input
+            type="radio"
+            class="hidden"
             name={@name}
             value={value}
             checked={to_string(@value) == value}

--- a/lib/livebook_web/controllers/auth_controller.ex
+++ b/lib/livebook_web/controllers/auth_controller.ex
@@ -76,7 +76,7 @@ defmodule LivebookWeb.AuthController do
   end
 
   defp any_public_app?() do
-    Livebook.Sessions.list_sessions()
-    |> Enum.any?(&(&1.mode == :app and &1.app_info.public?))
+    Livebook.Apps.list_apps()
+    |> Enum.any?(& &1.public?)
   end
 end

--- a/lib/livebook_web/helpers.ex
+++ b/lib/livebook_web/helpers.ex
@@ -74,4 +74,12 @@ defmodule LivebookWeb.Helpers do
   @spec pluralize(non_neg_integer(), String.t(), String.t()) :: String.t()
   def pluralize(1, singular, _plural), do: "1 #{singular}"
   def pluralize(count, _singular, plural), do: "#{count} #{plural}"
+
+  @doc """
+  Formats the given UTC datetime relatively to present.
+  """
+  @spec format_datetime_relatively(DateTime.t()) :: String.t()
+  def format_datetime_relatively(date) do
+    date |> DateTime.to_naive() |> Livebook.Utils.Time.time_ago_in_words()
+  end
 end

--- a/lib/livebook_web/live/app_helpers.ex
+++ b/lib/livebook_web/live/app_helpers.ex
@@ -2,20 +2,31 @@ defmodule LivebookWeb.AppHelpers do
   use LivebookWeb, :html
 
   @doc """
+  Renders page placeholder on unauthenticated dead render.
+  """
+  def auth_placeholder(assigns) do
+    ~H"""
+    <div class="flex justify-center items-center h-screen w-screen">
+      <img src={~p"/images/logo.png"} height="128" width="128" alt="livebook" class="animate-pulse" />
+    </div>
+    """
+  end
+
+  @doc """
   Renders app status with indicator.
   """
   attr :status, :atom, required: true
   attr :show_label, :boolean, default: true
 
-  def app_status(%{status: :booting} = assigns) do
+  def app_status(%{status: :executing} = assigns) do
     ~H"""
-    <.app_status_indicator text={@show_label && "Booting"} variant={:progressing} />
+    <.app_status_indicator text={@show_label && "Executing"} variant={:progressing} />
     """
   end
 
-  def app_status(%{status: :running} = assigns) do
+  def app_status(%{status: :executed} = assigns) do
     ~H"""
-    <.app_status_indicator text={@show_label && "Running"} variant={:success} />
+    <.app_status_indicator text={@show_label && "Executed"} variant={:success} />
     """
   end
 
@@ -31,9 +42,9 @@ defmodule LivebookWeb.AppHelpers do
     """
   end
 
-  def app_status(%{status: :stopped} = assigns) do
+  def app_status(%{status: :deactivated} = assigns) do
     ~H"""
-    <.app_status_indicator text={@show_label && "Stopped"} variant={:inactive} />
+    <.app_status_indicator text={@show_label && "Deactivated"} variant={:inactive} />
     """
   end
 
@@ -44,5 +55,22 @@ defmodule LivebookWeb.AppHelpers do
       <.status_indicator variant={@variant} />
     </span>
     """
+  end
+
+  @doc """
+  Shows a confirmation modal and closes the app on confirm.
+  """
+  def confirm_app_termination(socket, app_pid) do
+    on_confirm = fn socket ->
+      Livebook.App.close(app_pid)
+      socket
+    end
+
+    confirm(socket, on_confirm,
+      title: "Terminate app",
+      description: "All app sessions will be immediately terminated.",
+      confirm_text: "Terminate",
+      confirm_icon: "delete-bin-6-line"
+    )
   end
 end

--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -5,8 +5,7 @@ defmodule LivebookWeb.AppLive do
 
   @impl true
   def mount(%{"slug" => slug}, _session, socket) when socket.assigns.app_authenticated? do
-    if socket.assigns.app_settings.multi_session and
-         not socket.assigns.app_settings.auto_session_startup do
+    if socket.assigns.app_settings.multi_session do
       {:ok, app} = Livebook.Apps.fetch_app(slug)
 
       if connected?(socket) do
@@ -56,7 +55,11 @@ defmodule LivebookWeb.AppLive do
           App sessions
         </h3>
         <p class="text-gray-700">
-          This is a multi-session app, pick an existing session or create a new one.
+          <%= if @app_settings.show_existing_sessions do %>
+            This is a multi-session app, pick an existing session or create a new one.
+          <% else %>
+            This is a multi-session app, create a new one to get started.
+          <% end %>
         </p>
         <div class="flex justify-end">
           <button class="button-base button-outlined-blue" phx-click="new_session">
@@ -64,7 +67,7 @@ defmodule LivebookWeb.AppLive do
             <span>New session</span>
           </button>
         </div>
-        <div class="w-full flex flex-col space-y-4">
+        <div :if={@app_settings.show_existing_sessions} class="w-full flex flex-col space-y-4">
           <.link
             :for={app_session <- active_sessions(@app.sessions)}
             navigate={~p"/apps/#{@app.slug}/#{app_session.id}"}

--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -1,39 +1,24 @@
 defmodule LivebookWeb.AppLive do
   use LivebookWeb, :live_view
 
-  alias Livebook.Session
-  alias Livebook.Notebook
-  alias Livebook.Notebook.Cell
+  import LivebookWeb.AppHelpers
 
   @impl true
   def mount(%{"slug" => slug}, _session, socket) when socket.assigns.app_authenticated? do
-    {:ok, %{pid: session_pid, id: session_id}} = Livebook.Apps.fetch_session_by_slug(slug)
+    if socket.assigns.app_settings.multi_session and
+         not socket.assigns.app_settings.auto_session_startup do
+      {:ok, app} = Livebook.Apps.fetch_app(slug)
 
-    {data, client_id} =
       if connected?(socket) do
-        {data, client_id} =
-          Session.register_client(session_pid, self(), socket.assigns.current_user)
-
-        Session.subscribe(session_id)
-
-        {data, client_id}
-      else
-        data = Session.get_data(session_pid)
-        {data, nil}
+        Livebook.App.subscribe(slug)
       end
 
-    session = Session.get_by_pid(session_pid)
-
-    {:ok,
-     socket
-     |> assign(
-       slug: slug,
-       session: session,
-       page_title: get_page_title(data.notebook.name),
-       client_id: client_id,
-       data_view: data_to_view(data)
-     )
-     |> assign_private(data: data)}
+      {:ok, assign(socket, app: app)}
+    else
+      {:ok, pid} = Livebook.Apps.fetch_pid(slug)
+      session_id = Livebook.App.get_session_id(pid)
+      {:ok, push_navigate(socket, to: ~p"/apps/#{slug}/#{session_id}")}
+    end
   end
 
   def mount(%{"slug" => slug}, _session, socket) do
@@ -44,237 +29,76 @@ defmodule LivebookWeb.AppLive do
     end
   end
 
-  # Puts the given assigns in `socket.private`,
-  # to ensure they are not used for rendering.
-  defp assign_private(socket, assigns) do
-    Enum.reduce(assigns, socket, fn {key, value}, socket ->
-      put_in(socket.private[key], value)
-    end)
-  end
-
   @impl true
   def render(assigns) when assigns.app_authenticated? do
     ~H"""
-    <div class="h-full relative overflow-y-auto px-4 md:px-20" data-el-notebook>
-      <div class="w-full max-w-screen-lg py-4 mx-auto" data-el-notebook-content>
+    <div class="h-full relative overflow-y-auto px-4 md:px-20">
+      <div class="w-full max-w-screen-lg py-4 mx-auto">
         <div class="absolute md:fixed right-8 md:left-4 top-3 w-10 h-10">
-          <.menu id="app-menu" position={:bottom_left}>
-            <:toggle>
-              <button class="flex items-center text-gray-900">
-                <img src={~p"/images/logo.png"} height="40" width="40" alt="logo livebook" />
-                <.remix_icon icon="arrow-down-s-line" />
-              </button>
-            </:toggle>
-            <.menu_item>
-              <.link navigate={~p"/"} role="menuitem">
-                <.remix_icon icon="home-6-line" />
-                <span>Home</span>
-              </.link>
-            </.menu_item>
-            <.menu_item :if={@data_view.show_source}>
-              <.link patch={~p"/apps/#{@data_view.slug}/source"} role="menuitem">
-                <.remix_icon icon="code-line" />
-                <span>View source</span>
-              </.link>
-            </.menu_item>
-          </.menu>
+          <.link navigate={~p"/"}>
+            <img src={~p"/images/logo.png"} height="40" widthz="40" alt="logo livebook" />
+          </.link>
         </div>
-        <div data-el-js-view-iframes phx-update="ignore" id="js-view-iframes"></div>
         <div class="flex items-center pb-4 mb-2 space-x-4 border-b border-gray-200 pr-20 md:pr-0">
           <h1 class="text-3xl font-semibold text-gray-800">
-            <%= @data_view.notebook_name %>
+            <%= @app.notebook_name %>
           </h1>
         </div>
-        <div :if={@data_view.app_status == :booting} class="flex items-center space-x-2">
-          <span class="relative flex h-3 w-3">
-            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75">
-            </span>
-            <span class="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
-          </span>
-          <div class="text-gray-700 font-medium">
-            Booting
-          </div>
+        <div class="pt-4 flex flex-col space-y-16">
+          <.content_skeleton :for={_idx <- 1..5} empty={false} />
         </div>
-        <div :if={@data_view.app_status == :error} class="flex items-center space-x-2">
-          <span class="relative flex h-3 w-3">
-            <span class="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
-          </span>
-          <div class="text-gray-700 font-medium">
-            Error
-          </div>
-        </div>
-        <div
-          :if={@data_view.app_status in [:running, :shutting_down]}
-          class="pt-4 flex flex-col space-y-6"
-          data-el-outputs-container
-          id="outputs"
-        >
-          <div :for={output_view <- Enum.reverse(@data_view.output_views)}>
-            <LivebookWeb.Output.outputs
-              outputs={[output_view.output]}
-              dom_id_map={%{}}
-              session_id={@session.id}
-              session_pid={@session.pid}
-              client_id={@client_id}
-              input_values={output_view.input_values}
-            />
-          </div>
-        </div>
-        <div style="height: 80vh"></div>
       </div>
     </div>
 
-    <.modal
-      :if={@live_action == :source and @data_view.show_source}
-      id="source-modal"
-      show
-      width={:big}
-      patch={~p"/apps/#{@data_view.slug}"}
-    >
-      <.live_component module={LivebookWeb.AppLive.SourceComponent} id="source" session={@session} />
+    <.modal id="sessions-modal" show width={:big} patch={~p"/"}>
+      <div class="p-6 max-w-4xl flex flex-col space-y-3">
+        <h3 class="text-2xl font-semibold text-gray-800">
+          App sessions
+        </h3>
+        <p class="text-gray-700">
+          This is a multi-session app, pick an existing session or create a new one.
+        </p>
+        <div class="flex justify-end">
+          <button class="button-base button-outlined-blue" phx-click="new_session">
+            <.remix_icon icon="add-line" class="align-middle mr-1" />
+            <span>New session</span>
+          </button>
+        </div>
+        <div class="w-full flex flex-col space-y-4">
+          <.link
+            :for={app_session <- active_sessions(@app.sessions)}
+            navigate={~p"/apps/#{@app.slug}/#{app_session.id}"}
+            class="px-4 py-3 border border-gray-200 rounded-xl text-gray-800 pointer hover:bg-gray-50 flex justify-between"
+          >
+            <span class="font-semibold">
+              Started <%= format_datetime_relatively(app_session.created_at) %> ago
+            </span>
+            <div class="mr-0.5 flex">
+              <.app_status status={app_session.app_status} show_label={false} />
+            </div>
+          </.link>
+        </div>
+      </div>
     </.modal>
     """
   end
 
-  def render(assigns) do
-    ~H"""
-    <div class="flex justify-center items-center h-screen w-screen">
-      <img src={~p"/images/logo.png"} height="128" width="128" alt="livebook" class="animate-pulse" />
-    </div>
-    """
-  end
+  def render(assigns), do: auth_placeholder(assigns)
 
-  defp get_page_title(notebook_name) do
-    "Livebook - #{notebook_name}"
+  @impl true
+  def handle_event("new_session", %{}, socket) do
+    session_id = Livebook.App.get_session_id(socket.assigns.app.pid)
+    {:noreply, push_navigate(socket, to: ~p"/apps/#{socket.assigns.app.slug}/#{session_id}")}
   end
 
   @impl true
-  def handle_params(_params, _url, socket), do: {:noreply, socket}
-
-  @impl true
-  def handle_info({:operation, operation}, socket) do
-    {:noreply, handle_operation(socket, operation)}
-  end
-
-  def handle_info({:set_input_values, values, _local = true}, socket) do
-    socket =
-      Enum.reduce(values, socket, fn {input_id, value}, socket ->
-        operation = {:set_input_value, socket.assigns.client_id, input_id, value}
-        handle_operation(socket, operation)
-      end)
-
-    {:noreply, socket}
-  end
-
-  def handle_info(:session_closed, socket) do
-    {:noreply,
-     socket
-     |> put_flash(:info, "Session has been closed")
-     |> push_navigate(to: ~p"/")}
+  def handle_info({:app_updated, app}, socket) do
+    {:noreply, assign(socket, :app, app)}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}
 
-  defp handle_operation(socket, operation) do
-    case Session.Data.apply_operation(socket.private.data, operation) do
-      {:ok, data, _actions} ->
-        socket
-        |> assign_private(data: data)
-        |> assign(
-          data_view:
-            update_data_view(socket.assigns.data_view, socket.private.data, data, operation)
-        )
-
-      :error ->
-        socket
-    end
+  defp active_sessions(sessions) do
+    Enum.filter(sessions, &Livebook.Session.Data.app_active?(&1.app_status))
   end
-
-  defp update_data_view(data_view, _prev_data, data, operation) do
-    case operation do
-      # See LivebookWeb.SessionLive for more details
-      {:add_cell_evaluation_output, _client_id, _cell_id,
-       {:frame, _outputs, %{type: type, ref: ref}}}
-      when type != :default ->
-        for {idx, {:frame, frame_outputs, _}} <- Notebook.find_frame_outputs(data.notebook, ref) do
-          send_update(LivebookWeb.Output.FrameComponent,
-            id: "output-#{idx}",
-            outputs: frame_outputs,
-            update_type: type
-          )
-        end
-
-        data_view
-
-      _ ->
-        data_to_view(data)
-    end
-  end
-
-  defp data_to_view(data) do
-    %{
-      notebook_name: data.notebook.name,
-      output_views:
-        for(
-          output <- visible_outputs(data.notebook),
-          do: %{
-            output: output,
-            input_values: input_values_for_output(output, data)
-          }
-        ),
-      app_status: data.app_data.status,
-      show_source: data.notebook.app_settings.show_source,
-      slug: data.notebook.app_settings.slug
-    }
-  end
-
-  defp input_values_for_output(output, data) do
-    input_ids = for attrs <- Cell.find_inputs_in_output(output), do: attrs.id
-    Map.take(data.input_values, input_ids)
-  end
-
-  defp visible_outputs(notebook) do
-    for section <- Enum.reverse(notebook.sections),
-        cell <- Enum.reverse(section.cells),
-        Cell.evaluable?(cell),
-        output <- filter_outputs(cell.outputs, notebook.app_settings.output_type),
-        do: output
-  end
-
-  defp filter_outputs(outputs, :all), do: outputs
-  defp filter_outputs(outputs, :rich), do: rich_outputs(outputs)
-
-  defp rich_outputs(outputs) do
-    for output <- outputs, output = filter_output(output), do: output
-  end
-
-  defp filter_output({idx, output})
-       when elem(output, 0) in [:plain_text, :markdown, :image, :js, :control, :input],
-       do: {idx, output}
-
-  defp filter_output({idx, {:tabs, outputs, metadata}}) do
-    outputs_with_labels =
-      for {output, label} <- Enum.zip(outputs, metadata.labels),
-          output = filter_output(output),
-          do: {output, label}
-
-    {outputs, labels} = Enum.unzip(outputs_with_labels)
-
-    {idx, {:tabs, outputs, %{metadata | labels: labels}}}
-  end
-
-  defp filter_output({idx, {:grid, outputs, metadata}}) do
-    outputs = rich_outputs(outputs)
-
-    if outputs != [] do
-      {idx, {:grid, outputs, metadata}}
-    end
-  end
-
-  defp filter_output({idx, {:frame, outputs, metadata}}) do
-    outputs = rich_outputs(outputs)
-    {idx, {:frame, outputs, metadata}}
-  end
-
-  defp filter_output(_output), do: nil
 end

--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -1,0 +1,314 @@
+defmodule LivebookWeb.AppSessionLive do
+  use LivebookWeb, :live_view
+
+  import LivebookWeb.AppHelpers
+
+  alias Livebook.Session
+  alias Livebook.Notebook
+  alias Livebook.Notebook.Cell
+
+  @impl true
+  def mount(%{"slug" => slug, "id" => session_id}, _session, socket)
+      when socket.assigns.app_authenticated? do
+    {:ok, app} = Livebook.Apps.fetch_app(slug)
+
+    app_session = Enum.find(app.sessions, &(&1.id == session_id))
+
+    if app_session && Session.Data.app_active?(app_session.app_status) do
+      %{pid: session_pid} = app_session
+      session = Session.get_by_pid(session_pid)
+
+      {data, client_id} =
+        if connected?(socket) do
+          {data, client_id} =
+            Session.register_client(session_pid, self(), socket.assigns.current_user)
+
+          Session.subscribe(session_id)
+
+          {data, client_id}
+        else
+          data = Session.get_data(session_pid)
+          {data, nil}
+        end
+
+      {:ok,
+       socket
+       |> assign(
+         slug: slug,
+         session: session,
+         page_title: get_page_title(data.notebook.name),
+         client_id: client_id,
+         data_view: data_to_view(data)
+       )
+       |> assign_private(data: data)}
+    else
+      {:ok,
+       assign(socket,
+         nonexistent?: true,
+         slug: slug,
+         page_title: get_page_title(app.notebook_name)
+       )}
+    end
+  end
+
+  def mount(%{"slug" => slug} = params, _session, socket) do
+    if connected?(socket) do
+      to =
+        if id = params["id"] do
+          ~p"/apps/#{slug}/authenticate?id=#{id}"
+        else
+          ~p"/apps/#{slug}/authenticate"
+        end
+
+      {:ok, push_navigate(socket, to: to)}
+    else
+      {:ok, socket}
+    end
+  end
+
+  # Puts the given assigns in `socket.private`,
+  # to ensure they are not used for rendering.
+  defp assign_private(socket, assigns) do
+    Enum.reduce(assigns, socket, fn {key, value}, socket ->
+      put_in(socket.private[key], value)
+    end)
+  end
+
+  @impl true
+  def render(%{nonexistent?: true} = assigns) when assigns.app_authenticated? do
+    ~H"""
+    <div class="h-screen flex items-center justify-center">
+      <div class="flex flex-col space-y-4 items-center">
+        <a href={~p"/"}>
+          <img src={~p"/images/logo.png"} height="128" width="128" alt="livebook" />
+        </a>
+        <div class="text-2xl text-gray-800">
+          This app session does not exist
+        </div>
+        <div class="max-w-2xl text-center text-gray-700">
+          <span>Visit the</span>
+          <.link class="border-b border-gray-700 hover:border-none" navigate={~p"/apps/#{@slug}"}>app page</.link>.
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def render(assigns) when assigns.app_authenticated? do
+    ~H"""
+    <div class="h-full relative overflow-y-auto px-4 md:px-20" data-el-notebook>
+      <div class="w-full max-w-screen-lg py-4 mx-auto" data-el-notebook-content>
+        <div class="absolute md:fixed right-8 md:left-4 top-3 w-10 h-10">
+          <.menu id="app-menu" position={:bottom_left}>
+            <:toggle>
+              <button class="flex items-center text-gray-900">
+                <img src={~p"/images/logo.png"} height="40" width="40" alt="logo livebook" />
+                <.remix_icon icon="arrow-down-s-line" />
+              </button>
+            </:toggle>
+            <.menu_item>
+              <.link navigate={~p"/"} role="menuitem">
+                <.remix_icon icon="home-6-line" />
+                <span>Home</span>
+              </.link>
+            </.menu_item>
+            <.menu_item :if={@data_view.show_source}>
+              <.link patch={~p"/apps/#{@data_view.slug}/#{@session.id}/source"} role="menuitem">
+                <.remix_icon icon="code-line" />
+                <span>View source</span>
+              </.link>
+            </.menu_item>
+          </.menu>
+        </div>
+        <div data-el-js-view-iframes phx-update="ignore" id="js-view-iframes"></div>
+        <div class="flex items-center pb-4 mb-2 space-x-4 border-b border-gray-200 pr-20 md:pr-0">
+          <h1 class="text-3xl font-semibold text-gray-800">
+            <%= @data_view.notebook_name %>
+          </h1>
+        </div>
+        <div class="pt-4 flex flex-col space-y-6" data-el-outputs-container id="outputs">
+          <div :for={output_view <- Enum.reverse(@data_view.output_views)}>
+            <LivebookWeb.Output.outputs
+              outputs={[output_view.output]}
+              dom_id_map={%{}}
+              session_id={@session.id}
+              session_pid={@session.pid}
+              client_id={@client_id}
+              input_values={output_view.input_values}
+            />
+          </div>
+        </div>
+        <div style="height: 80vh"></div>
+      </div>
+    </div>
+
+    <.modal
+      :if={@live_action == :source and @data_view.show_source}
+      id="source-modal"
+      show
+      width={:big}
+      patch={~p"/apps/#{@data_view.slug}/#{@session.id}"}
+    >
+      <.live_component
+        module={LivebookWeb.AppSessionLive.SourceComponent}
+        id="source"
+        session={@session}
+      />
+    </.modal>
+    """
+  end
+
+  def render(assigns), do: auth_placeholder(assigns)
+
+  defp get_page_title(notebook_name) do
+    "Livebook - #{notebook_name}"
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_info({:operation, operation}, socket) do
+    {:noreply, handle_operation(socket, operation)}
+  end
+
+  def handle_info({:set_input_values, values, local}, socket) do
+    if local do
+      socket =
+        Enum.reduce(values, socket, fn {input_id, value}, socket ->
+          operation = {:set_input_value, socket.assigns.client_id, input_id, value}
+          handle_operation(socket, operation)
+        end)
+
+      {:noreply, socket}
+    else
+      for {input_id, value} <- values do
+        Session.set_input_value(socket.assigns.session.pid, input_id, value)
+      end
+
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(:session_closed, socket) do
+    {:noreply, redirect_on_closed(socket)}
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  defp handle_operation(socket, operation) do
+    case Session.Data.apply_operation(socket.private.data, operation) do
+      {:ok, data, _actions} ->
+        socket
+        |> assign_private(data: data)
+        |> assign(
+          data_view:
+            update_data_view(socket.assigns.data_view, socket.private.data, data, operation)
+        )
+        |> after_operation(socket, operation)
+
+      :error ->
+        socket
+    end
+  end
+
+  defp after_operation(socket, _prev_socket, {:app_deactivate, _client_id}) do
+    redirect_on_closed(socket)
+  end
+
+  defp after_operation(socket, _prev_socket, _operation), do: socket
+
+  defp redirect_on_closed(socket) do
+    socket
+    |> put_flash(:info, "Session has been closed")
+    |> push_navigate(to: ~p"/")
+  end
+
+  defp update_data_view(data_view, _prev_data, data, operation) do
+    case operation do
+      # See LivebookWeb.SessionLive for more details
+      {:add_cell_evaluation_output, _client_id, _cell_id,
+       {:frame, _outputs, %{type: type, ref: ref}}}
+      when type != :default ->
+        for {idx, {:frame, frame_outputs, _}} <- Notebook.find_frame_outputs(data.notebook, ref) do
+          send_update(LivebookWeb.Output.FrameComponent,
+            id: "output-#{idx}",
+            outputs: frame_outputs,
+            update_type: type
+          )
+        end
+
+        data_view
+
+      _ ->
+        data_to_view(data)
+    end
+  end
+
+  defp data_to_view(data) do
+    %{
+      notebook_name: data.notebook.name,
+      output_views:
+        for(
+          output <- visible_outputs(data.notebook),
+          do: %{
+            output: output,
+            input_values: input_values_for_output(output, data)
+          }
+        ),
+      app_status: data.app_data.status,
+      show_source: data.notebook.app_settings.show_source,
+      slug: data.notebook.app_settings.slug
+    }
+  end
+
+  defp input_values_for_output(output, data) do
+    input_ids = for attrs <- Cell.find_inputs_in_output(output), do: attrs.id
+    Map.take(data.input_values, input_ids)
+  end
+
+  defp visible_outputs(notebook) do
+    for section <- Enum.reverse(notebook.sections),
+        cell <- Enum.reverse(section.cells),
+        Cell.evaluable?(cell),
+        output <- filter_outputs(cell.outputs, notebook.app_settings.output_type),
+        do: output
+  end
+
+  defp filter_outputs(outputs, :all), do: outputs
+  defp filter_outputs(outputs, :rich), do: rich_outputs(outputs)
+
+  defp rich_outputs(outputs) do
+    for output <- outputs, output = filter_output(output), do: output
+  end
+
+  defp filter_output({idx, output})
+       when elem(output, 0) in [:plain_text, :markdown, :image, :js, :control, :input],
+       do: {idx, output}
+
+  defp filter_output({idx, {:tabs, outputs, metadata}}) do
+    outputs_with_labels =
+      for {output, label} <- Enum.zip(outputs, metadata.labels),
+          output = filter_output(output),
+          do: {output, label}
+
+    {outputs, labels} = Enum.unzip(outputs_with_labels)
+
+    {idx, {:tabs, outputs, %{metadata | labels: labels}}}
+  end
+
+  defp filter_output({idx, {:grid, outputs, metadata}}) do
+    outputs = rich_outputs(outputs)
+
+    if outputs != [] do
+      {idx, {:grid, outputs, metadata}}
+    end
+  end
+
+  defp filter_output({idx, {:frame, outputs, metadata}}) do
+    outputs = rich_outputs(outputs)
+    {idx, {:frame, outputs, metadata}}
+  end
+
+  defp filter_output(_output), do: nil
+end

--- a/lib/livebook_web/live/app_session_live/source_component.ex
+++ b/lib/livebook_web/live/app_session_live/source_component.ex
@@ -1,4 +1,4 @@
-defmodule LivebookWeb.AppLive.SourceComponent do
+defmodule LivebookWeb.AppSessionLive.SourceComponent do
   use LivebookWeb, :live_component
 
   alias Livebook.Session

--- a/lib/livebook_web/live/apps_live.ex
+++ b/lib/livebook_web/live/apps_live.ex
@@ -36,7 +36,7 @@ defmodule LivebookWeb.AppsLive do
     """
   end
 
-  defp app_list(%{app: []} = assigns) do
+  defp app_list(%{apps: []} = assigns) do
     ~H"""
     <.no_entries>
       You do not have any apps running. <br />
@@ -72,6 +72,11 @@ defmodule LivebookWeb.AppsLive do
                 v<%= app.version %>
               </.labeled_text>
             </div>
+            <div class="flex-1">
+              <.labeled_text label="Session type" one_line>
+                <%= if(app.multi_session, do: "Multi", else: "Single") %>
+              </.labeled_text>
+            </div>
           </div>
           <div class="flex flex-col md:flex-row md:items-center gap-2">
             <span class="tooltip top" data-tooltip="Terminate">
@@ -85,77 +90,79 @@ defmodule LivebookWeb.AppsLive do
             </span>
           </div>
         </div>
-        <div class="my-2 text-gray-600 font-medium text-sm">
-          App sessions
-        </div>
-        <.table rows={app.sessions}>
-          <:col :let={app_session} label="Status">
-            <a
-              aria-label="debug app"
-              href={app_session.app_status == :error && ~p"/sessions/#{app_session.id}"}
-              target="_blank"
-            >
-              <.app_status status={app_session.app_status} />
-            </a>
-          </:col>
-          <:col :let={app_session} label="Uptime">
-            <%= format_datetime_relatively(app_session.created_at) %>
-          </:col>
-          <:col :let={app_session} label="Version" align={:center}>
-            v<%= app_session.version %>
-          </:col>
-          <:col :let={app_session} label="Clients" align={:center}>
-            <%= app_session.client_count %>
-          </:col>
-          <:actions :let={app_session}>
-            <span class="tooltip left" data-tooltip="Open">
+        <div class="ml-4">
+          <div class="my-2 text-gray-600 font-medium text-sm">
+            App sessions
+          </div>
+          <.table rows={app.sessions}>
+            <:col :let={app_session} label="Status">
               <a
-                class={[
-                  "icon-button",
-                  not Livebook.Session.Data.app_active?(app_session.app_status) && "disabled"
-                ]}
-                aria-label="open app"
-                href={~p"/apps/#{app.slug}/#{app_session.id}"}
+                aria-label="debug app"
+                href={app_session.app_status == :error && ~p"/sessions/#{app_session.id}"}
+                target="_blank"
               >
-                <.remix_icon icon="link" class="text-lg" />
+                <.app_status status={app_session.app_status} />
               </a>
-            </span>
-            <span class="tooltip left" data-tooltip="Debug">
-              <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{app_session.id}"}>
-                <.remix_icon icon="terminal-line" class="text-lg" />
-              </a>
-            </span>
-            <%= if Livebook.Session.Data.app_active?(app_session.app_status) do %>
-              <span class="tooltip left" data-tooltip="Deactivate">
-                <button
-                  class="icon-button"
-                  aria-label="deactivate app session"
-                  phx-click={
-                    JS.push("deactivate_app_session",
-                      value: %{slug: app.slug, session_id: app_session.id}
-                    )
-                  }
+            </:col>
+            <:col :let={app_session} label="Uptime">
+              <%= format_datetime_relatively(app_session.created_at) %>
+            </:col>
+            <:col :let={app_session} label="Version" align={:center}>
+              v<%= app_session.version %>
+            </:col>
+            <:col :let={app_session} label="Clients" align={:center}>
+              <%= app_session.client_count %>
+            </:col>
+            <:actions :let={app_session}>
+              <span class="tooltip left" data-tooltip="Open">
+                <a
+                  class={[
+                    "icon-button",
+                    not Livebook.Session.Data.app_active?(app_session.app_status) && "disabled"
+                  ]}
+                  aria-label="open app"
+                  href={~p"/apps/#{app.slug}/#{app_session.id}"}
                 >
-                  <.remix_icon icon="stop-circle-line" class="text-lg" />
-                </button>
+                  <.remix_icon icon="link" class="text-lg" />
+                </a>
               </span>
-            <% else %>
-              <span class="tooltip left" data-tooltip="Terminate">
-                <button
-                  class="icon-button"
-                  aria-label="terminate app session"
-                  phx-click={
-                    JS.push("terminate_app_session",
-                      value: %{slug: app.slug, session_id: app_session.id}
-                    )
-                  }
-                >
-                  <.remix_icon icon="delete-bin-6-line" class="text-lg" />
-                </button>
+              <span class="tooltip left" data-tooltip="Debug">
+                <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{app_session.id}"}>
+                  <.remix_icon icon="terminal-line" class="text-lg" />
+                </a>
               </span>
-            <% end %>
-          </:actions>
-        </.table>
+              <%= if Livebook.Session.Data.app_active?(app_session.app_status) do %>
+                <span class="tooltip left" data-tooltip="Deactivate">
+                  <button
+                    class="icon-button"
+                    aria-label="deactivate app session"
+                    phx-click={
+                      JS.push("deactivate_app_session",
+                        value: %{slug: app.slug, session_id: app_session.id}
+                      )
+                    }
+                  >
+                    <.remix_icon icon="stop-circle-line" class="text-lg" />
+                  </button>
+                </span>
+              <% else %>
+                <span class="tooltip left" data-tooltip="Terminate">
+                  <button
+                    class="icon-button"
+                    aria-label="terminate app session"
+                    phx-click={
+                      JS.push("terminate_app_session",
+                        value: %{slug: app.slug, session_id: app_session.id}
+                      )
+                    }
+                  >
+                    <.remix_icon icon="delete-bin-6-line" class="text-lg" />
+                  </button>
+                </span>
+              <% end %>
+            </:actions>
+          </.table>
+        </div>
       </div>
     </div>
     """

--- a/lib/livebook_web/live/apps_live.ex
+++ b/lib/livebook_web/live/apps_live.ex
@@ -2,25 +2,20 @@ defmodule LivebookWeb.AppsLive do
   use LivebookWeb, :live_view
 
   import LivebookWeb.AppHelpers
-  import LivebookWeb.SessionHelpers
 
   alias LivebookWeb.LayoutHelpers
-  alias Livebook.Sessions
 
   on_mount LivebookWeb.SidebarHook
 
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      Livebook.Sessions.subscribe()
+      Livebook.Apps.subscribe()
     end
 
-    sessions =
-      Sessions.list_sessions()
-      |> Enum.filter(&(&1.mode == :app))
-      |> Enum.sort_by(& &1.created_at, {:desc, DateTime})
+    apps = Livebook.Apps.list_apps()
 
-    {:ok, assign(socket, sessions: sessions, page_title: "App - Livebook")}
+    {:ok, assign(socket, apps: apps, page_title: "Apps - Livebook")}
   end
 
   @impl true
@@ -33,15 +28,15 @@ defmodule LivebookWeb.AppsLive do
     >
       <div class="p-4 md:px-12 md:py-7 max-w-screen-lg mx-auto">
         <LayoutHelpers.title text="Apps" />
-        <div class="mt-8">
-          <.app_list sessions={@sessions} />
+        <div class="mt-10">
+          <.app_list apps={@apps} />
         </div>
       </div>
     </LayoutHelpers.layout>
     """
   end
 
-  defp app_list(%{sessions: []} = assigns) do
+  defp app_list(%{app: []} = assigns) do
     ~H"""
     <.no_entries>
       You do not have any apps running. <br />
@@ -53,114 +48,207 @@ defmodule LivebookWeb.AppsLive do
 
   defp app_list(assigns) do
     ~H"""
-    <div class="flex flex-col space-y-8">
-      <div :for={{slug, sessions} <- group_apps(@sessions)}>
+    <div class="flex flex-col space-y-10">
+      <div :for={app <- Enum.sort_by(@apps, & &1.slug)} data-app-slug={app.slug}>
         <div class="mb-2 text-gray-800 font-medium text-lg">
-          <%= "/" <> slug %>
+          <%= "/" <> app.slug %>
         </div>
-        <div class="flex flex-col">
-          <%= for {session, idx} <- Enum.with_index(sessions) do %>
-            <div :if={idx > 0} class="ml-4 border-l-2 border-gray-300 border-dashed h-6"></div>
-            <.app_box session={session} />
-          <% end %>
+        <div class="border border-gray-200 rounded-lg flex justify-between p-4">
+          <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-8 w-full max-w-2xl">
+            <div class="flex-1">
+              <.labeled_text label="Name" one_line>
+                <%= app.notebook_name %>
+              </.labeled_text>
+            </div>
+            <div class="flex-1">
+              <.labeled_text label="URL" one_line>
+                <a href={~p"/apps/#{app.slug}"}>
+                  <%= ~p"/apps/#{app.slug}" %>
+                </a>
+              </.labeled_text>
+            </div>
+            <div class="flex-1">
+              <.labeled_text label="Version" one_line>
+                v<%= app.version %>
+              </.labeled_text>
+            </div>
+          </div>
+          <div class="flex flex-col md:flex-row md:items-center gap-2">
+            <span class="tooltip top" data-tooltip="Terminate">
+              <button
+                class="icon-button"
+                aria-label="terminate app"
+                phx-click={JS.push("terminate_app", value: %{slug: app.slug})}
+              >
+                <.remix_icon icon="delete-bin-6-line" class="text-lg" />
+              </button>
+            </span>
+          </div>
         </div>
-      </div>
-    </div>
-    """
-  end
-
-  defp app_box(assigns) do
-    ~H"""
-    <div
-      class="border border-gray-200 rounded-lg flex justify-between p-4"
-      data-app-slug={@session.app_info.slug}
-    >
-      <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-8 w-full max-w-2xl">
-        <div class="flex-1">
-          <.labeled_text label="Status">
+        <div class="my-2 text-gray-600 font-medium text-sm">
+          App sessions
+        </div>
+        <.table rows={app.sessions}>
+          <:col :let={app_session} label="Status">
             <a
-              class="inline-block"
               aria-label="debug app"
-              href={@session.app_info.status == :error && ~p"/sessions/#{@session.id}"}
+              href={app_session.app_status == :error && ~p"/sessions/#{app_session.id}"}
               target="_blank"
             >
-              <.app_status status={@session.app_info.status} />
+              <.app_status status={app_session.app_status} />
             </a>
-          </.labeled_text>
-        </div>
-        <div class="flex-1">
-          <.labeled_text label="Name">
-            <%= @session.notebook_name %>
-          </.labeled_text>
-        </div>
-        <div class="flex-1 grow-[2]">
-          <.labeled_text label="URL">
-            <%= if @session.app_info.registered do %>
-              <a href={~p"/apps/#{@session.app_info.slug}"}>
-                <%= ~p"/apps/#{@session.app_info.slug}" %>
+          </:col>
+          <:col :let={app_session} label="Uptime">
+            <%= format_datetime_relatively(app_session.created_at) %>
+          </:col>
+          <:col :let={app_session} label="Version" align={:center}>
+            v<%= app_session.version %>
+          </:col>
+          <:col :let={app_session} label="Clients" align={:center}>
+            <%= app_session.client_count %>
+          </:col>
+          <:actions :let={app_session}>
+            <span class="tooltip left" data-tooltip="Open">
+              <a
+                class={[
+                  "icon-button",
+                  not Livebook.Session.Data.app_active?(app_session.app_status) && "disabled"
+                ]}
+                aria-label="open app"
+                href={~p"/apps/#{app.slug}/#{app_session.id}"}
+              >
+                <.remix_icon icon="link" class="text-lg" />
               </a>
+            </span>
+            <span class="tooltip left" data-tooltip="Debug">
+              <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{app_session.id}"}>
+                <.remix_icon icon="terminal-line" class="text-lg" />
+              </a>
+            </span>
+            <%= if Livebook.Session.Data.app_active?(app_session.app_status) do %>
+              <span class="tooltip left" data-tooltip="Deactivate">
+                <button
+                  class="icon-button"
+                  aria-label="deactivate app session"
+                  phx-click={
+                    JS.push("deactivate_app_session",
+                      value: %{slug: app.slug, session_id: app_session.id}
+                    )
+                  }
+                >
+                  <.remix_icon icon="stop-circle-line" class="text-lg" />
+                </button>
+              </span>
             <% else %>
-              -
+              <span class="tooltip left" data-tooltip="Terminate">
+                <button
+                  class="icon-button"
+                  aria-label="terminate app session"
+                  phx-click={
+                    JS.push("terminate_app_session",
+                      value: %{slug: app.slug, session_id: app_session.id}
+                    )
+                  }
+                >
+                  <.remix_icon icon="delete-bin-6-line" class="text-lg" />
+                </button>
+              </span>
             <% end %>
-          </.labeled_text>
-        </div>
-      </div>
-      <div class="flex flex-col md:flex-row md:items-center gap-2">
-        <span class="tooltip top" data-tooltip="Debug">
-          <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{@session.id}"}>
-            <.remix_icon icon="terminal-line" class="text-lg" />
-          </a>
-        </span>
-        <%= if @session.app_info.registered do %>
-          <span class="tooltip top" data-tooltip="Stop">
-            <button
-              class="icon-button"
-              aria-label="stop app"
-              phx-click={JS.push("stop_app", value: %{session_id: @session.id})}
-            >
-              <.remix_icon icon="stop-circle-line" class="text-lg" />
-            </button>
-          </span>
-        <% else %>
-          <span class="tooltip top" data-tooltip="Terminate">
-            <button
-              class="icon-button"
-              aria-label="terminate app"
-              phx-click={JS.push("terminate_app", value: %{session_id: @session.id})}
-            >
-              <.remix_icon icon="delete-bin-6-line" class="text-lg" />
-            </button>
-          </span>
-        <% end %>
+          </:actions>
+        </.table>
       </div>
     </div>
     """
   end
 
+  defp table(assigns) do
+    ~H"""
+    <div class="overflow-x-auto border border-gray-200 rounded-lg">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr>
+            <th
+              :for={col <- @col}
+              class={["px-4 py-2 text-gray-500 text-sm font-normal", align_to_class(col[:align])]}
+            >
+              <%= col[:label] %>
+            </th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            :for={row <- @rows}
+            class="whitespace-nowrap border-y last:border-b-0 border-gray-200 border-dashed hover:bg-gray-50"
+          >
+            <td
+              :for={col <- @col}
+              class={["px-4 py-2 text-gray-800 text-sm font-semibold", align_to_class(col[:align])]}
+            >
+              <%= render_slot(col, row) %>
+            </td>
+            <td class="px-4 py-2">
+              <div class="flex flex-row items-center justify-end gap-2">
+                <%= render_slot(@actions, row) %>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp align_to_class(:right), do: "text-right"
+  defp align_to_class(:center), do: "text-center"
+  defp align_to_class(_), do: "text-left"
+
   @impl true
-  def handle_info({type, session} = event, socket)
-      when type in [:session_created, :session_updated, :session_closed] and session.mode == :app do
-    {:noreply, update(socket, :sessions, &update_session_list(&1, event))}
+  def handle_info({type, _app} = event, socket)
+      when type in [:app_created, :app_updated, :app_closed] do
+    {:noreply, update(socket, :apps, &update_app_list(&1, event))}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}
 
   @impl true
-  def handle_event("terminate_app", %{"session_id" => session_id}, socket) do
-    session = Enum.find(socket.assigns.sessions, &(&1.id == session_id))
-    Livebook.Session.close(session.pid)
+  def handle_event("terminate_app", %{"slug" => slug}, socket) do
+    app = Enum.find(socket.assigns.apps, &(&1.slug == slug))
+    {:noreply, confirm_app_termination(socket, app.pid)}
+  end
+
+  def handle_event("terminate_app_session", %{"slug" => slug, "session_id" => session_id}, socket) do
+    app_session = find_app_session(socket.assigns.apps, slug, session_id)
+    Livebook.Session.close(app_session.pid)
     {:noreply, socket}
   end
 
-  def handle_event("stop_app", %{"session_id" => session_id}, socket) do
-    session = Enum.find(socket.assigns.sessions, &(&1.id == session_id))
-    Livebook.Session.app_stop(session.pid)
+  def handle_event(
+        "deactivate_app_session",
+        %{"slug" => slug, "session_id" => session_id},
+        socket
+      ) do
+    app_session = find_app_session(socket.assigns.apps, slug, session_id)
+    Livebook.Session.app_deactivate(app_session.pid)
     {:noreply, socket}
   end
 
-  defp group_apps(sessions) do
-    sessions
-    |> Enum.group_by(& &1.app_info.slug)
-    |> Enum.sort_by(&elem(&1, 0))
+  defp find_app_session(apps, slug, session_id) do
+    app = Enum.find(apps, &(&1.slug == slug))
+    Enum.find(app.sessions, &(&1.id == session_id))
+  end
+
+  def update_app_list(apps, {:app_created, app}) do
+    if app in apps, do: apps, else: [app | apps]
+  end
+
+  def update_app_list(apps, {:app_updated, app}) do
+    Enum.map(apps, fn other ->
+      if other.slug == app.slug, do: app, else: other
+    end)
+  end
+
+  def update_app_list(apps, {:app_closed, app}) do
+    Enum.reject(apps, &(&1.slug == app.slug))
   end
 end

--- a/lib/livebook_web/live/auth_app_list_live.ex
+++ b/lib/livebook_web/live/auth_app_list_live.ex
@@ -1,18 +1,15 @@
 defmodule LivebookWeb.AuthAppListLive do
   use LivebookWeb, :live_view
 
-  import LivebookWeb.AppHelpers
-  import LivebookWeb.SessionHelpers
-
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      Livebook.Sessions.subscribe()
+      Livebook.Apps.subscribe()
     end
 
-    sessions = Livebook.Sessions.list_sessions() |> Enum.filter(&(&1.mode == :app))
+    apps = Livebook.Apps.list_apps()
 
-    {:ok, assign(socket, sessions: sessions), layout: false}
+    {:ok, assign(socket, apps: apps), layout: false}
   end
 
   @impl true
@@ -20,37 +17,19 @@ defmodule LivebookWeb.AuthAppListLive do
     ~H"""
     <div class="w-full flex flex-col space-y-4">
       <.link
-        :for={session <- visible_sessions(@sessions)}
-        navigate={~p"/apps/#{session.app_info.slug}"}
-        class={[
-          "px-4 py-3 border border-gray-200 rounded-xl text-gray-800 pointer hover:bg-gray-50 flex justify-between",
-          not session.app_info.registered && "pointer-events-none"
-        ]}
+        :for={app <- visible_apps(@apps)}
+        navigate={~p"/apps/#{app.slug}"}
+        class="px-4 py-3 border border-gray-200 rounded-xl text-gray-800 pointer hover:bg-gray-50 flex justify-between"
       >
-        <span class="font-semibold"><%= session.notebook_name %></span>
-        <%= if session.app_info.registered do %>
-          <.remix_icon icon="arrow-right-line" class="" />
-        <% else %>
-          <div class="mr-0.5 flex">
-            <.app_status status={session.app_info.status} show_label={false} />
-          </div>
-        <% end %>
+        <span class="font-semibold"><%= app.notebook_name %></span>
       </.link>
     </div>
     """
   end
 
-  @impl true
-  def handle_info({type, session} = event, socket)
-      when type in [:session_created, :session_updated, :session_closed] and session.mode == :app do
-    {:noreply, update(socket, :sessions, &update_session_list(&1, event))}
-  end
-
-  def handle_info(_message, socket), do: {:noreply, socket}
-
-  defp visible_sessions(sessions) do
-    sessions
-    |> Enum.filter(& &1.app_info.public?)
+  defp visible_apps(apps) do
+    apps
+    |> Enum.filter(& &1.public?)
     |> Enum.sort_by(& &1.notebook_name)
   end
 end

--- a/lib/livebook_web/live/hooks/app_auth_hook.ex
+++ b/lib/livebook_web/live/hooks/app_auth_hook.ex
@@ -29,12 +29,12 @@ defmodule LivebookWeb.AppAuthHook do
   #     server we use that token to authenticate.
   #
   # This module defines a hook that sets the `:app_authenticated?`
-  # assign to reflect the current authentication state. For public
-  # apps (or in case the user has full access) it is set to `true`
-  # on both dead and live render.
+  # assign to reflect the current authentication state and also
+  # `:app_settings`. For public apps (or in case the user has full
+  # access) it is set to `true` on both dead and live render.
 
   def on_mount(:default, %{"slug" => slug}, session, socket) do
-    case Livebook.Apps.fetch_settings_by_slug(slug) do
+    case Livebook.Apps.fetch_settings(slug) do
       {:ok, %{access_type: :public} = app_settings} ->
         {:cont, assign(socket, app_authenticated?: true, app_settings: app_settings)}
 

--- a/lib/livebook_web/live/notebook_cards_component.ex
+++ b/lib/livebook_web/live/notebook_cards_component.ex
@@ -21,7 +21,7 @@ defmodule LivebookWeb.NotebookCardsComponent do
             <%= @card_icon && render_slot(@card_icon, {info, idx}) %>
           </div>
           <div class="mt-1 flex-grow text-gray-600 text-sm">
-            <%= @added_at_label %> <%= format_date_relatively(info.added_at) %>
+            <%= @added_at_label %> <%= format_datetime_relatively(info.added_at) %> ago
           </div>
           <div class="mt-2 flex space-x-6">
             <%= if session = session_by_file(info.file, @sessions) do %>
@@ -47,11 +47,6 @@ defmodule LivebookWeb.NotebookCardsComponent do
       <% end %>
     </div>
     """
-  end
-
-  defp format_date_relatively(date) do
-    time_words = date |> DateTime.to_naive() |> Livebook.Utils.Time.time_ago_in_words()
-    time_words <> " ago"
   end
 
   @impl true

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -9,7 +9,7 @@ defmodule LivebookWeb.SessionLive do
   alias Livebook.Notebook.{Cell, ContentLoader}
   alias Livebook.JSInterop
 
-  on_mount(LivebookWeb.SidebarHook)
+  on_mount LivebookWeb.SidebarHook
 
   @impl true
   def mount(%{"id" => session_id}, _session, socket) do
@@ -29,6 +29,17 @@ defmodule LivebookWeb.SessionLive do
           else
             data = Session.get_data(session_pid)
             {data, nil}
+          end
+
+        app =
+          if slug = data.deployed_app_slug do
+            {:ok, app} = Livebook.Apps.fetch_app(slug)
+
+            if connected?(socket) do
+              Livebook.App.subscribe(slug)
+            end
+
+            app
           end
 
         socket =
@@ -53,6 +64,7 @@ defmodule LivebookWeb.SessionLive do
          |> assign(
            self_path: ~p"/sessions/#{session.id}",
            session: session,
+           app: app,
            client_id: client_id,
            platform: platform,
            data_view: data_to_view(data),
@@ -140,7 +152,7 @@ defmodule LivebookWeb.SessionLive do
             data-el-app-indicator
             class={[
               "absolute w-[12px] h-[12px] border-gray-900 border-2 rounded-full right-1.5 top-1.5 pointer-events-none",
-              app_status_color(@data_view.apps_status)
+              app_status_color(app_status(@app))
             ]}
           />
         </div>
@@ -207,7 +219,8 @@ defmodule LivebookWeb.SessionLive do
             id="app-info"
             session={@session}
             settings={@data_view.app_settings}
-            apps={@data_view.apps}
+            app={@app}
+            deployed_app_slug={@data_view.deployed_app_slug}
           />
         </div>
         <div data-el-runtime-info>
@@ -1431,6 +1444,10 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, assign(socket, starred_files: starred_files(starred_notebooks))}
   end
 
+  def handle_info({:app_updated, app}, socket) when socket.assigns.app != nil do
+    {:noreply, assign(socket, :app, app)}
+  end
+
   def handle_info(_message, socket), do: {:noreply, socket}
 
   defp handle_relative_path(socket, path, requested_url) do
@@ -1729,13 +1746,34 @@ defmodule LivebookWeb.SessionLive do
     prune_cell_sources(socket)
   end
 
+  defp after_operation(socket, prev_socket, {:set_deployed_app_slug, _client_id, slug}) do
+    prev_slug = prev_socket.private.data.deployed_app_slug
+
+    if slug == prev_slug do
+      socket
+    else
+      if prev_slug do
+        Livebook.App.unsubscribe(prev_slug)
+      end
+
+      app =
+        if slug do
+          {:ok, app} = Livebook.Apps.fetch_app(slug)
+          Livebook.App.subscribe(slug)
+          app
+        end
+
+      assign(socket, app: app)
+    end
+  end
+
   defp after_operation(socket, _prev_socket, _operation), do: socket
 
   defp handle_actions(socket, actions) do
     Enum.reduce(actions, socket, &handle_action(&2, &1))
   end
 
-  defp handle_action(socket, {:broadcast_delta, client_id, cell, tag, delta}) do
+  defp handle_action(socket, {:report_delta, client_id, cell, tag, delta}) do
     if client_id == socket.assigns.client_id do
       push_event(socket, "cell_acknowledgement:#{cell.id}:#{tag}", %{})
     else
@@ -1968,9 +2006,8 @@ defmodule LivebookWeb.SessionLive do
       secrets: data.secrets,
       hub: Livebook.Hubs.fetch_hub!(data.notebook.hub_id),
       hub_secrets: data.hub_secrets,
-      apps_status: apps_status(data),
       app_settings: data.notebook.app_settings,
-      apps: data.apps
+      deployed_app_slug: data.deployed_app_slug
     }
   end
 
@@ -2119,8 +2156,8 @@ defmodule LivebookWeb.SessionLive do
     Map.take(data.input_values, input_ids)
   end
 
-  defp apps_status(%{apps: []}), do: nil
-  defp apps_status(%{apps: [app | _]}), do: app.status
+  def app_status(%{sessions: [app_session | _]}), do: app_session.app_status
+  def app_status(_), do: nil
 
   # Updates current data_view in response to an operation.
   # In most cases we simply recompute data_view, but for the
@@ -2133,7 +2170,7 @@ defmodule LivebookWeb.SessionLive do
       {:apply_cell_delta, _client_id, _cell_id, _tag, _delta, _revision} ->
         update_dirty_status(data_view, data)
 
-      {:update_smart_cell, _client_id, _cell_id, _cell_state, _delta, _chunks, _reevaluate} ->
+      {:update_smart_cell, _client_id, _cell_id, _cell_state, _delta, _chunks} ->
         update_dirty_status(data_view, data)
 
       # For outputs that update existing outputs we send the update directly
@@ -2232,9 +2269,9 @@ defmodule LivebookWeb.SessionLive do
   end
 
   defp app_status_color(nil), do: "bg-gray-400"
-  defp app_status_color(:booting), do: "bg-blue-500"
-  defp app_status_color(:running), do: "bg-green-bright-400"
+  defp app_status_color(:executing), do: "bg-blue-500"
+  defp app_status_color(:executed), do: "bg-green-bright-400"
   defp app_status_color(:error), do: "bg-red-400"
   defp app_status_color(:shutting_down), do: "bg-gray-500"
-  defp app_status_color(:stopped), do: "bg-gray-500"
+  defp app_status_color(:deactivated), do: "bg-gray-500"
 end

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -42,61 +42,101 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
           myself={@myself}
         />
       </div>
-      <%= if @apps != [] do %>
+      <%= if @app do %>
         <h3 class="mt-16 uppercase text-sm font-semibold text-gray-500">
-          Deployments
+          Deployment
         </h3>
+        <div class="mt-2 border border-gray-200 rounded-lg">
+          <div class="p-4 flex flex-col space-y-3">
+            <.labeled_text label="URL" one_line>
+              <a href={~p"/apps/#{@app.slug}"}>
+                <%= ~p"/apps/#{@app.slug}" %>
+              </a>
+            </.labeled_text>
+            <.labeled_text label="Version" one_line>
+              v<%= @app.version %>
+            </.labeled_text>
+          </div>
+          <div class="border-t border-gray-200 px-3 py-2 flex space-x-2">
+            <div class="grow" />
+            <span class="tooltip top" data-tooltip="Terminate">
+              <button
+                class="icon-button"
+                aria-label="terminate app"
+                phx-click={JS.push("terminate_app", target: @myself)}
+              >
+                <.remix_icon icon="delete-bin-6-line" class="text-lg" />
+              </button>
+            </span>
+          </div>
+        </div>
+        <div class="mt-2 text-gray-600 font-medium text-sm">
+          App sessions
+        </div>
         <div class="mt-2 flex flex-col space-y-4">
-          <div :for={app <- @apps} class="border border-gray-200 rounded-lg">
+          <div :for={app_session <- @app.sessions} class="border border-gray-200 rounded-lg">
             <div class="p-4 flex flex-col space-y-3">
               <.labeled_text label="Status">
                 <a
                   class="inline-block"
                   aria-label="debug app"
-                  href={app.status == :error && ~p"/sessions/#{app.session_id}"}
+                  href={app_session.app_status == :error && ~p"/sessions/#{app_session.id}"}
                   target="_blank"
                 >
-                  <.app_status status={app.status} />
+                  <.app_status status={app_session.app_status} />
                 </a>
               </.labeled_text>
-              <.labeled_text label="URL" one_line>
-                <%= if app.registered do %>
-                  <a href={~p"/apps/#{app.settings.slug}"}>
-                    <%= ~p"/apps/#{app.settings.slug}" %>
-                  </a>
-                <% else %>
-                  -
-                <% end %>
+              <.labeled_text label="Version">
+                v<%= app_session.version %>
               </.labeled_text>
             </div>
-            <div class="border-t border-gray-200 px-3 py-2 flex space-x-2 justify-between">
+            <div class="border-t border-gray-200 px-3 py-2 flex space-x-2">
+              <span class="tooltip top" data-tooltip="Open">
+                <a
+                  class={[
+                    "icon-button",
+                    not Livebook.Session.Data.app_active?(app_session.app_status) && "disabled"
+                  ]}
+                  aria-label="open app"
+                  href={~p"/apps/#{@app.slug}/#{app_session.id}"}
+                >
+                  <.remix_icon icon="link" class="text-lg" />
+                </a>
+              </span>
+              <div class="grow" />
               <span class="tooltip top" data-tooltip="Debug">
-                <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{app.session_id}"}>
+                <a class="icon-button" aria-label="debug app" href={~p"/sessions/#{app_session.id}"}>
                   <.remix_icon icon="terminal-line" class="text-lg" />
                 </a>
               </span>
-              <%= if app.registered do %>
-                <span class="tooltip top" data-tooltip="Stop">
-                  <button
-                    class="icon-button"
-                    aria-label="stop app"
-                    phx-click={
-                      JS.push("stop_app", value: %{session_id: app.session_id}, target: @myself)
-                    }
-                  >
-                    <.remix_icon icon="stop-circle-line" class="text-lg" />
-                  </button>
-                </span>
-              <% else %>
+              <%= if app_session.app_status in [:deactivated, :shutting_down] do %>
                 <span class="tooltip top" data-tooltip="Terminate">
                   <button
                     class="icon-button"
-                    aria-label="terminate app"
+                    aria-label="terminate app session"
                     phx-click={
-                      JS.push("terminate_app", value: %{session_id: app.session_id}, target: @myself)
+                      JS.push("terminate_app_session",
+                        value: %{session_id: app_session.id},
+                        target: @myself
+                      )
                     }
                   >
                     <.remix_icon icon="delete-bin-6-line" class="text-lg" />
+                  </button>
+                </span>
+              <% else %>
+                <span class="tooltip top" data-tooltip="Deactivate">
+                  <button
+                    class="icon-button"
+                    aria-label="deactivate app session"
+                    phx-click={
+                      JS.push("deactivate_app_session",
+                        value: %{session_id: app_session.id},
+                        target: @myself
+                      )
+                    }
+                  >
+                    <.remix_icon icon="stop-circle-line" class="text-lg" />
                   </button>
                 </span>
               <% end %>
@@ -126,7 +166,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
     """
   end
 
-  defp app_form(%{session: %{app_info: %{}}} = assigns) do
+  defp app_form(%{session: %{mode: :app}} = assigns) do
     ~H"""
     <div class="mt-5 flex flex-col space-y-6">
       <span class="text-gray-700 text-sm">
@@ -146,7 +186,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
     ~H"""
     <div class="mt-5">
       <span class="text-gray-700 text-sm">
-        Another app is already running under this slug, do you want to replace it?
+        An app with this slug already exists, do you want to deploy a new version?
       </span>
       <div class="mt-5 flex space-x-2">
         <button
@@ -186,6 +226,28 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
           phx-debounce
           class="bg-gray-100"
         />
+        <.radio_button_group_field
+          field={f[:multi_session]}
+          options={[{"false", "Single-session"}, {"true", "Multi-session"}]}
+          full_width
+        />
+        <.select_field
+          field={f[:auto_shutdown_type]}
+          label="Auto shutdown"
+          options={[
+            {"Never", "never"},
+            {"No users", "inactive_5s"},
+            {"No users for 1 minute", "inactive_1m"},
+            {"No users for 1 hour", "inactive_1h"},
+            {"New version", "new_version"}
+          ]}
+        />
+        <%= unless Ecto.Changeset.get_field(@changeset, :multi_session) do %>
+          <.checkbox_field field={f[:zero_downtime]} label="Zero-downtime deployment" />
+        <% end %>
+        <%= if Ecto.Changeset.get_field(@changeset, :multi_session) do %>
+          <.checkbox_field field={f[:auto_session_startup]} label="Start sessions automatically" />
+        <% end %>
         <div class="flex flex-col space-y-1">
           <.checkbox_field
             field={f[:access_type]}
@@ -241,7 +303,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
       {:ok, settings} ->
         Livebook.Session.set_app_settings(socket.assigns.session.pid, settings)
 
-        if slug_taken?(settings.slug, socket.assigns.apps) do
+        if slug_taken?(settings.slug, socket.assigns.deployed_app_slug) do
           {:noreply, assign(socket, deploy_confirmation: true)}
         else
           Livebook.Session.deploy_app(socket.assigns.session.pid)
@@ -262,24 +324,23 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
     {:noreply, assign(socket, deploy_confirmation: false)}
   end
 
-  def handle_event("terminate_app", %{"session_id" => session_id}, socket) do
-    app = Enum.find(socket.assigns.apps, &(&1.session_id == session_id))
-    Livebook.Session.close(app.session_pid)
+  def handle_event("terminate_app", %{}, socket) do
+    {:noreply, confirm_app_termination(socket, socket.assigns.app.pid)}
+  end
+
+  def handle_event("terminate_app_session", %{"session_id" => session_id}, socket) do
+    app_session = Enum.find(socket.assigns.app.sessions, &(&1.id == session_id))
+    Livebook.Session.close(app_session.pid)
     {:noreply, socket}
   end
 
-  def handle_event("stop_app", %{"session_id" => session_id}, socket) do
-    app = Enum.find(socket.assigns.apps, &(&1.session_id == session_id))
-    Livebook.Session.app_stop(app.session_pid)
+  def handle_event("deactivate_app_session", %{"session_id" => session_id}, socket) do
+    app_session = Enum.find(socket.assigns.app.sessions, &(&1.id == session_id))
+    Livebook.Session.app_deactivate(app_session.pid)
     {:noreply, socket}
   end
 
-  defp slug_taken?(slug, apps) do
-    own? =
-      Enum.any?(apps, fn app ->
-        app.registered and app.settings.slug == slug
-      end)
-
-    not own? and Livebook.Apps.exists?(slug)
+  defp slug_taken?(slug, deployed_app_slug) do
+    slug != deployed_app_slug and Livebook.Apps.exists?(slug)
   end
 end

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -56,6 +56,9 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
             <.labeled_text label="Version" one_line>
               v<%= @app.version %>
             </.labeled_text>
+            <.labeled_text label="Session type" one_line>
+              <%= if(@app.multi_session, do: "Multi", else: "Single") %>
+            </.labeled_text>
           </div>
           <div class="border-t border-gray-200 px-3 py-2 flex space-x-2">
             <div class="grow" />
@@ -228,25 +231,25 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
         />
         <.radio_button_group_field
           field={f[:multi_session]}
-          options={[{"false", "Single-session"}, {"true", "Multi-session"}]}
+          options={[{"false", "Single"}, {"true", "Multi"}]}
+          label="Session type"
           full_width
         />
         <.select_field
-          field={f[:auto_shutdown_type]}
-          label="Auto shutdown"
+          field={f[:auto_shutdown_ms]}
+          label="Shutdown after inactivity"
           options={[
-            {"Never", "never"},
-            {"No users", "inactive_5s"},
-            {"No users for 1 minute", "inactive_1m"},
-            {"No users for 1 hour", "inactive_1h"},
-            {"New version", "new_version"}
+            {"Never", ""},
+            {"5 seconds", "5000"},
+            {"1 minute", "60000"},
+            {"1 hour", "3600000"}
           ]}
         />
         <%= unless Ecto.Changeset.get_field(@changeset, :multi_session) do %>
           <.checkbox_field field={f[:zero_downtime]} label="Zero-downtime deployment" />
         <% end %>
         <%= if Ecto.Changeset.get_field(@changeset, :multi_session) do %>
-          <.checkbox_field field={f[:auto_session_startup]} label="Start sessions automatically" />
+          <.checkbox_field field={f[:show_existing_sessions]} label="List existing sessions" />
         <% end %>
         <div class="flex flex-col space-y-1">
           <.checkbox_field
@@ -260,10 +263,11 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
           <% end %>
         </div>
         <.checkbox_field field={f[:show_source]} label="Show source" />
-        <.radio_field
+        <.checkbox_field
           field={f[:output_type]}
-          label="Output type"
-          options={[{"all", "All"}, {"rich", "Rich only"}]}
+          label="Only render rich outputs"
+          checked_value="rich"
+          unchecked_value="all"
         />
       </div>
       <div class="mt-6 flex space-x-2">

--- a/lib/livebook_web/live/session_live/bin_component.ex
+++ b/lib/livebook_web/live/session_live/bin_component.ex
@@ -101,7 +101,7 @@ defmodule LivebookWeb.SessionLive.BinComponent do
                   </div>
                   <div class="flex justify-end space-x-2">
                     <span class="text-sm text-gray-500">
-                      <%= format_date_relatively(entry.deleted_at) %>
+                      <%= format_datetime_relatively(entry.deleted_at) %> ago
                     </span>
                   </div>
                 </div>
@@ -187,11 +187,6 @@ defmodule LivebookWeb.SessionLive.BinComponent do
   defp cell_language(%Cell.Markdown{}), do: "markdown"
   defp cell_language(%Cell.Code{}), do: "elixir"
   defp cell_language(%Cell.Smart{}), do: "elixir"
-
-  defp format_date_relatively(date) do
-    time_words = date |> DateTime.to_naive() |> Livebook.Utils.Time.time_ago_in_words()
-    time_words <> " ago"
-  end
 
   @impl true
   def handle_event("search", %{"search" => search}, socket) do

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -114,7 +114,9 @@ defmodule LivebookWeb.Router do
 
       live "/apps/:slug", AppLive, :page
       live "/apps/:slug/authenticate", AppAuthLive, :page
-      live "/apps/:slug/source", AppLive, :source
+
+      live "/apps/:slug/:id", AppSessionLive, :page
+      live "/apps/:slug/:id/source", AppSessionLive, :source
     end
   end
 

--- a/test/livebook/app_test.exs
+++ b/test/livebook/app_test.exs
@@ -1,0 +1,266 @@
+defmodule Livebook.AppTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.{App, Notebook, Utils}
+
+  describe "start_link/1" do
+    test "eagerly starts a session in single-session mode" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      assert {:ok, app_pid} = App.start_link(notebook: notebook)
+      assert %{sessions: [%{pid: session_pid}]} = App.get_by_pid(app_pid)
+
+      assert %{mode: :app} = Livebook.Session.get_by_pid(session_pid)
+    end
+
+    test "does not eagerly start session given auto shutdown on inactivity" do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          auto_shutdown_type: :inactive_5s
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      assert {:ok, app_pid} = App.start_link(notebook: notebook)
+      assert %{sessions: []} = App.get_by_pid(app_pid)
+    end
+
+    test "does not eagerly start session in multi-session mode" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      assert {:ok, app_pid} = App.start_link(notebook: notebook)
+      assert %{sessions: []} = App.get_by_pid(app_pid)
+    end
+  end
+
+  describe "deploy/2" do
+    test "updates app version and reflects new notebook name" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      App.deploy(app_pid, %{notebook | name: "New name"})
+      assert %{version: 2, notebook_name: "New name"} = App.get_by_pid(app_pid)
+    end
+
+    test "keeps old sessions when auto shutdown is set to never" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, auto_shutdown_type: :never}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      App.subscribe(slug)
+
+      App.deploy(app_pid, notebook)
+
+      assert_receive {:app_updated,
+                      %{
+                        sessions: [
+                          %{app_status: :executed, version: 2},
+                          %{app_status: :executed, version: 1}
+                        ]
+                      }}
+    end
+
+    test "shuts down old sessions when auto shutdown is set to new version" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, auto_shutdown_type: :new_version}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      App.subscribe(slug)
+
+      app_pid = start_app(notebook)
+      assert_receive {:app_updated, %{sessions: [%{app_status: :executed, version: 1}]}}
+
+      App.deploy(app_pid, notebook)
+
+      assert_receive {:app_updated, %{sessions: [%{app_status: :executing, version: 2}]}}
+      assert_receive {:app_updated, %{sessions: [%{app_status: :executed, version: 2}]}}
+    end
+
+    test "keeps old executed session during single-session zero-downtime deployment" do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          auto_shutdown_type: :new_version,
+          zero_downtime: true
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      App.subscribe(slug)
+
+      app_pid = start_app(notebook)
+      assert_receive {:app_updated, %{sessions: [%{app_status: :executed, version: 1}]}}
+
+      App.deploy(app_pid, notebook)
+
+      assert_receive {:app_updated,
+                      %{
+                        sessions: [
+                          %{app_status: :executing, version: 2},
+                          %{app_status: :executed, version: 1}
+                        ]
+                      }}
+
+      assert_receive {:app_updated, %{sessions: [%{app_status: :executed, version: 2}]}}
+    end
+  end
+
+  describe "get_session_id/1" do
+    test "starts a new session if none in single-session mode" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, auto_shutdown_type: :inactive_5s}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      assert %{sessions: []} = App.get_by_pid(app_pid)
+
+      session_id = App.get_session_id(app_pid)
+      assert ^session_id = App.get_session_id(app_pid)
+
+      assert %{sessions: [%{id: ^session_id}]} = App.get_by_pid(app_pid)
+    end
+
+    test "returns an executed session if possible in single-session mode with zero-downtime deployment" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, zero_downtime: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      App.subscribe(slug)
+
+      app_pid = start_app(notebook)
+      assert_receive {:app_updated, %{sessions: [%{id: session_id1, app_status: :executed}]}}
+
+      App.deploy(app_pid, notebook)
+
+      assert_receive {:app_updated,
+                      %{
+                        sessions: [
+                          %{id: session_id2, app_status: :executing},
+                          %{id: ^session_id1, app_status: :executed}
+                        ]
+                      }}
+
+      assert ^session_id1 = App.get_session_id(app_pid)
+
+      assert_receive {:app_updated, %{sessions: [%{id: ^session_id2, app_status: :executed}]}}
+      assert ^session_id2 = App.get_session_id(app_pid)
+    end
+
+    test "starts a new session in multi-session mode" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      assert %{sessions: []} = App.get_by_pid(app_pid)
+
+      session_id1 = App.get_session_id(app_pid)
+      session_id2 = App.get_session_id(app_pid)
+
+      assert %{sessions: [%{id: ^session_id2}, %{id: ^session_id1}]} = App.get_by_pid(app_pid)
+    end
+  end
+
+  describe "automatic shutdown" do
+    test "shuts down sessions on inactivity when configured to" do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          multi_session: true,
+          auto_shutdown_type: :inactive_5s
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      App.subscribe(slug)
+
+      session_id = App.get_session_id(app_pid)
+      assert_receive {:app_updated, %{sessions: [%{id: ^session_id}]}}
+
+      # Should close in 50ms
+      assert_receive {:app_updated, %{sessions: []}}, 70
+    end
+
+    test "does not count inactivity while there are connected clients" do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          multi_session: true,
+          auto_shutdown_type: :inactive_5s
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      App.subscribe(slug)
+
+      session_id = App.get_session_id(app_pid)
+      assert_receive {:app_updated, %{sessions: [%{id: ^session_id, pid: session_pid}]}}
+
+      client_pid = spawn_link(fn -> receive do: (:stop -> :ok) end)
+      user = Livebook.Users.User.new()
+      {_, _client_id} = Livebook.Session.register_client(session_pid, client_pid, user)
+
+      refute_receive {:app_updated, %{sessions: []}}, 70
+      send(client_pid, :stop)
+      assert_receive {:app_updated, %{sessions: []}}, 70
+    end
+
+    test "reschedules inactivity timers when a new auto shutdown type is deployed" do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          multi_session: true,
+          auto_shutdown_type: :never
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      app_pid = start_app(notebook)
+
+      App.subscribe(slug)
+
+      session_id = App.get_session_id(app_pid)
+      assert_receive {:app_updated, %{sessions: [%{id: ^session_id}]}}
+
+      Process.sleep(50)
+
+      notebook = put_in(notebook.app_settings.auto_shutdown_type, :inactive_5s)
+      App.deploy(app_pid, notebook)
+
+      # It's been 50ms of inactivity, so the session should be closed right away
+      assert_receive {:app_updated, %{sessions: []}}, 10
+    end
+  end
+
+  defp start_app(notebook) do
+    auto_shutdown_inactivity_ms = %{inactive_5s: 50, inactive_1m: 70_000, inactive_1h: 3700_000}
+    opts = [notebook: notebook, auto_shutdown_inactivity_ms: auto_shutdown_inactivity_ms]
+    start_supervised!({App, opts})
+  end
+end

--- a/test/livebook/apps_test.exs
+++ b/test/livebook/apps_test.exs
@@ -21,23 +21,18 @@ defmodule Livebook.AppsTest do
       # App 2
       """)
 
-      Livebook.Sessions.subscribe()
+      Livebook.Apps.subscribe()
 
       Livebook.Apps.deploy_apps_in_dir(tmp_dir)
 
-      assert_receive {:session_created, %{app_info: %{slug: "app1"}}}
+      assert_receive {:app_created, %{slug: "app1"} = app1}
+      assert_receive {:app_updated, %{slug: "app1", sessions: [%{app_status: :executed}]}}
 
-      assert_receive {:session_updated,
-                      %{app_info: %{slug: "app1", status: :running, registered: true}} =
-                        app1_session}
+      assert_receive {:app_created, %{slug: "app2"} = app2}
+      assert_receive {:app_updated, %{slug: "app2", sessions: [%{app_status: :executed}]}}
 
-      assert_receive {:session_created, %{app_info: %{slug: "app2"}}}
-
-      assert_receive {:session_updated,
-                      %{app_info: %{slug: "app2", status: :running, registered: true}} =
-                        app2_session}
-
-      Livebook.Session.close([app1_session.pid, app2_session.pid])
+      Livebook.App.close(app1.pid)
+      Livebook.App.close(app2.pid)
     end
 
     @tag :tmp_dir
@@ -63,14 +58,15 @@ defmodule Livebook.AppsTest do
       # App
       """)
 
-      Livebook.Sessions.subscribe()
+      Livebook.Apps.subscribe()
 
       Livebook.Apps.deploy_apps_in_dir(tmp_dir, password: "verylongpass")
 
-      assert_receive {:session_created, %{app_info: %{slug: "app"}} = session}
+      assert_receive {:app_created, %{slug: "app"} = app}
 
-      %{access_type: :protected, password: "verylongpass"} =
-        Livebook.Session.get_app_settings(session.pid)
+      %{access_type: :protected, password: "verylongpass"} = Livebook.App.get_settings(app.pid)
+
+      Livebook.App.close(app.pid)
     end
   end
 end

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1149,6 +1149,10 @@ defmodule Livebook.LiveMarkdown.ExportTest do
           app_settings: %{
             Notebook.AppSettings.new()
             | slug: "app",
+              multi_session: true,
+              zero_downtime: false,
+              auto_session_startup: true,
+              auto_shutdown_type: :inactive_1h,
               access_type: :public,
               show_source: true,
               output_type: :rich
@@ -1156,7 +1160,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       }
 
       expected_document = """
-      <!-- livebook:{"app_settings":{"access_type":"public","output_type":"rich","show_source":true,"slug":"app"}} -->
+      <!-- livebook:{"app_settings":{"access_type":"public","auto_session_startup":true,"auto_shutdown_type":"inactive_1h","multi_session":true,"output_type":"rich","show_source":true,"slug":"app"}} -->
 
       # My Notebook
       """

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1151,8 +1151,8 @@ defmodule Livebook.LiveMarkdown.ExportTest do
             | slug: "app",
               multi_session: true,
               zero_downtime: false,
-              auto_session_startup: true,
-              auto_shutdown_type: :inactive_1h,
+              show_existing_sessions: false,
+              auto_shutdown_ms: 5_000,
               access_type: :public,
               show_source: true,
               output_type: :rich
@@ -1160,7 +1160,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       }
 
       expected_document = """
-      <!-- livebook:{"app_settings":{"access_type":"public","auto_session_startup":true,"auto_shutdown_type":"inactive_1h","multi_session":true,"output_type":"rich","show_source":true,"slug":"app"}} -->
+      <!-- livebook:{"app_settings":{"access_type":"public","auto_shutdown_ms":5000,"multi_session":true,"output_type":"rich","show_existing_sessions":false,"show_source":true,"slug":"app"}} -->
 
       # My Notebook
       """

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -750,7 +750,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
   describe "app settings" do
     test "imports settings" do
       markdown = """
-      <!-- livebook:{"app_settings":{"access_type":"public","output_type":"rich","show_source":true,"slug":"app"}} -->
+      <!-- livebook:{"app_settings":{"access_type":"public","auto_session_startup":true,"auto_shutdown_type":"inactive_1h","multi_session":true,"output_type":"rich","show_source":true,"slug":"app"}} -->
 
       # My Notebook
       """
@@ -761,6 +761,10 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                name: "My Notebook",
                app_settings: %{
                  slug: "app",
+                 multi_session: true,
+                 zero_downtime: false,
+                 auto_session_startup: true,
+                 auto_shutdown_type: :inactive_1h,
                  access_type: :public,
                  show_source: true,
                  output_type: :rich

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -750,7 +750,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
   describe "app settings" do
     test "imports settings" do
       markdown = """
-      <!-- livebook:{"app_settings":{"access_type":"public","auto_session_startup":true,"auto_shutdown_type":"inactive_1h","multi_session":true,"output_type":"rich","show_source":true,"slug":"app"}} -->
+      <!-- livebook:{"app_settings":{"access_type":"public","auto_shutdown_ms":5000,"multi_session":true,"output_type":"rich","show_existing_sessions":false,"show_source":true,"slug":"app"}} -->
 
       # My Notebook
       """
@@ -763,8 +763,8 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  slug: "app",
                  multi_session: true,
                  zero_downtime: false,
-                 auto_session_startup: true,
-                 auto_shutdown_type: :inactive_1h,
+                 show_existing_sessions: false,
+                 auto_shutdown_ms: 5_000,
                  access_type: :public,
                  show_source: true,
                  output_type: :rich

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -1,38 +1,117 @@
 defmodule LivebookWeb.AppLiveTest do
   use LivebookWeb.ConnCase, async: true
 
-  import Livebook.SessionHelpers
   import Phoenix.LiveViewTest
 
-  alias Livebook.Session
+  alias Livebook.{App, Apps, Notebook, Utils}
 
-  test "renders only rich output when output type is rich", %{conn: conn} do
-    session = start_session()
+  describe "single-session app" do
+    test "redirects to the current session page", %{conn: conn} do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: false}
+      notebook = %{Notebook.new() | app_settings: app_settings}
 
-    Session.subscribe(session.id)
+      Apps.subscribe()
+      {:ok, app_pid} = Apps.deploy(notebook)
 
-    slug = Livebook.Utils.random_short_id()
-    app_settings = %{Livebook.Notebook.AppSettings.new() | slug: slug, output_type: :rich}
-    Session.set_app_settings(session.pid, app_settings)
+      assert_receive {:app_created, %{pid: ^app_pid, sessions: [%{id: session_id}]}}
 
-    section_id = insert_section(session.pid)
-    insert_cell_with_output(session.pid, section_id, {:stdout, "Printed output"})
-    insert_cell_with_output(session.pid, section_id, {:plain_text, "Custom text"})
+      {:error, {:live_redirect, %{to: to}}} = live(conn, ~p"/apps/#{slug}")
+      assert to == ~p"/apps/#{slug}/#{session_id}"
 
-    Session.deploy_app(session.pid)
-
-    assert_receive {:operation, {:add_app, _, _, _}}
-    assert_receive {:operation, {:set_app_registered, _, _, true}}
-
-    {:ok, view, _} = live(conn, ~p"/apps/#{slug}")
-
-    refute render(view) =~ "Printed output"
-    assert render(view) =~ "Custom text"
+      App.close(app_pid)
+    end
   end
 
-  defp start_session() do
-    {:ok, session} = Livebook.Sessions.create_session()
-    on_exit(fn -> Session.close(session.pid) end)
-    session
+  describe "multi-session app" do
+    test "renders a list of active app sessions", %{conn: conn} do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      Apps.subscribe()
+      {:ok, app_pid} = Apps.deploy(notebook)
+
+      assert_receive {:app_created, %{pid: ^app_pid, sessions: []}}
+
+      session_id1 = App.get_session_id(app_pid)
+      session_id2 = App.get_session_id(app_pid)
+
+      assert_receive {:app_updated,
+                      %{pid: ^app_pid, sessions: [%{id: ^session_id2, pid: session_pid2}, _]}}
+
+      Livebook.Session.app_deactivate(session_pid2)
+
+      {:ok, view, _} = live(conn, ~p"/apps/#{slug}")
+
+      assert render(view) =~ ~p"/apps/#{slug}/#{session_id1}"
+      refute render(view) =~ ~p"/apps/#{slug}/#{session_id2}"
+
+      # Create a new app session
+      session_id3 = App.get_session_id(app_pid)
+
+      assert_receive {:app_updated,
+                      %{pid: ^app_pid, sessions: [%{id: ^session_id3, pid: session_pid3}, _, _]}}
+
+      assert render(view) =~ ~p"/apps/#{slug}/#{session_id3}"
+
+      # Deactivate the app session
+      Livebook.Session.app_deactivate(session_pid3)
+
+      assert_receive {:app_updated,
+                      %{pid: ^app_pid, sessions: [%{app_status: :deactivated}, _, _]}}
+
+      refute render(view) =~ ~p"/apps/#{slug}/#{session_id3}"
+
+      App.close(app_pid)
+    end
+
+    test "creating a new session", %{conn: conn} do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      Apps.subscribe()
+      {:ok, app_pid} = Apps.deploy(notebook)
+
+      assert_receive {:app_created, %{pid: ^app_pid, sessions: []}}
+
+      {:ok, view, _} = live(conn, ~p"/apps/#{slug}")
+
+      {:error, {:live_redirect, %{to: to}}} =
+        view
+        |> element("button", "New session")
+        |> render_click()
+
+      assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{id: session_id}]}}
+
+      assert to == ~p"/apps/#{slug}/#{session_id}"
+
+      App.close(app_pid)
+    end
+
+    test "redirects to a new session page if automatic session startup is enabled", %{conn: conn} do
+      slug = Utils.random_short_id()
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          multi_session: true,
+          auto_session_startup: true
+      }
+
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      Apps.subscribe()
+      {:ok, app_pid} = Apps.deploy(notebook)
+
+      assert_receive {:app_created, %{pid: ^app_pid, sessions: []}}
+
+      {:error, {:live_redirect, %{to: to}}} = live(conn, ~p"/apps/#{slug}")
+      assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{id: session_id}]}}
+      assert to == ~p"/apps/#{slug}/#{session_id}"
+
+      App.close(app_pid)
+    end
   end
 end

--- a/test/livebook_web/live/app_session_live_test.exs
+++ b/test/livebook_web/live/app_session_live_test.exs
@@ -1,0 +1,106 @@
+defmodule LivebookWeb.AppSessionLiveTest do
+  use LivebookWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Livebook.TestHelpers
+
+  alias Livebook.{App, Apps, Notebook, Utils}
+
+  test "shows a nonexisting message if the session does not exist", %{conn: conn} do
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings}
+
+    {:ok, app_pid} = Apps.deploy(notebook)
+
+    {:ok, view, _} = live(conn, ~p"/apps/#{slug}/nonexistent")
+    assert render(view) =~ "This app session does not exist"
+    assert render(view) =~ ~p"/apps/#{slug}"
+
+    App.close(app_pid)
+  end
+
+  test "shows a nonexisting message if the session is deactivated", %{conn: conn} do
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings}
+
+    Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
+
+    assert_receive {:app_created, %{pid: ^app_pid}}
+
+    assert_receive {:app_updated,
+                    %{pid: ^app_pid, sessions: [%{id: session_id, pid: session_pid}]}}
+
+    Livebook.Session.app_deactivate(session_pid)
+    assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{app_status: :deactivated}]}}
+
+    {:ok, view, _} = live(conn, ~p"/apps/#{slug}/#{session_id}")
+    assert render(view) =~ "This app session does not exist"
+    assert render(view) =~ ~p"/apps/#{slug}"
+
+    App.close(app_pid)
+  end
+
+  test "redirects to homepage if the session gets deactivated", %{conn: conn} do
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings}
+
+    Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
+
+    assert_receive {:app_created, %{pid: ^app_pid}}
+
+    assert_receive {:app_updated,
+                    %{pid: ^app_pid, sessions: [%{id: session_id, pid: session_pid}]}}
+
+    {:ok, view, _} = live(conn, ~p"/apps/#{slug}/#{session_id}")
+
+    Livebook.Session.app_deactivate(session_pid)
+
+    flash = assert_redirect(view, ~p"/")
+    assert flash["info"] == "Session has been closed"
+
+    App.close(app_pid)
+  end
+
+  test "renders only rich output when output type is rich", %{conn: conn} do
+    slug = Livebook.Utils.random_short_id()
+    app_settings = %{Livebook.Notebook.AppSettings.new() | slug: slug, output_type: :rich}
+
+    notebook = %{
+      Livebook.Notebook.new()
+      | app_settings: app_settings,
+        sections: [
+          %{
+            Livebook.Notebook.Section.new()
+            | cells: [
+                %{
+                  Livebook.Notebook.Cell.new(:code)
+                  | source: source_for_output({:stdout, "Printed output"})
+                },
+                %{
+                  Livebook.Notebook.Cell.new(:code)
+                  | source: source_for_output({:plain_text, "Custom text"})
+                }
+              ]
+          }
+        ]
+    }
+
+    Livebook.Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
+
+    assert_receive {:app_created, %{pid: ^app_pid} = app}
+    assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{app_status: :executed}]}}
+
+    {:ok, view, _} = conn |> live(~p"/apps/#{slug}") |> follow_redirect(conn)
+
+    refute render(view) =~ "Printed output"
+    assert render(view) =~ "Custom text"
+
+    Livebook.App.close(app.pid)
+  end
+end

--- a/test/livebook_web/live/apps_live_test.exs
+++ b/test/livebook_web/live/apps_live_test.exs
@@ -2,74 +2,77 @@ defmodule LivebookWeb.AppsLiveTest do
   use LivebookWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
+  import Livebook.TestHelpers
 
-  alias Livebook.{Session, Sessions}
+  alias Livebook.{App, Apps, Notebook, Utils}
 
   test "updates UI when app is deployed and terminated", %{conn: conn} do
-    session = start_session()
-
-    Sessions.subscribe()
-
-    slug = Livebook.Utils.random_short_id()
-    app_settings = %{Livebook.Notebook.AppSettings.new() | slug: slug}
-    Session.set_app_settings(session.pid, app_settings)
-
-    Session.set_notebook_name(session.pid, "My app #{slug}")
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings, name: "My app #{slug}"}
 
     {:ok, view, _} = live(conn, ~p"/apps")
 
     refute render(view) =~ slug
 
-    Session.deploy_app(session.pid)
+    Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
 
-    assert_receive {:session_created, %{app_info: %{slug: ^slug}}}
+    assert_receive {:app_created, %{pid: ^app_pid}}
     assert render(view) =~ "My app #{slug}"
 
-    assert_receive {:session_updated, %{app_info: %{slug: ^slug, registered: true}} = app_session}
-    assert render(view) =~ ~p"/apps/#{slug}"
+    App.close(app_pid)
 
-    Session.app_unregistered(app_session.pid)
-
-    assert_receive {:session_closed, %{app_info: %{slug: ^slug}}}
+    assert_receive {:app_closed, %{pid: ^app_pid}}
     refute render(view) =~ slug
   end
 
   test "terminating an app", %{conn: conn} do
-    session = start_session()
-
-    Sessions.subscribe()
-
-    slug = Livebook.Utils.random_short_id()
-    app_settings = %{Livebook.Notebook.AppSettings.new() | slug: slug}
-    Session.set_app_settings(session.pid, app_settings)
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings, name: "My app #{slug}"}
 
     {:ok, view, _} = live(conn, ~p"/apps")
 
-    Session.deploy_app(session.pid)
-    assert_receive {:session_created, %{app_info: %{slug: ^slug}}}
+    Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
 
-    assert_receive {:session_updated,
-                    %{app_info: %{slug: ^slug, status: :running, registered: true}}}
-
-    view
-    |> element(~s/[data-app-slug="#{slug}"] button[aria-label="stop app"]/)
-    |> render_click()
-
-    assert_receive {:session_updated,
-                    %{app_info: %{slug: ^slug, status: :stopped, registered: false}}}
+    assert_receive {:app_created, %{pid: ^app_pid}}
 
     view
     |> element(~s/[data-app-slug="#{slug}"] button[aria-label="terminate app"]/)
     |> render_click()
 
-    assert_receive {:session_closed, %{app_info: %{slug: ^slug}}}
+    render_confirm(view)
 
-    refute render(view) =~ slug
+    assert_receive {:app_closed, %{pid: ^app_pid}}
   end
 
-  defp start_session() do
-    {:ok, session} = Livebook.Sessions.create_session()
-    on_exit(fn -> Session.close(session.pid) end)
-    session
+  test "deactivating and terminating an app session", %{conn: conn} do
+    slug = Utils.random_short_id()
+    app_settings = %{Notebook.AppSettings.new() | slug: slug}
+    notebook = %{Notebook.new() | app_settings: app_settings, name: "My app #{slug}"}
+
+    {:ok, view, _} = live(conn, ~p"/apps")
+
+    Apps.subscribe()
+    {:ok, app_pid} = Apps.deploy(notebook)
+
+    assert_receive {:app_created, %{pid: ^app_pid}}
+    assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{app_status: :executed}]}}
+
+    view
+    |> element(~s/[data-app-slug="#{slug}"] button[aria-label="deactivate app session"]/)
+    |> render_click()
+
+    assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{app_status: :deactivated}]}}
+
+    view
+    |> element(~s/[data-app-slug="#{slug}"] button[aria-label="terminate app session"]/)
+    |> render_click()
+
+    assert_receive {:app_updated, %{pid: ^app_pid, sessions: []}}
+
+    App.close(app_pid)
   end
 end

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -150,15 +150,17 @@ defmodule LivebookWeb.HomeLiveTest do
 
       {:ok, view, _} = live(conn, ~p"/")
 
+      Livebook.NotebookManager.subscribe_starred_notebooks()
+
       Livebook.NotebookManager.add_starred_notebook(file, "Special notebook")
-      render(view)
+      assert_receive {:starred_notebooks_updated, _}
 
       assert view
              |> element(~s/#starred-notebooks/, "Special notebook")
              |> has_element?()
 
       Livebook.NotebookManager.remove_starred_notebook(file)
-      render(view)
+      assert_receive {:starred_notebooks_updated, _}
 
       refute view
              |> element(~s/#starred-notebooks/, "Special notebook")

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -56,4 +56,17 @@ defmodule Livebook.TestHelpers do
     |> element(~s/[data-el-confirm-form]/)
     |> render_submit()
   end
+
+  @doc """
+  Builds code that renders the given output as part of evaluation.
+  """
+  def source_for_output(output) do
+    quote do
+      send(
+        Process.group_leader(),
+        {:io_request, self(), make_ref(), {:livebook_put_output, unquote(Macro.escape(output))}}
+      )
+    end
+    |> Macro.to_string()
+  end
 end


### PR DESCRIPTION
This adds a new multi-session mode when deploying an app. In that mode, multiple sessions (instantiations) of the app can be started by going to `/app/:slug` (depending on configuration, either by the clicking a button or automatically). Sessions can automatically be closed on inactivity (a period with no users).

<details>
<summary>

### User Interface

</summary>

#### Settings

<img width="400" alt="image" src="https://github.com/livebook-dev/livebook/assets/17034772/d207f4d4-411f-4c89-a426-dd8b20ab47ce">

<img width="400" alt="image" src="https://github.com/livebook-dev/livebook/assets/17034772/33b2dea1-4f4b-4ed4-ae40-3d5a780f2ae9">

#### Apps page

<img width="1512" alt="image" src="https://github.com/livebook-dev/livebook/assets/17034772/74e441f9-0fc6-4b98-b075-ccc1a329f2e5">

#### Multi-session app page

<img width="1512" alt="image" src="https://github.com/livebook-dev/livebook/assets/17034772/b0ff9efc-42cf-4d8e-857b-fae4a8789ce3">

</details> 

### Technical details

So far an app was coupled to a single session, registered using `:global` and managed ad-hoc. Now an app may exist without any sessions, so I separated the concerns.

Each app is identified by a slug and has a process responsible for starting/stopping sessions and tracking relevant information. App processes are registered using `Phoenix.Tracker`, the same way we do for session processes. When deploying a notebook, we check if the slug has an app process (a) if no, we start it; (b) if yes, we tell it to deploy the notebook as a new version.

The app process takes care of starting sessions when requested or eagerly (for single-instance apps) with optional zero-downtime deployment. It also takes care of closing the sessions depending on the configuration (a) never; (b) on inactivity; (c) when new version is deployed.