### PR TITLE
Doctest updates

### DIFF
--- a/assets/css/ansi.css
+++ b/assets/css/ansi.css
@@ -1,8 +1,8 @@
 /*
 Variables for HTML-ized ANSI string.
 
-Many colors are taken from the One Light theme
-to be consistent with the editor.
+Many colors are taken from the One Light and One Dark theme for
+consistency with the editor.
 */
 
 :root {
@@ -24,19 +24,21 @@ to be consistent with the editor.
   --ansi-color-light-white: white;
 }
 
-/* The same as above but brightned by 10% */
-[data-editor-theme="default"] {
-  --ansi-color-red: #dd1f53;
-  --ansi-color-green: #5ab756;
-  --ansi-color-yellow: #d9930b;
-  --ansi-color-blue: #4d8cfb;
-  --ansi-color-magenta: #b02fbb;
-  --ansi-color-cyan: #05a4d0;
-  --ansi-color-light-black: #676e7b;
-  --ansi-color-light-red: #f35c57;
-  --ansi-color-light-green: #42dcab;
-  --ansi-color-light-yellow: #fdea9a;
-  --ansi-color-light-blue: #77c0fc;
-  --ansi-color-light-magenta: #d181e5;
-  --ansi-color-light-cyan: #64ccda;
+body[data-editor-theme="default"] .editor-theme-aware-ansi {
+  --ansi-color-black: black;
+  --ansi-color-red: #be5046;
+  --ansi-color-green: #98c379;
+  --ansi-color-yellow: #e5c07b;
+  --ansi-color-blue: #61afef;
+  --ansi-color-magenta: #c678dd;
+  --ansi-color-cyan: #56b6c2;
+  --ansi-color-white: white;
+  --ansi-color-light-black: #5c6370;
+  --ansi-color-light-red: #e06c75;
+  --ansi-color-light-green: #34d399;
+  --ansi-color-light-yellow: #fde68a;
+  --ansi-color-light-blue: #93c5fd;
+  --ansi-color-light-magenta: #f472b6;
+  --ansi-color-light-cyan: #6be3f2;
+  --ansi-color-light-white: white;
 }

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -159,46 +159,50 @@ Also some spacing adjustments.
   transform: none;
 }
 
