### PR TITLE
Update required Elixir version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ with [Nerves](https://www.nerves-project.org/).
 ### Direct installation with Elixir
 
 You can run Livebook on your own machine using just Elixir. You will need
-[Elixir v1.13](https://elixir-lang.org/install.html) or later.
+[Elixir v1.14.2](https://elixir-lang.org/install.html) or later.
 Livebook also requires the following Erlang applications: `inets`,
 `os_mon`, `runtime_tools`, `ssl` and `xmerl`. Those applications come
 with most Erlang distributions but certain package managers may split


### PR DESCRIPTION
The mix.exs requires 1.14.2 or higher, as does connecting to a remote node.