### PR TITLE
Add on-hover details for types

### DIFF
--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -477,9 +477,7 @@ defmodule Livebook.Intellisense do
        }) do
     join_with_divider([
       format_type_signature(type_spec, module) |> code(),
-      join_with_middle_dot([
-        format_docs_link(module, {:type, name, arity})
-      ]),
+      format_docs_link(module, {:type, name, arity}),
       format_type_spec(type_spec, @extended_line_length) |> code(),
       format_documentation(documentation, :all)
     ])
@@ -616,9 +614,7 @@ defmodule Livebook.Intellisense do
       end
       |> Macro.to_string()
 
-    type_spec_code =
-      ["@#{type_kind} ", type_string]
-      |> IO.iodata_to_binary()
+    type_spec_code = "@#{type_kind} #{type_string}"
 
     try do
       Code.format_string!(type_spec_code, line_length: line_length)

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -610,9 +610,21 @@ defmodule Livebook.Intellisense do
     end
   end
 
-  defp format_type_spec({type_kind, type}, line_length) do
+  defp format_type_spec({type_kind, type}, line_length) when type_kind in [:type, :opaque] do
+    type_string = Code.Typespec.type_to_quoted(type) |> Macro.to_string()
+
+    type =
+      case type_kind do
+        :type ->
+          type_string
+
+        :opaque ->
+          [name_and_vars, _def] = String.split(type_string, " :: ")
+          name_and_vars
+      end
+
     type_spec_code =
-      ["@#{type_kind} ", Code.Typespec.type_to_quoted(type) |> Macro.to_string()]
+      ["@#{type_kind} ", type]
       |> IO.iodata_to_binary()
 
     try do
@@ -621,6 +633,8 @@ defmodule Livebook.Intellisense do
       _ -> type_spec_code
     end
   end
+
+  defp format_type_spec(_, _line_length), do: nil
 
   defp format_documentation(doc, variant)
 

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -533,12 +533,24 @@ defmodule Livebook.Intellisense do
 
     cond do
       is_otp? ->
-        hash = docs_link_hash(:erlang, function_or_type)
+        hash =
+          case function_or_type do
+            {:function, function, arity} -> "##{function}-#{arity}"
+            {:type, type, _arity} -> "#type-#{type}"
+            nil -> ""
+          end
+
         url = "https://www.erlang.org/doc/man/#{module_name}.html#{hash}"
         "[View on Erlang Docs](#{url})"
 
       vsn = app && Application.spec(app, :vsn) ->
-        hash = docs_link_hash(:hexdocs, function_or_type)
+        hash =
+          case function_or_type do
+            {:function, function, arity} -> "##{function}/#{arity}"
+            {:type, type, arity} -> "#t:#{type}/#{arity}"
+            nil -> ""
+          end
+
         url = "https://hexdocs.pm/#{app}/#{vsn}/#{module_name}.html#{hash}"
         "[View on Hexdocs](#{url})"
 
@@ -546,12 +558,6 @@ defmodule Livebook.Intellisense do
         nil
     end
   end
-
-  defp docs_link_hash(:erlang, {:function, function, arity}), do: "##{function}-#{arity}"
-  defp docs_link_hash(:erlang, {:type, type, _arity}), do: "#type-#{type}"
-  defp docs_link_hash(:hexdocs, {:function, function, arity}), do: "##{function}/#{arity}"
-  defp docs_link_hash(:hexdocs, {:type, type, arity}), do: "#t:#{type}/#{arity}"
-  defp docs_link_hash(_target, nil), do: ""
 
   defp format_signatures([], _module), do: nil
 

--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -83,7 +83,7 @@ defmodule Livebook.Intellisense.Docs do
     type_specs =
       with true <- :type in kinds,
            {:ok, types} <- Code.Typespec.fetch_types(module) do
-        Enum.filter(types, fn {type_kind, _} -> :type == type_kind end)
+        Enum.filter(types, fn {type_kind, _} -> type_kind in [:type, :opaque] end)
         |> Enum.map(fn {_type_kind, {name, _defs, vars}} = type ->
           {{name, Enum.count(vars)}, type}
         end)

--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -12,6 +12,7 @@ defmodule Livebook.Intellisense.Docs do
           documentation: documentation(),
           signatures: list(signature()),
           specs: list(spec()),
+          type_spec: type_spec(),
           meta: meta()
         }
 
@@ -27,6 +28,13 @@ defmodule Livebook.Intellisense.Docs do
   A single spec annotation in the Erlang Abstract Format.
   """
   @type spec :: term()
+
+  @typedoc """
+  A tuple containing a single type annotation in the Erlang Abstract Format,
+  tagged by its kind.
+  """
+  @type type_spec() :: {type_kind(), term()}
+  @type type_kind() :: :type | :opaque
 
   @doc """
   Fetches documentation for the given module if available.

--- a/lib/livebook/intellisense/docs.ex
+++ b/lib/livebook/intellisense/docs.ex
@@ -83,11 +83,10 @@ defmodule Livebook.Intellisense.Docs do
     type_specs =
       with true <- :type in kinds,
            {:ok, types} <- Code.Typespec.fetch_types(module) do