-/* To style circles for doctest results */
-.line-circle-red,
-.line-circle-green,
-.line-circle-grey {
+/* === Doctest status decoration === */
+
+.doctest-status-decoration-running,
+.doctest-status-decoration-success,
+.doctest-status-decoration-failed {
   height: 100%;
   position: relative;
 }
 
-.line-circle-red::after,
-.line-circle-green::after,
-.line-circle-grey::after {
+.doctest-status-decoration-running::after,
+.doctest-status-decoration-success::after,
+.doctest-status-decoration-failed::after {
   box-sizing: border-box;
   border-radius: 2px;
   content: "";
   display: block;
   height: 12px;
   width: 12px;
-  margin-left: 6px;
   position: absolute;
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
-.line-circle-red::after {
-  background-color: rgb(233 117 121);
+.doctest-status-decoration-running::after {
+  @apply bg-gray-400;
 }
 
-.line-circle-green::after {
-  background-color: rgb(74 222 128);
+.doctest-status-decoration-success::after {
+  @apply bg-green-bright-400;
 }
 
-.line-circle-grey::after {
-  background-color: rgb(97 117 138);
+.doctest-status-decoration-failed::after {
+  @apply bg-red-400;
 }
 
-.doctest-failure-overlay {
+/* === Doctest failure details === */
+
+.doctest-details-widget {
   @apply font-editor;
   white-space: pre;
   background-color: rgba(0, 0, 0, 0.05);
-  padding-left: calc(68px + 6ch);
+  padding-top: 6px;
+  padding-bottom: 6px;
   position: absolute;
   width: 100%;
 }

--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -248,19 +248,9 @@ const Cell = {
         });
 
         this.handleEvent(
-          `doctest_result:${this.props.cellId}`,
-          ({ state, column, line, end_line, contents }) => {
-            switch (state) {
-              case "evaluating":
-                liveEditor.addEvaluatingDoctest(line);
-                break;
-              case "success":
-                liveEditor.addSuccessDoctest(line);
-                break;
-              case "failed":
-                liveEditor.addFailedDoctest(column, line, end_line, contents);
-                break;
-            }
+          `doctest_report:${this.props.cellId}`,
+          (doctestReport) => {
+            liveEditor.updateDoctest(doctestReport);
           }
         );
       }

--- a/assets/js/hooks/cell_editor/live_editor/doctest.js
+++ b/assets/js/hooks/cell_editor/live_editor/doctest.js
@@ -1,0 +1,134 @@
+import monaco from "./monaco";
+
+/**
+ * Doctest visual indicators within the editor.
+ *
+ * Consists of a status widget and optional error details.
+ */
+export default class Doctest {
+  constructor(editor, doctestReport) {
+    this._editor = editor;
+
+    this._statusDecoration = new StatusDecoration(
+      editor,
+      doctestReport.line,
+      doctestReport.status
+    );
+
+    if (doctestReport.status === "failed") {
+      this._detailsWidget = new DetailsWidget(editor, doctestReport);
+    }
+  }
+
+  /**
+   * Updates doctest indicator.
+   */
+  update(doctestReport) {
+    this._statusDecoration.update(doctestReport.status);
+
+    if (doctestReport.status === "failed") {
+      this._detailsWidget && this._detailsWidget.dispose();
+      this._detailsWidget = new DetailsWidget(this._editor, doctestReport);
+    }
+  }
+
+  /**
+   * Performs necessary cleanup actions.
+   */
+  dispose() {
+    this._statusDecoration.dispose();
+    this._detailsWidget && this._detailsWidget.dispose();
+  }
+}
+
+class StatusDecoration {
+  constructor(editor, lineNumber, status) {
+    this._editor = editor;
+    this._lineNumber = lineNumber;
+    this._decorations = [];
+
+    this.update(status);
+  }
+
+  update(status) {
+    const newDecorations = [
+      {
+        range: new monaco.Range(this._lineNumber, 1, this._lineNumber, 1),
+        options: {
+          isWholeLine: true,
+          linesDecorationsClassName: `doctest-status-decoration-${status}`,
+        },
+      },
+    ];
+
+    this._decorations = this._editor.deltaDecorations(
+      this._decorations,
+      newDecorations
+    );
+  }
+
+  dispose() {
+    this._editor.deltaDecorations(this._decorations, []);
+  }
+}
+
+class DetailsWidget {
+  constructor(editor, doctestReport) {
+    this._editor = editor;
+
+    const { line, end_line, details, column } = doctestReport;
+    const detailsHtml = details.join("\n");
+    const numberOfLines = details.length;
+
+    const marginWidth = this._editor
+      .getDomNode()
+      .querySelector(".margin-view-overlays").offsetWidth;
+
+    const fontSize = this._editor.getOption(
+      monaco.editor.EditorOption.fontSize
+    );
+
+    const lineHeight = this._editor.getOption(
+      monaco.editor.EditorOption.lineHeight
+    );
+
+    const detailsNode = document.createElement("div");
+    detailsNode.innerHTML = detailsHtml;
+    detailsNode.classList.add(
+      "doctest-details-widget",
+      "editor-theme-aware-ansi"
+    );
+    detailsNode.style.fontSize = `${fontSize}px`;
+    detailsNode.style.paddingLeft = `calc(${marginWidth}px + ${column}ch)`;
+
+    this._overlayWidget = {
+      getId: () => `livebook.doctest.overlay.${line}`,
+      getDomNode: () => detailsNode,
+      getPosition: () => null,
+    };
+
+    this._editor.addOverlayWidget(this._overlayWidget);
+
+    this._editor.changeViewZones((changeAccessor) => {
+      this._viewZone = changeAccessor.addZone({
+        afterLineNumber: end_line,
+        // Placeholder for all lines and additional padding
+        heightInPx: numberOfLines * lineHeight + 12,
+        domNode: document.createElement("div"),
+        onDomNodeTop: (top) => {
+          detailsNode.style.top = `${top}px`;
+        },
+        onComputedHeight: (height) => {
+          detailsNode.style.height = `${height}px`;
+        },
+      });
+    });
+  }
+
+  dispose() {
+    this._editor.removeOverlayWidget(this._overlayWidget);
+    this._editor.changeViewZones((changeAccessor) => {
+      changeAccessor.removeZone(this._viewZone);
+    });
+  }
+}

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -93,6 +93,24 @@ defprotocol Livebook.Runtime do
         }
 
   @typedoc """
+  Includes information about a running or finished doctest.
+
+  Failed doctests have additional details formatted as a string.
+  """
+  @type doctest_report ::
+          %{
+            status: :running | :success,
+            line: pos_integer()
+          }
+          | %{
+              status: :failed,
+              column: pos_integer(),
+              line: pos_integer(),
+              end_line: pos_integer(),
+              details: String.t()
+            }
+
+  @typedoc """
   Recognised intellisense request.
   """
   @type intellisense_request ::
@@ -402,6 +420,13 @@ defprotocol Livebook.Runtime do
     * `{:runtime_container_down, container_ref, message}`
 
   to notify the owner.
+
+  ### Doctests
+
+  If the cell includes doctests, the runtime can evaluate them and
+  send reports as a message:
+
+    * `{:runtime_doctest_report, evaluation_ref, doctest_report}`
 
   ## Options
 

--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -240,6 +240,11 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
     {:ok, state}
   end
 
+  defp io_request({:livebook_doctest_report, doctest_report}, state) do
+    send(state.send_to, {:runtime_doctest_report, state.ref, doctest_report})
+    {:ok, state}
+  end
+
   defp io_request({:livebook_get_input_value, input_id}, state) do
     input_cache =
       Map.put_new_lazy(state.input_cache, input_id, fn ->

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1324,6 +1324,11 @@ defmodule Livebook.Session do
     {:noreply, state}
   end
 
+  def handle_info({:runtime_doctest_report, cell_id, doctest_report}, state) do
+    operation = {:add_cell_doctest_report, @client_id, cell_id, doctest_report}
+    {:noreply, handle_operation(state, operation)}
+  end
+
   def handle_info({:runtime_evaluation_output_to_clients, cell_id, output}, state) do
     operation = {:add_cell_evaluation_output, @client_id, cell_id, output}
     broadcast_operation(state.session_id, operation)

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -181,6 +181,7 @@ defmodule Livebook.Session.Data do
           | {:move_cell, client_id(), Cell.id(), offset :: integer()}
           | {:move_section, client_id(), Section.id(), offset :: integer()}
           | {:queue_cells_evaluation, client_id(), list(Cell.id())}
+          | {:add_cell_doctest_report, client_id(), Cell.id(), Runtime.doctest_report()}
           | {:add_cell_evaluation_output, client_id(), Cell.id(), term()}
           | {:add_cell_evaluation_response, client_id(), Cell.id(), term(), metadata :: map()}
           | {:bind_input, client_id(), code_cell_id :: Cell.id(), input_id()}
@@ -546,10 +547,7 @@ defmodule Livebook.Session.Data do
     end
   end
 
-  def apply_operation(
-        data,
-        {:add_cell_evaluation_output, _client_id, id, {:doctest_result, _result}}
-      ) do
+  def apply_operation(data, {:add_cell_doctest_report, _client_id, id, _doctest_report}) do
     with {:ok, _cell, _} <- Notebook.fetch_cell_and_section(data.notebook, id) do
       data
       |> with_actions()

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -437,49 +437,37 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 4, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 4, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result,
-                       %{
-                         column: 6,
-                         contents:
-                           "\e[31mexpected exception ArgumentError but got RuntimeError with message \"oops\"\e[0m",
-                         end_line: 5,
-                         line: 4,
-                         state: :failed
-                       }}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 7, state: :evaluating}}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {
-                        :doctest_result,
-                        %{
-                          column: 6,
-                          contents: "\e[31mExpected truthy, got false\e[0m",
-                          end_line: 8,
-                          line: 7,
-                          state: :failed
-                        }
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details:
+                          "\e[31mexpected exception ArgumentError but got RuntimeError with message \"oops\"\e[0m",
+                        end_line: 5,
+                        line: 4,
+                        status: :failed
                       }}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 12, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 7, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 12, state: :success}}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 19, state: :evaluating}}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {
-                        :doctest_result,
-                        %{column: 4, contents: _, end_line: 20, line: 19, state: :failed}
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details: "\e[31mExpected truthy, got false\e[0m",
+                        end_line: 8,
+                        line: 7,
+                        status: :failed
                       }}
