### PR TITLE
Add "allowfullscreen" attribute to iframes

### DIFF
--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -292,9 +292,6 @@ const JSView = {
       !!this.el.closest(`[data-js-focused]`)
     );
 
-    // Allow iframes to enter fullscreen mode
-    this.iframe.setAttribute("allowfullscreen", "");
-
     // Cleanup
 
     const remove = () => {

--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -292,6 +292,9 @@ const JSView = {
       !!this.el.closest(`[data-js-focused]`)
     );
 
+    // Allow iframes to enter fullscreen mode
+    this.iframe.setAttribute("allowfullscreen", "");
+
     // Cleanup
 
     const remove = () => {

--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -35,7 +35,7 @@ export function initializeIframeSource(iframe, iframePort, iframeUrl) {
     iframe.sandbox =
       "allow-scripts allow-same-origin allow-downloads allow-modals allow-popups";
     iframe.allow =
-      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write";
+      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; fullscreen; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write";
     iframe.src = url;
   });
 }


### PR DESCRIPTION
![image](https://github.com/livebook-dev/livebook/assets/11441198/ba0bb080-407b-487c-a364-5d246ded22c6)

Currently I build a Kino to create gantt charts. It would be really nice if I could use the whole screen size to edit it. With this PR it is possible for the iframe to enter fullscreen mode.

Furthermore it would be really nice if it's possible to define the Kino size of each element for the deployed application.