### PR TITLE
Add Tracer @type

### DIFF
--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -58,7 +58,7 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
   @doc """
   Flushes any buffered output and returns gathered metadata.
   """
-  @spec after_evaluation(pid()) :: %{tracer_info: %Evaluator.Tracer{}}
+  @spec after_evaluation(pid()) :: %{tracer_info: Evaluator.Tracer.t()}
   def after_evaluation(pid) do
     GenServer.call(pid, :after_evaluation)
   end

--- a/lib/livebook/runtime/evaluator/tracer.ex
+++ b/lib/livebook/runtime/evaluator/tracer.ex
@@ -19,6 +19,18 @@ defmodule Livebook.Runtime.Evaluator.Tracer do
             imports_defined?: false,
             undefined_vars: MapSet.new()
 
+  @type t :: %__MODULE__{
+          modules_used: MapSet.t(),
+          modules_defined: map(),
+          aliases_used: MapSet.t(),
+          aliases_defined: map(),
+          requires_used: MapSet.t(),
+          requires_defined: MapSet.t(),
+          imports_used?: boolean(),
+          imports_defined?: boolean(),
+          undefined_vars: MapSet.t()
+        }
+
   @doc false
   def trace(event, env) do
     case event_to_updates(event, env) do


### PR DESCRIPTION
I ran credo and I got this message. So I make Tracer type into `Tracer` module and fix `IOProxy.after_evaluation/1` spec.
How about you?

---
mix credo

  Livebook.Runtime.Evaluator.IOProxy                                                                                                      
┃ 
┃   [W] Category: warning 
┃    →  Priority: normal 
┃ 
┃       Struct %Evaluator.Tracer{} found in @spec
┃       lib/livebook/runtime/evaluator/io_proxy.ex:61 (Livebook.Runtime.Evaluator.IOProxy)
┃ 
┃    __ CODE IN QUESTION
┃ 
┃    59   Flushes any buffered output and returns gathered metadata.
┃    60   """
┃    61   @spec after_evaluation(pid()) :: %{tracer_info: %Evaluator.Tracer{}}
┃    62   def after_evaluation(pid) do
┃    63     GenServer.call(pid, :after_evaluation)
┃       
┃    __ WHY IT MATTERS
┃ 
┃       Structs create compile-time dependencies between modules.  Using a struct in a spec
┃       will cause the module to be recompiled whenever the struct's module changes.
┃       
┃       It is preferable to define and use `MyModule.t()` instead of `%MyModule{}` in specs.
┃       
┃       Example:
┃       
┃           # preferred
┃           @spec a_function(MyModule.t()) :: any
┃       
┃           # NOT preferred
┃           @spec a_function(%MyModule{}) :: any
┃ 
┃    __ CONFIGURATION OPTIONS
┃ 
┃       You can disable this check by using this tuple
┃ 
┃         {Credo.Check.Warning.SpecWithStruct, false}
┃ 
┃       There are no other configuration options.
┃ 
