### PR TITLE
Erlang error improvements

### DIFF
--- a/lib/livebook/runtime/evaluator/formatter.ex
+++ b/lib/livebook/runtime/evaluator/formatter.ex
@@ -31,6 +31,19 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
     to_output(value)
   end
 
+  def format_result({:error, kind, error, stacktrace}, :erlang) do
+    if is_exception(error) do
+      format_result({:error, kind, error, stacktrace}, :elixir)
+    else
+      formatted =
+        :erl_error.format_exception(kind, error, stacktrace)
+        |> error_color
+        |> :erlang.list_to_binary()
+
+      {:error, formatted, error_type(error)}
+    end
+  end
+
   def format_result({:error, kind, error, stacktrace}, _language) do
     formatted = format_error(kind, error, stacktrace)
     {:error, formatted, error_type(error)}

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -1173,22 +1173,22 @@ defmodule Livebook.Runtime.EvaluatorTest do
       # Incomplete input
       Evaluator.evaluate_code(evaluator, :erlang, "X =", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, {:error, message, _}, metadata()}
-      assert String.starts_with?(message, "\e[31m** (TokenMissingError)")
+      assert "\e[31m** (TokenMissingError)" <> _ = message
 
       # Parser error
       Evaluator.evaluate_code(evaluator, :erlang, "X ==/== a.", :code_2, [])
       assert_receive {:runtime_evaluation_response, :code_2, {:error, message, _}, metadata()}
-      assert String.starts_with?(message, "\e[31m** (SyntaxError)")
+      assert "\e[31m** (SyntaxError)" <> _ = message
 
       # Tokenizer error
       Evaluator.evaluate_code(evaluator, :erlang, "$a$", :code_3, [])
       assert_receive {:runtime_evaluation_response, :code_3, {:error, message, _}, metadata()}
-      assert String.starts_with?(message, "\e[31m** (SyntaxError)")
+      assert "\e[31m** (SyntaxError)" <> _ = message
 
       # Erlang exception
       Evaluator.evaluate_code(evaluator, :erlang, "list_to_binary(1).", :code_4, [])
       assert_receive {:runtime_evaluation_response, :code_4, {:error, message, _}, metadata()}
-      assert String.starts_with?(message, "\e[31mexception error: bad argument")
+      assert "\e[31mexception error: bad argument" <> _ = message
     end
   end
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -1168,6 +1168,28 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       assert metadata.code_markers == []
     end
+
+    test "syntax and tokenizer errors are converted", %{evaluator: evaluator} do
+      # Incomplete input
+      Evaluator.evaluate_code(evaluator, :erlang, "X =", :code_1, [])
+      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, _}, metadata()}
+      assert String.starts_with?(message, "\e[31m** (TokenMissingError)")
+
+      # Parser error
+      Evaluator.evaluate_code(evaluator, :erlang, "X ==/== a.", :code_2, [])
+      assert_receive {:runtime_evaluation_response, :code_2, {:error, message, _}, metadata()}
+      assert String.starts_with?(message, "\e[31m** (SyntaxError)")
+
+      # Tokenizer error
+      Evaluator.evaluate_code(evaluator, :erlang, "$a$", :code_3, [])
+      assert_receive {:runtime_evaluation_response, :code_3, {:error, message, _}, metadata()}
+      assert String.starts_with?(message, "\e[31m** (SyntaxError)")
+
+      # Erlang exception
+      Evaluator.evaluate_code(evaluator, :erlang, "list_to_binary(1).", :code_4, [])
+      assert_receive {:runtime_evaluation_response, :code_4, {:error, message, _}, metadata()}
+      assert String.starts_with?(message, "\e[31mexception error: bad argument")
+    end
   end
 
   describe "formatting" do


### PR DESCRIPTION
- Convert Erlang tokenizer/parser errors to SyntaxError, format exceptions
- Raise TokenMissingError for incomplete input
- Use the same snippet code as Elixir does