+
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 12, status: :running}}
+
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 12, status: :success}}
+
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 19, status: :running}}
+
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{column: 4, details: _, end_line: 20, line: 19, status: :failed}}
     end
 
     # TODO: Run this test on Elixir v1.15+
@@ -502,18 +490,16 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 4, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 4, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result,
-                       %{
-                         column: 6,
-                         contents: _,
-                         end_line: 7,
-                         line: 4,
-                         state: :failed
-                       }}}
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details: _,
+                        end_line: 7,
+                        line: 4,
+                        status: :failed
+                      }}
     end
 
     test "runtime errors", %{evaluator: evaluator} do
@@ -545,49 +531,39 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 4, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 4, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result,
-                       %{
-                         column: 6,
-                         contents: "\e[31mmatch (=) failed" <> _,
-                         end_line: 4,
-                         line: 4,
-                         state: :failed
-                       }}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 9, state: :evaluating}}}
-
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {
-                        :doctest_result,
-                        %{
-                          column: 6,
-                          contents:
-                            "\e[31m** (Protocol.UndefinedError) protocol Enumerable not implemented for 1 of type Integer. " <>
-                              _,
-                          end_line: 10,
-                          line: 9,
-                          state: :failed
-                        }
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details: "\e[31mmatch (=) failed" <> _,
+                        end_line: 4,
+                        line: 4,
+                        status: :failed
                       }}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 17, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 9, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {
-                        :doctest_result,
-                        %{
-                          column: 6,
-                          contents: "\e[31m** (EXIT from #PID<" <> _,
-                          end_line: 18,
-                          line: 17,
-                          state: :failed
-                        }
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details:
+                          "\e[31m** (Protocol.UndefinedError) protocol Enumerable not implemented for 1 of type Integer. " <>
+                            _,
+                        end_line: 10,
+                        line: 9,
+                        status: :failed
+                      }}
+
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 17, status: :running}}
+
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details: "\e[31m** (EXIT from #PID<" <> _,
+                        end_line: 18,
+                        line: 17,
+                        status: :failed
                       }}
     end
 
@@ -606,19 +582,16 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, code, :code_1, [])
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result, %{line: 4, state: :evaluating}}}
+      assert_receive {:runtime_doctest_report, :code_1, %{line: 4, status: :running}}
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:doctest_result,
-                       %{
-                         column: 6,
-                         contents:
-                           "\e[31mDoctest did not compile, got: (TokenMissingError) " <> _,
-                         end_line: 5,
-                         line: 4,
-                         state: :failed
-                       }}}
+      assert_receive {:runtime_doctest_report, :code_1,
+                      %{
+                        column: 6,
+                        details: "\e[31mDoctest did not compile, got: (TokenMissingError) " <> _,
+                        end_line: 5,
+                        line: 4,
+                        status: :failed
+                      }}
     end
   end
 


### PR DESCRIPTION
Final touches on doctests:

* a dedicated runtime message for doctest reports
* encapsulates all doctest indicators in custom widget object
* reads line height and font size directly from editor config
* fixes dark-mode ANSI to only apply within the editor
* small styling updates