### PR TITLE
Use registry to identify IO proxy in log handler

### DIFF
--- a/lib/livebook/runtime/erl_dist/logger_gl_backend.ex
+++ b/lib/livebook/runtime/erl_dist/logger_gl_backend.ex
@@ -96,19 +96,10 @@ defmodule Livebook.Runtime.ErlDist.LoggerGLBackend do
   defp log_event(level, msg, ts, md, gl, state) do
     output = format_event(level, msg, ts, md, state)
 
-    if io_proxy?(gl) do
+    if Livebook.Runtime.ErlDist.NodeManager.known_io_proxy?(gl) do
       async_io(gl, output)
     else
       send(Livebook.Runtime.ErlDist.NodeManager, {:orphan_log, output})
-    end
-  end
-
-  defp io_proxy?(pid) do
-    try do
-      info = Process.info(pid, [:dictionary])
-      info[:dictionary][:"$initial_call"] == {Livebook.Runtime.Evaluator.IOProxy, :init, 1}
-    rescue
-      _ -> false
     end
   end
 

--- a/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
+++ b/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
@@ -5,19 +5,10 @@ defmodule Livebook.Runtime.ErlDist.LoggerGLHandler do
   def log(%{meta: meta} = event, %{formatter: {formatter_module, formatter_config}}) do
     message = apply(formatter_module, :format, [event, formatter_config])
 
-    if io_proxy?(meta.gl) do
+    if Livebook.Runtime.ErlDist.NodeManager.known_io_proxy?(meta.gl) do
       async_io(meta.gl, message)
     else
       send(Livebook.Runtime.ErlDist.NodeManager, {:orphan_log, message})
-    end
-  end
-
-  defp io_proxy?(pid) do
-    try do
-      info = Process.info(pid, [:dictionary])
-      info[:dictionary][:"$initial_call"] == {Livebook.Runtime.Evaluator.IOProxy, :init, 1}
-    rescue
-      _ -> false
     end
   end
 

--- a/lib/livebook/runtime/erl_dist/runtime_server.ex
+++ b/lib/livebook/runtime/erl_dist/runtime_server.ex
@@ -51,6 +51,9 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
       to merge new values into when setting environment variables.
       Defaults to `System.get_env("PATH", "")`
 
+    * `:io_proxy_registry` - the registry to register IO proxy
+      processes in
+
   """
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts)
@@ -316,6 +319,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
        base_env_path:
          Keyword.get_lazy(opts, :base_env_path, fn -> System.get_env("PATH", "") end),
        ebin_path: Keyword.get(opts, :ebin_path),
+       io_proxy_registry: Keyword.get(opts, :io_proxy_registry),
        tmp_dir: Keyword.get(opts, :tmp_dir)
      }}
   end
@@ -675,7 +679,8 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
           send_to: state.owner,
           runtime_broadcast_to: state.runtime_broadcast_to,
           object_tracker: state.object_tracker,
-          ebin_path: state.ebin_path
+          ebin_path: state.ebin_path,
+          io_proxy_registry: state.io_proxy_registry
         )
 
       Process.monitor(evaluator.pid)

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -89,6 +89,9 @@ defmodule Livebook.Runtime.Evaluator do
     * `:ebin_path` - a directory to write modules bytecode into. When
       not specified, modules are not written to disk
 
+    * `:io_proxy_registry` - the registry to register IO proxy
+      processes in
+
   """
   @spec start_link(keyword()) :: {:ok, pid(), t()} | {:error, term()}
   def start_link(opts \\ []) do
@@ -271,9 +274,17 @@ defmodule Livebook.Runtime.Evaluator do
     object_tracker = Keyword.fetch!(opts, :object_tracker)
     formatter = Keyword.get(opts, :formatter, Evaluator.IdentityFormatter)
     ebin_path = Keyword.get(opts, :ebin_path)
+    io_proxy_registry = Keyword.get(opts, :io_proxy_registry)
 
     {:ok, io_proxy} =
-      Evaluator.IOProxy.start(self(), send_to, runtime_broadcast_to, object_tracker, ebin_path)
+      Evaluator.IOProxy.start(
+        self(),
+        send_to,
+        runtime_broadcast_to,
+        object_tracker,
+        ebin_path,
+        io_proxy_registry
+      )
 
     io_proxy_monitor = Process.monitor(io_proxy)
 

