### PR TITLE
Add hub id to hubs pubsub messages

### DIFF
--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -82,7 +82,7 @@ defmodule Livebook.Hubs do
     attributes = struct |> Map.from_struct() |> Map.to_list()
     :ok = Storage.insert(@namespace, struct.id, attributes)
     :ok = connect_hub(struct)
-    :ok = Broadcasts.hub_changed()
+    :ok = Broadcasts.hub_changed(struct.id)
 
     struct
   end
@@ -94,7 +94,7 @@ defmodule Livebook.Hubs do
   def delete_hub(id) do
     with {:ok, hub} <- fetch_hub(id) do
       true = Provider.type(hub) != "personal"
-      :ok = Broadcasts.hub_changed()
+      :ok = Broadcasts.hub_changed(hub.id)
       :ok = Storage.delete(@namespace, id)
       :ok = disconnect_hub(hub)
     end
@@ -118,14 +118,14 @@ defmodule Livebook.Hubs do
 
   Topic `hubs:crud`:
 
-    * `:hub_changed`
+    * `{:hub_changed, hub_id}`
 
   Topic `hubs:connection`:
 
-    * `:hub_connected`
-    * `:hub_disconnected`
-    * `{:hub_connection_failed, reason}`
-    * `{:hub_server_error, reason}`
+    * `{:hub_connected, hub_id}`
+    * `{:hub_disconnected, hub_id}`
+    * `{:hub_connection_failed, hub_id, reason}`
+    * `{:hub_server_error, hub_id, reason}`
 
   Topic `hubs:secrets`:
 

--- a/lib/livebook/hubs/broadcasts.ex
+++ b/lib/livebook/hubs/broadcasts.ex
@@ -12,33 +12,33 @@ defmodule Livebook.Hubs.Broadcasts do
   @doc """
   Broadcasts under `#{@crud_topic}` topic when hubs changed.
   """
-  @spec hub_changed() :: broadcast()
-  def hub_changed do
-    broadcast(@crud_topic, :hub_changed)
+  @spec hub_changed(String.t()) :: broadcast()
+  def hub_changed(hub_id) do
+    broadcast(@crud_topic, {:hub_changed, hub_id})
   end
 
   @doc """
   Broadcasts under `#{@connection_topic}` topic when hub connected.
   """
-  @spec hub_connected() :: broadcast()
-  def hub_connected do
-    broadcast(@connection_topic, :hub_connected)
+  @spec hub_connected(String.t()) :: broadcast()
+  def hub_connected(hub_id) do
+    broadcast(@connection_topic, {:hub_connected, hub_id})
   end
 
   @doc """
   Broadcasts under `#{@connection_topic}` topic when hub is out-of-date.
   """
-  @spec hub_server_error(String.t()) :: broadcast()
-  def hub_server_error(reason) when is_binary(reason) do
-    broadcast(@connection_topic, {:hub_server_error, reason})
+  @spec hub_server_error(String.t(), String.t()) :: broadcast()
+  def hub_server_error(hub_id, reason) when is_binary(reason) do
+    broadcast(@connection_topic, {:hub_server_error, hub_id, reason})
   end
 
   @doc """
   Broadcasts under `#{@connection_topic}` topic when hub received a connection error.
   """
-  @spec hub_connection_failed(String.t()) :: broadcast()
-  def hub_connection_failed(reason) when is_binary(reason) do
-    broadcast(@connection_topic, {:hub_connection_failed, reason})
+  @spec hub_connection_failed(String.t(), String.t()) :: broadcast()
+  def hub_connection_failed(hub_id, reason) when is_binary(reason) do
+    broadcast(@connection_topic, {:hub_connection_failed, hub_id, reason})
   end
 
   @doc """

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -80,17 +80,17 @@ defmodule Livebook.Hubs.TeamClient do
 
   @impl true
   def handle_info(:connected, state) do
-    Broadcasts.hub_connected()
+    Broadcasts.hub_connected(state.hub.id)
     {:noreply, %{state | connected?: true, connection_error: nil}}
   end
 
   def handle_info({:connection_error, reason}, state) do
-    Broadcasts.hub_connection_failed(reason)
+    Broadcasts.hub_connection_failed(state.hub.id, reason)
     {:noreply, %{state | connected?: false, connection_error: reason}}
   end
 
   def handle_info({:server_error, reason}, state) do
-    Broadcasts.hub_server_error("#{state.hub.hub_name}: #{reason}")
+    Broadcasts.hub_server_error(state.hub.id, "#{state.hub.hub_name}: #{reason}")
     :ok = Livebook.Hubs.delete_hub(state.hub.id)
 
     {:noreply, %{state | connected?: false}}

--- a/lib/livebook_web/live/hooks/sidebar_hook.ex
+++ b/lib/livebook_web/live/hooks/sidebar_hook.ex
@@ -27,15 +27,15 @@ defmodule LivebookWeb.SidebarHook do
 
   @connection_events ~w(hub_connected hub_changed)a
 
-  defp handle_info(event, socket) when event in @connection_events do
+  defp handle_info(event, socket) when elem(event, 0) in @connection_events do
     {:cont, assign(socket, saved_hubs: Livebook.Hubs.get_metadatas())}
   end
 
-  defp handle_info({:hub_connection_failed, _reason}, socket) do
+  defp handle_info({:hub_connection_failed, _hub_id, _reason}, socket) do
     {:cont, assign(socket, saved_hubs: Livebook.Hubs.get_metadatas())}
   end
 
-  defp handle_info({:hub_server_error, error}, socket) do
+  defp handle_info({:hub_server_error, _hub_id, error}, socket) do
     {:cont,
      socket
      |> assign(saved_hubs: Livebook.Hubs.get_metadatas())

--- a/test/livebook/hubs/team_client_test.exs
+++ b/test/livebook/hubs/team_client_test.exs
@@ -25,10 +25,12 @@ defmodule Livebook.Hubs.TeamClientTest do
           session_token: token
         )
 
+      id = team.id
+
       refute TeamClient.connected?(team.id)
 
       TeamClient.start_link(team)
-      assert_receive :hub_connected
+      assert_receive {:hub_connected, ^id}
       assert TeamClient.connected?(team.id)
     end
 
@@ -41,9 +43,11 @@ defmodule Livebook.Hubs.TeamClientTest do
           session_token: token
         )
 
+      id = team.id
+
       TeamClient.start_link(team)
 
-      assert_receive {:hub_server_error, error}
+      assert_receive {:hub_server_error, ^id, error}
 
       assert error ==
                "#{team.hub_name}: Your session is out-of-date. Please re-join the organization."


### PR DESCRIPTION
Assertions like `assert_receive :hub_connected` are prone to race conditions, because concurrent tests may create multiple hubs, this adds hub it to those messages, so we can have more precise assertions.