-        Enum.filter(types, fn {type_kind, _} -> type_kind in [:type, :opaque] end)
-        |> Enum.map(fn {_type_kind, {name, _defs, vars}} = type ->
-          {{name, Enum.count(vars)}, type}
-        end)
-        |> Map.new()
+        for {type_kind, {name, _defs, vars}} = type <- types,
+            type_kind in [:type, :opaque],
+            into: Map.new(),
+            do: {{name, Enum.count(vars)}, type}
       else
         _ -> %{}
       end

--- a/lib/livebook/intellisense/identifier_matcher.ex
+++ b/lib/livebook/intellisense/identifier_matcher.ex
@@ -62,7 +62,8 @@ defmodule Livebook.Intellisense.IdentifierMatcher do
               module: module(),
               name: name(),
               arity: arity(),
-              documentation: Docs.documentation()
+              documentation: Docs.documentation(),
+              type_spec: Docs.type_spec()
             }
           | %{
               kind: :module_attribute,

--- a/lib/livebook/intellisense/identifier_matcher.ex
+++ b/lib/livebook/intellisense/identifier_matcher.ex
@@ -710,11 +710,18 @@ defmodule Livebook.Intellisense.IdentifierMatcher do
 
     Enum.map(matching_types, fn {name, arity} ->
       doc_item =
-        Enum.find(doc_items, %{documentation: nil}, fn doc_item ->
+        Enum.find(doc_items, %{documentation: nil, type_spec: nil}, fn doc_item ->
           doc_item.name == name && doc_item.arity == arity
         end)
 
-      %{kind: :type, module: mod, name: name, arity: arity, documentation: doc_item.documentation}
+      %{
+        kind: :type,
+        module: mod,
+        name: name,
+        arity: arity,
+        documentation: doc_item.documentation,
+        type_spec: doc_item.type_spec
+      }
     end)
   end
 

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1391,6 +1391,26 @@ defmodule Livebook.IntellisenseTest do
       assert date_range =~ "Date.Range"
     end
 
+    test "returns module-prepended type signatures" do
+      context = eval(do: nil)
+
+      assert %{contents: [type]} = Intellisense.get_details("Date.t", 6, context)
+      assert type =~ "Date.t()"
+
+      assert %{contents: [type]} = Intellisense.get_details(":code.load_error_rsn", 8, context)
+      assert type =~ ":code.load_error_rsn()"
+    end
+
+    test "includes type specs" do
+      context = eval(do: nil)
+
+      assert %{contents: [type]} = Intellisense.get_details("Date.t", 6, context)
+      assert type =~ "@type t() :: %Date"
+
+      assert %{contents: [type]} = Intellisense.get_details(":code.load_error_rsn", 8, context)
+      assert type =~ "@type load_error_rsn() ::"
+    end
+
     test "returns link to online documentation" do
       context = eval(do: nil)
 
@@ -1401,6 +1421,14 @@ defmodule Livebook.IntellisenseTest do
                Intellisense.get_details("Integer.to_string(10)", 15, context)
 
       assert content =~ ~r"https://hexdocs.pm/elixir/[^/]+/Integer.html#to_string/2"
+
+      # test elixir types
+      assert %{contents: [content]} = Intellisense.get_details("GenServer.on_start", 12, context)
+      assert content =~ ~r"https://hexdocs.pm/elixir/[^/]+/GenServer.html#t:on_start/0"
+
+      # test erlang types
+      assert %{contents: [content]} = Intellisense.get_details(":code.load_ret", 7, context)
+      assert content =~ ~r"https://www.erlang.org/doc/man/code.html#type-load_ret"
 
       # test erlang modules on hexdocs
       assert %{contents: [content]} = Intellisense.get_details(":telemetry.span", 13, context)

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -1409,6 +1409,10 @@ defmodule Livebook.IntellisenseTest do
 
       assert %{contents: [type]} = Intellisense.get_details(":code.load_error_rsn", 8, context)
       assert type =~ "@type load_error_rsn() ::"
+
+      # opaque types are listed without internal definition
+      assert %{contents: [type]} = Intellisense.get_details("MapSet.internal", 10, context)
+      assert type =~ "@opaque internal(value)\n"
     end
 
     test "returns link to online documentation" do


### PR DESCRIPTION
Hello! 👋  

Been bugged by the fact that type specs are not displayed in the on-hover windows and decided to try and change that.

This PR adds more details:
- includes type spec 
- includes full type signature, e.g. `GenServer.on_start()` instead of just `on_start`
- includes link to erlang/hexdocs documentation

### Examples

#### Elixir before
<img width="392" alt="from_elixir" src="https://github.com/livebook-dev/livebook/assets/15570798/d8fbbfad-681d-4d89-901d-86bb988b88c5">

#### Elixir after
<img width="768" alt="to_elixir" src="https://github.com/livebook-dev/livebook/assets/15570798/8382b58e-1dde-4b87-aad3-f68c3a7f2bf4">
<img width="324" alt="to_elixir_opaque" src="https://github.com/livebook-dev/livebook/assets/15570798/8b3f25ec-1530-4f06-a5c1-8b55f5941954">

#### Erlang before
<img width="691" alt="from_erlang" src="https://github.com/livebook-dev/livebook/assets/15570798/e119f349-fe9c-400f-886d-ff3851ae7959">

#### Erlang after
<img width="690" alt="to_erlang" src="https://github.com/livebook-dev/livebook/assets/15570798/8b81fcf3-afd1-4cbd-b6cd-580542be66f8">
