### PR TITLE
Fix lack of searchability in Spotlight

### DIFF
--- a/rel/app/macos/Info.plist
+++ b/rel/app/macos/Info.plist
@@ -10,6 +10,8 @@
   <string>$(app_version)</string>
   <key>CFBundleIconFile</key>
   <string>AppIcon</string>
+  <key>CFBundleExecutable</key>
+	<string>Livebook</string>
   <key>LSUIElement</key>
   <true/>
   <key>LSRequiresNativeExecution</key>


### PR DESCRIPTION
This fixes the lack of searchability in spotlight _however_ there is a nuance that I have yet to figure out (may require executable changes?) I'm not a MacOS native developer, so I'm not certain. 

Scenario: Livebook has not been opened
Spotlight -> Search Livebook -> Select the app
Result: Livebook creates the icon in the menu bar, opens Livebook in the browser
Desired: Works as expected

Scenario: Livebook has been opened, but the tab was closed (icon is in menu bar)
Spotlight -> Search Livebook -> Select the app
Result: Nothing happens
Desired: A new Livebook tab is opened in your browser