### PR TITLE
Fix opening up Livebook Desktop via Spotlight

### DIFF
--- a/rel/app/macos/Sources/Livebook/Livebook.swift
+++ b/rel/app/macos/Sources/Livebook/Livebook.swift
@@ -92,8 +92,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ElixirKit.API.stop()
     }
 
-    func applicationDidBecomeActive(_ aNotification: Notification) {
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         ElixirKit.API.publish("open", "")
+        return true
     }
 
     func application(_ app: NSApplication, open urls: [URL]) {


### PR DESCRIPTION
`applicationDidBecomeActive` was fired along with `application(_, open urls)` resulting in launching the browser twice.

From `applicationShouldHandleReopen` docs:

> These events are sent whenever the Finder reactivates an already running application because someone double-clicked it again or used the dock to activate it.

And this is more inline with what we want.

cc @BobbyMcWho 