--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -26,22 +26,23 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
   For all supported requests a message is sent to the configured
   `:send_to` process, so this device serves as a proxy.
   """
-  @spec start(pid(), pid(), pid(), pid(), String.t() | nil) :: GenServer.on_start()
-  def start(evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path) do
+  @spec start(pid(), pid(), pid(), pid(), String.t() | nil, atom() | nil) :: GenServer.on_start()
+  def start(evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path, registry) do
     GenServer.start(
       __MODULE__,
-      {evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path}
+      {evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path, registry}
     )
   end
 
   @doc """
   Linking version of `start/4`.
   """
-  @spec start_link(pid(), pid(), pid(), pid(), String.t() | nil) :: GenServer.on_start()
-  def start_link(evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path) do
+  @spec start_link(pid(), pid(), pid(), pid(), String.t() | nil, atom() | nil) ::
+          GenServer.on_start()
+  def start_link(evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path, registry) do
     GenServer.start_link(
       __MODULE__,
-      {evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path}
+      {evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path, registry}
     )
   end
 
@@ -72,8 +73,12 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
   end
 
   @impl true
-  def init({evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path}) do
+  def init({evaluator, send_to, runtime_broadcast_to, object_tracker, ebin_path, registry}) do
     evaluator_monitor = Process.monitor(evaluator)
+
+    if registry do
+      Registry.register(registry, nil, nil)
+    end
 
     {:ok,
      %{

--- a/test/livebook/runtime/erl_dist/node_manager_test.exs
+++ b/test/livebook/runtime/erl_dist/node_manager_test.exs
@@ -1,21 +1,25 @@
 defmodule Livebook.Runtime.ErlDist.NodeManagerTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
+  alias Livebook.Runtime
   alias Livebook.Runtime.ErlDist.{NodeManager, RuntimeServer}
 
   test "terminates when the last runtime server terminates" do
-    {:ok, manager_pid} =
-      start_supervised({NodeManager, [unload_modules_on_termination: false, anonymous: true]})
+    # We use a standalone runtime, so that we have an isolated node
+    # with its own node manager
+    assert {:ok, %{node: node, server_pid: server1} = runtime} =
+             Runtime.ElixirStandalone.new() |> Runtime.connect()
 
-    server1 = NodeManager.start_runtime_server(manager_pid)
-    server2 = NodeManager.start_runtime_server(manager_pid)
+    Runtime.take_ownership(runtime)
 
+    manager_pid = :erpc.call(node, Process, :whereis, [Livebook.Runtime.ErlDist.NodeManager])
     ref = Process.monitor(manager_pid)
 
-    RuntimeServer.stop(server1)
-    assert Process.alive?(manager_pid)
+    server2 = NodeManager.start_runtime_server(node)
 
+    RuntimeServer.stop(server1)
     RuntimeServer.stop(server2)
+
     assert_receive {:DOWN, ^ref, :process, _, _}
   end
 end

--- a/test/livebook/runtime/erl_dist/runtime_server_test.exs
+++ b/test/livebook/runtime/erl_dist/runtime_server_test.exs
@@ -4,17 +4,13 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
   alias Livebook.Runtime.ErlDist.{NodeManager, RuntimeServer}
 
   setup ctx do
-    {:ok, manager_pid} =
-      start_supervised({NodeManager, [unload_modules_on_termination: false, anonymous: true]})
-
-    runtime_server_pid = NodeManager.start_runtime_server(manager_pid, ctx[:opts] || [])
+    runtime_server_pid = NodeManager.start_runtime_server(node(), ctx[:opts] || [])
     RuntimeServer.attach(runtime_server_pid, self())
-    {:ok, %{pid: runtime_server_pid, manager_pid: manager_pid}}
+    {:ok, %{pid: runtime_server_pid}}
   end
 
   describe "attach/2" do
-    test "starts watching the given process and terminates as soon as it terminates",
-         %{manager_pid: manager_pid} do
+    test "starts watching the given process and terminates as soon as it terminates" do
       owner =
         spawn(fn ->
           receive do
@@ -22,7 +18,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
           end
         end)
 
-      pid = NodeManager.start_runtime_server(manager_pid)
+      pid = NodeManager.start_runtime_server(node())
       RuntimeServer.attach(pid, owner)
 
       # Make sure the node is running.

--- a/test/livebook/session/file_guard_test.exs
+++ b/test/livebook/session/file_guard_test.exs
@@ -1,5 +1,5 @@
 defmodule Livebook.Session.FileGuardTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import Livebook.TestHelpers
 


### PR DESCRIPTION
As noted in https://github.com/livebook-dev/livebook/pull/1918#discussion_r1209513140.

Currently we fetch the process dictionary whenever we need to log, this improves it by checking pid against a registry instead.

The first commit drops the `:anonymous` node manager option we use in tests, I changed the relevant tests to work without that (generally we operate under assumption that there's only one node manager per node).