### PR TITLE
Add link to apps sessions on multi-session app page

### DIFF
--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -52,7 +52,7 @@ defmodule LivebookWeb.AppLive do
     <.modal id="sessions-modal" show width={:big} patch={~p"/"}>
       <div class="p-6 max-w-4xl flex flex-col space-y-3">
         <h3 class="text-2xl font-semibold text-gray-800">
-          App sessions
+          <%= @app.notebook_name %>
         </h3>
         <p class="text-gray-700">
           <%= if @app_settings.show_existing_sessions do %>

--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -112,6 +112,12 @@ defmodule LivebookWeb.AppSessionLive do
                 <span>Home</span>
               </.link>
             </.menu_item>
+            <.menu_item :if={@data_view.multi_session}>
+              <.link navigate={~p"/apps/#{@data_view.slug}"} role="menuitem">
+                <.remix_icon icon="play-list-add-line" />
+                <span>App sessions</span>
+              </.link>
+            </.menu_item>
             <.menu_item :if={@data_view.show_source}>
               <.link patch={~p"/apps/#{@data_view.slug}/#{@session.id}/source"} role="menuitem">
                 <.remix_icon icon="code-line" />
@@ -288,7 +294,8 @@ defmodule LivebookWeb.AppSessionLive do
         ),
       app_status: data.app_data.status,
       show_source: data.notebook.app_settings.show_source,
-      slug: data.notebook.app_settings.slug
+      slug: data.notebook.app_settings.slug,
+      multi_session: data.notebook.app_settings.multi_session
     }
   end
 

--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -115,7 +115,7 @@ defmodule LivebookWeb.AppSessionLive do
             <.menu_item :if={@data_view.multi_session}>
               <.link navigate={~p"/apps/#{@data_view.slug}"} role="menuitem">
                 <.remix_icon icon="play-list-add-line" />
-                <span>App sessions</span>
+                <span>Sessions</span>
               </.link>
             </.menu_item>
             <.menu_item :if={@data_view.show_source}>


### PR DESCRIPTION
![image](https://github.com/livebook-dev/livebook/assets/17034772/ea49bdd6-e5fc-4cf2-aea5-8758c55038a6)

Could be "Add session", but that implies a direct action, so I like the above more. @josevalim wdyt?