### PR TITLE
Ignore code server error logs when checking for modules

### DIFF
--- a/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
+++ b/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
@@ -15,4 +15,18 @@ defmodule Livebook.Runtime.ErlDist.LoggerGLHandler do
   def async_io(device, output) when is_pid(device) do
     send(device, {:io_request, self(), make_ref(), {:put_chars, :unicode, output}})
   end
+
+  @doc false
+  def filter_code_server_logs(%{meta: meta} = event, _) do
+    # When checking if a miscapitalized module, such as Io, is loaded,
+    # :code_server logs an error message on a case insensitive file
+    # system "Error loading module 'Elixir.Io'". We want to ignore
+    # such logs
+
+    if Process.whereis(:code_server) == meta.pid do
+      :stop
+    else
+      event
+    end
+  end
 end

--- a/lib/livebook/runtime/erl_dist/node_manager.ex
+++ b/lib/livebook/runtime/erl_dist/node_manager.ex
@@ -99,7 +99,11 @@ defmodule Livebook.Runtime.ErlDist.NodeManager do
     # TODO: remove logger backend once we require Elixir v1.15
     if Code.ensure_loaded?(Logger) and function_exported?(Logger, :add_handlers, 1) do
       :logger.add_handler(:livebook_gl_handler, Livebook.Runtime.ErlDist.LoggerGLHandler, %{
-        formatter: Logger.Formatter.new()
+        formatter: Logger.Formatter.new(),
+        filters: [
+          code_server_logs:
+            {&Livebook.Runtime.ErlDist.LoggerGLHandler.filter_code_server_logs/2, nil}
+        ]
       })
     else
       Logger.add_backend(Livebook.Runtime.ErlDist.LoggerGLBackend)

--- a/test/livebook/runtime/erl_dist/runtime_server_test.exs
+++ b/test/livebook/runtime/erl_dist/runtime_server_test.exs
@@ -166,6 +166,21 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
       assert_receive {:runtime_intellisense_response, ^ref, ^request,
                       %{items: [%{label: "bright/0"}]}}
     end
+
+    @tag capture_log: true
+    test "ignores code server error logs when loading mistyped module", %{pid: pid} do
+      RuntimeServer.evaluate_code(pid, :elixir, "", {:c1, :e1}, [])
+      assert_receive {:runtime_evaluation_response, :e1, _, %{evaluation_time_ms: _time_ms}}
+
+      request = {:completion, "Io."}
+      ref = RuntimeServer.handle_intellisense(pid, self(), request, [])
+
+      assert_receive {:runtime_intellisense_response, ^ref, ^request, %{items: []}}
+
+      # Checking if the module is loaded results in "Error loading module 'Elixir.Io'"
+      # error log, which should be ignored
+      refute_receive {:runtime_evaluation_output, :e1, {:stdout, _log_message}}
+    end
   end
 
   describe "handle_intellisense/5 given details request" do


### PR DESCRIPTION
See https://github.com/erlang/otp/issues/7363.