### PR TITLE
Allow Livebook to update and delete Team hub secrets

### DIFF
--- a/lib/livebook/hubs/team.ex
+++ b/lib/livebook/hubs/team.ex
@@ -103,7 +103,7 @@ defimpl Livebook.Hubs.Provider, for: Livebook.Hubs.Team do
 
   def create_secret(team, secret), do: Teams.create_secret(team, secret)
 
-  def update_secret(_team, _secret), do: :ok
+  def update_secret(team, secret), do: Teams.update_secret(team, secret)
 
   def delete_secret(_team, _secret), do: :ok
 

--- a/lib/livebook/hubs/team.ex
+++ b/lib/livebook/hubs/team.ex
@@ -105,7 +105,7 @@ defimpl Livebook.Hubs.Provider, for: Livebook.Hubs.Team do
 
   def update_secret(team, secret), do: Teams.update_secret(team, secret)
 
-  def delete_secret(_team, _secret), do: :ok
+  def delete_secret(team, secret), do: Teams.delete_secret(team, secret)
 
   def connection_error(team) do
     reason = TeamClient.get_connection_error(team.id)

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -124,7 +124,12 @@ defmodule Livebook.Hubs.TeamClient do
   end
 
   defp put_secret(state, secret) do
+    state = remove_secret(state, secret)
     %{state | secrets: [secret | state.secrets]}
+  end
+
+  defp remove_secret(state, secret) do
+    %{state | secrets: Enum.reject(state.secrets, &(&1.name == secret.name))}
   end
 
   defp build_secret(state, %{name: name, value: value}) do
@@ -142,6 +147,13 @@ defmodule Livebook.Hubs.TeamClient do
   defp handle_event(:secret_created, secret_created, state) do
     secret = build_secret(state, secret_created)
     Broadcasts.secret_created(secret)
+
+    put_secret(state, secret)
+  end
+
+  defp handle_event(:secret_updated, secret_updated, state) do
+    secret = build_secret(state, secret_updated)
+    Broadcasts.secret_updated(secret)
 
     put_secret(state, secret)
   end

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -157,4 +157,11 @@ defmodule Livebook.Hubs.TeamClient do
 
     put_secret(state, secret)
   end
+
+  defp handle_event(:secret_deleted, secret_deleted, state) do
+    secret = Enum.find(state.secrets, &(&1.name == secret_deleted.name))
+    Broadcasts.secret_deleted(secret)
+
+    remove_secret(state, secret)
+  end
 end

--- a/lib/livebook/teams.ex
+++ b/lib/livebook/teams.ex
@@ -134,6 +134,24 @@ defmodule Livebook.Teams do
   end
 
   @doc """
+  Deletes a Secret.
+
+  With success, returns the response from Livebook Teams API.
+  Otherwise, it will return an error tuple with changeset.
+  """
+  @spec delete_secret(Team.t(), Secret.t()) ::
+          :ok
+          | {:error, Ecto.Changeset.t()}
+          | {:transport_error, String.t()}
+  def delete_secret(%Team{} = team, %Secret{} = secret) do
+    case Requests.delete_secret(team, secret) do
+      {:ok, _} -> :ok
+      {:error, %{"errors" => errors}} -> {:error, add_secret_errors(secret, errors)}
+      any -> any
+    end
+  end
+
+  @doc """
   Creates a Hub.
 
   It notifies interested processes about hub metadatas data change.

--- a/lib/livebook/teams.ex
+++ b/lib/livebook/teams.ex
@@ -116,6 +116,24 @@ defmodule Livebook.Teams do
   end
 
   @doc """
+  Updates a Secret.
+
+  With success, returns the response from Livebook Teams API.
+  Otherwise, it will return an error tuple with changeset.
+  """
+  @spec update_secret(Team.t(), Secret.t()) ::
+          :ok
+          | {:error, Ecto.Changeset.t()}
+          | {:transport_error, String.t()}
+  def update_secret(%Team{} = team, %Secret{} = secret) do
+    case Requests.update_secret(team, secret) do
+      {:ok, %{"id" => _}} -> :ok
+      {:error, %{"errors" => errors}} -> {:error, add_secret_errors(secret, errors)}
+      any -> any
+    end
+  end
+
+  @doc """
   Creates a Hub.
 
   It notifies interested processes about hub metadatas data change.

--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -59,6 +59,21 @@ defmodule Livebook.Teams.Requests do
     post("/api/v1/org/secrets", params, headers)
   end
 
+  @doc """
+  Send a request to Livebook Team API to update a secret.
+  """
+  @spec update_secret(Team.t(), Secret.t()) ::
+          {:ok, map()} | {:error, map() | String.t()} | {:transport_error, String.t()}
+  def update_secret(team, secret) do
+    {secret_key, sign_secret} = Teams.derive_keys(team.teams_key)
+    secret_value = Teams.encrypt_secret_value(secret.value, secret_key, sign_secret)
+
+    headers = auth_headers(team)
+    params = %{name: secret.name, value: secret_value}
+
+    put("/api/v1/org/secrets", params, headers)
+  end
+
   defp auth_headers(team) do
     token = "#{team.user_id}:#{team.org_id}:#{team.org_key_id}:#{team.session_token}"
     [{"authorization", "Bearer " <> token}]
@@ -67,6 +82,11 @@ defmodule Livebook.Teams.Requests do
   defp post(path, json, headers \\ []) do
     body = {"application/json", Jason.encode!(json)}
     request(:post, path, body: body, headers: headers)
+  end
+
+  defp put(path, json, headers) do
+    body = {"application/json", Jason.encode!(json)}
+    request(:put, path, body: body, headers: headers)
   end
 
   defp get(path, params \\ %{}, headers \\ []) do

--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -81,13 +81,16 @@ defmodule Livebook.Teams.Requests do
     url = endpoint <> path
 
     case HTTP.request(method, url, opts) do
-      {:ok, status, header, body} when status in 200..299 ->
-        if json?(header),
+      {:ok, 204, _headers, body} ->
+        {:ok, body}
+
+      {:ok, status, headers, body} when status in 200..299 ->
+        if json?(headers),
           do: {:ok, Jason.decode!(body)},
           else: {:error, body}
 
-      {:ok, status, header, body} when status in [410, 422] ->
-        if json?(header),
+      {:ok, status, headers, body} when status in [410, 422] ->
+        if json?(headers),
           do: {:error, Jason.decode!(body)},
           else: {:transport_error, body}
 

--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -74,6 +74,18 @@ defmodule Livebook.Teams.Requests do
     put("/api/v1/org/secrets", params, headers)
   end
 
+  @doc """
+  Send a request to Livebook Team API to delete a secret.
+  """
+  @spec delete_secret(Team.t(), Secret.t()) ::
+          {:ok, String.t()} | {:error, map() | String.t()} | {:transport_error, String.t()}
+  def delete_secret(team, secret) do
+    headers = auth_headers(team)
+    params = %{name: secret.name}
+
+    delete("/api/v1/org/secrets", params, headers)
+  end
+
   defp auth_headers(team) do
     token = "#{team.user_id}:#{team.org_id}:#{team.org_key_id}:#{team.session_token}"
     [{"authorization", "Bearer " <> token}]
@@ -87,6 +99,11 @@ defmodule Livebook.Teams.Requests do
   defp put(path, json, headers) do
     body = {"application/json", Jason.encode!(json)}
     request(:put, path, body: body, headers: headers)
+  end
+
+  defp delete(path, json, headers) do
+    body = {"application/json", Jason.encode!(json)}
+    request(:delete, path, body: body, headers: headers)
   end
 
   defp get(path, params \\ %{}, headers \\ []) do

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -32,7 +32,125 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id={"#{@id}-component"} class="space-y-8 pb-8">
+    <div id={"#{@id}-component"}>
+      <div class="mb-8">
+        <div class="space-y-8">
+          <LayoutHelpers.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
+
+          <p class="text-gray-700">
+            Your personal hub. All data is stored on your machine and only you can access it.
+          </p>
+
+          <div class="flex flex-col space-y-10">
+            <div class="flex flex-col space-y-2">
+              <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
+                General
+              </h2>
+
+              <.form
+                :let={f}
+                id={@id}
+                class="flex flex-col mt-4 space-y-4"
+                for={@changeset}
+                phx-submit="save"
+                phx-change="validate"
+                phx-target={@myself}
+              >
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <.text_field field={f[:hub_name]} label="Name" />
+                  <.emoji_field field={f[:hub_emoji]} label="Emoji" />
+                </div>
+                <div>
+                  <button
+                    class="button-base button-blue"
+                    type="submit"
+                    phx-disable-with="Updating..."
+                    disable={not @changeset.valid?}
+                  >
+                    Save
+                  </button>
+                </div>
+              </.form>
+            </div>
+
+            <div class="flex flex-col space-y-4">
+              <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
+                Secrets
+              </h2>
+
+              <p class="text-gray-700">
+                Secrets are a safe way to share credentials and tokens with notebooks.
+                They are often shared with Smart cells and can be read as
+                environment variables using the <code>LB_</code> prefix.
+              </p>
+
+              <.live_component
+                module={LivebookWeb.Hub.SecretListComponent}
+                id="hub-secrets-list"
+                hub={@hub}
+                secrets={@secrets}
+                target={@myself}
+              />
+            </div>
+
+            <div class="flex flex-col space-y-4">
+              <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
+                Stamping
+              </h2>
+
+              <p class="text-gray-700">
+                Notebooks may be stamped using your <span class="font-medium text-gray-800">secret key</span>.
+                A stamp allows to securely store information such as the names of the secrets that you granted access to.
+                You must not share your secret key with others. But you may copy the secret key between
+                different machines you own.
+              </p>
+              <p class="text-gray-700">
+                If you change the <span class="font-medium text-gray-800">secret key</span>, you will need
+                to grant access to secrets once again in previously stamped notebooks.
+              </p>
+
+              <.form
+                :let={f}
+                id={"#{@id}-stamp"}
+                class="flex flex-col mt-4 space-y-4"
+                for={@stamp_changeset}
+                phx-submit="stamp_save"
+                phx-change="stamp_validate"
+                phx-target={@myself}
+              >
+                <div class="flex space-x-2">
+                  <div class="grow">
+                    <.password_field field={f[:secret_key]} label="Secret key" />
+                  </div>
+                  <div class="mt-6">
+                    <span class="tooltip top" data-tooltip="Generate">
+                      <button
+                        class="button-base button-outlined-gray button-square-icon"
+                        type="button"
+                        phx-click="generate_secret_key"
+                        phx-target={@myself}
+                      >
+                        <.remix_icon icon="refresh-line" class="text-xl" />
+                      </button>
+                    </span>
+                  </div>
+                </div>
+                <div>
+                  <button
+                    class="button-base button-blue"
+                    type="submit"
+                    phx-disable-with="Updating..."
+                    disable={not @stamp_changeset.valid?}
+                  >
+                    Save
+                  </button>
+                </div>
+              </.form>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <.modal
         :if={@live_action in [:new_secret, :edit_secret]}
         id="secrets-modal"
@@ -49,122 +167,6 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
           return_to={~p"/hub/#{@hub.id}"}
         />
       </.modal>
-
-      <div class="space-y-4">
-        <LayoutHelpers.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
-
-        <p class="text-gray-700">
-          Your personal hub. All data is stored on your machine and only you can access it.
-        </p>
-      </div>
-
-      <div class="flex flex-col space-y-10">
-        <div class="flex flex-col space-y-2">
-          <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
-            General
-          </h2>
-
-          <.form
-            :let={f}
-            id={@id}
-            class="flex flex-col mt-4 space-y-4"
-            for={@changeset}
-            phx-submit="save"
-            phx-change="validate"
-            phx-target={@myself}
-          >
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <.text_field field={f[:hub_name]} label="Name" />
-              <.emoji_field field={f[:hub_emoji]} label="Emoji" />
-            </div>
-            <div>
-              <button
-                class="button-base button-blue"
-                type="submit"
-                phx-disable-with="Updating..."
-                disable={not @changeset.valid?}
-              >
-                Save
-              </button>
-            </div>
-          </.form>
-        </div>
-
-        <div class="flex flex-col space-y-4">
-          <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
-            Secrets
-          </h2>
-
-          <p class="text-gray-700">
-            Secrets are a safe way to share credentials and tokens with notebooks.
-            They are often shared with Smart cells and can be read as
-            environment variables using the <code>LB_</code> prefix.
-          </p>
-
-          <.live_component
-            module={LivebookWeb.Hub.SecretListComponent}
-            id="hub-secrets-list"
-            hub={@hub}
-            secrets={@secrets}
-            target={@myself}
-          />
-        </div>
-
-        <div class="flex flex-col space-y-4">
-          <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
-            Stamping
-          </h2>
-
-          <p class="text-gray-700">
-            Notebooks may be stamped using your <span class="font-medium text-gray-800">secret key</span>.
-            A stamp allows to securely store information such as the names of the secrets that you granted access to.
-            You must not share your secret key with others. But you may copy the secret key between
-            different machines you own.
-          </p>
-          <p class="text-gray-700">
-            If you change the <span class="font-medium text-gray-800">secret key</span>, you will need
-            to grant access to secrets once again in previously stamped notebooks.
-          </p>
-
-          <.form
-            :let={f}
-            id={"#{@id}-stamp"}
-            class="flex flex-col mt-4 space-y-4"
-            for={@stamp_changeset}
-            phx-submit="stamp_save"
-            phx-change="stamp_validate"
-            phx-target={@myself}
-          >
-            <div class="flex space-x-2">
-              <div class="grow">
-                <.password_field field={f[:secret_key]} label="Secret key" />
-              </div>
-              <div class="mt-6">
-                <span class="tooltip top" data-tooltip="Generate">
-                  <button
-                    class="button-base button-outlined-gray button-square-icon"
-                    type="button"
-                    phx-click="generate_secret_key"
-                    phx-target={@myself}
-                  >
-                    <.remix_icon icon="refresh-line" class="text-xl" />
-                  </button>
-                </span>
-              </div>
-            </div>
-            <div>
-              <button
-                class="button-base button-blue"
-                type="submit"
-                phx-disable-with="Updating..."
-                disable={not @stamp_changeset.valid?}
-              >
-                Save
-              </button>
-            </div>
-          </.form>
-        </div>
-      </div>
     </div>
     """
   end

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -15,9 +15,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
 
     secret_value =
       if assigns.live_action == :edit_secret do
-        secrets
-        |> Enum.find(&(&1.name == secret_name))
-        |> Map.get(:value)
+        Enum.find_value(secrets, &(&1.name == secret_name && &1.value))
       end
 
     {:ok,

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -142,6 +142,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
           <LayoutHelpers.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
 
           <button
+            id="delete-hub"
             phx-click={JS.push("delete_hub", value: %{id: @hub.id})}
             class="absolute right-0 button-base button-red"
           >

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -33,6 +33,66 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
   def render(assigns) do
     ~H"""
     <div id={"#{@id}-component"}>
+      <div class="mb-8">
+        <div class="flex relative mb-8">
+          <LayoutHelpers.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
+
+          <button
+            id="delete-hub"
+            phx-click={JS.push("delete_hub", value: %{id: @hub.id})}
+            class="absolute right-0 button-base button-red"
+          >
+            Delete hub
+          </button>
+        </div>
+
+        <div class="flex flex-col space-y-10">
+          <div class="flex flex-col space-y-2">
+            <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
+              General
+            </h2>
+
+            <.form
+              :let={f}
+              id={@id}
+              class="flex flex-col mt-4 space-y-4"
+              for={@form}
+              phx-submit="save"
+              phx-change="validate"
+              phx-target={@myself}
+            >
+              <div class="grid grid-cols-1 md:grid-cols-1 gap-3">
+                <.emoji_field field={f[:hub_emoji]} label="Emoji" />
+              </div>
+
+              <button class="button-base button-blue" type="submit" phx-disable-with="Updating...">
+                Update Hub
+              </button>
+            </.form>
+          </div>
+
+          <div class="flex flex-col space-y-4">
+            <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
+              Secrets
+            </h2>
+
+            <p class="text-gray-700">
+              Secrets are a safe way to share credentials and tokens with notebooks.
+              They are often shared with Smart cells and can be read as
+              environment variables using the <code>LB_</code> prefix.
+            </p>
+
+            <.live_component
+              module={LivebookWeb.Hub.SecretListComponent}
+              id="hub-secrets-list"
+              hub={@hub}
+              secrets={@secrets}
+              target={@myself}
+            />
+          </div>
+        </div>
+      </div>
+
       <.modal
         :if={@show_key}
         id="show-key-modal"
@@ -134,66 +194,6 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
           return_to={~p"/hub/#{@hub.id}"}
         />
       </.modal>
-
-      <div class="space-y-8">
-        <div class="flex relative">
-          <LayoutHelpers.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
-
-          <button
-            id="delete-hub"
-            phx-click={JS.push("delete_hub", value: %{id: @hub.id})}
-            class="absolute right-0 button-base button-red"
-          >
-            Delete hub
-          </button>
-        </div>
-
-        <div class="flex flex-col space-y-10">
-          <div class="flex flex-col space-y-2">
-            <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
-              General
-            </h2>
-
-            <.form
-              :let={f}
-              id={@id}
-              class="flex flex-col mt-4 space-y-4"
-              for={@form}
-              phx-submit="save"
-              phx-change="validate"
-              phx-target={@myself}
-            >
-              <div class="grid grid-cols-1 md:grid-cols-1 gap-3">
-                <.emoji_field field={f[:hub_emoji]} label="Emoji" />
-              </div>
-
-              <button class="button-base button-blue" type="submit" phx-disable-with="Updating...">
-                Update Hub
-              </button>
-            </.form>
-          </div>
-
-          <div class="flex flex-col space-y-4">
-            <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
-              Secrets
-            </h2>
-
-            <p class="text-gray-700">
-              Secrets are a safe way to share credentials and tokens with notebooks.
-              They are often shared with Smart cells and can be read as
-              environment variables using the <code>LB_</code> prefix.
-            </p>
-
-            <.live_component
-              module={LivebookWeb.Hub.SecretListComponent}
-              id="hub-secrets-list"
-              hub={@hub}
-              secrets={@secrets}
-              target={@myself}
-            />
-          </div>
-        </div>
-      </div>
     </div>
     """
   end

--- a/lib/livebook_web/live/hub/edit_live.ex
+++ b/lib/livebook_web/live/hub/edit_live.ex
@@ -60,6 +60,7 @@ defmodule LivebookWeb.Hub.EditLive do
     <.live_component
       module={LivebookWeb.Hub.Edit.TeamComponent}
       hub={@hub}
+      live_action={@live_action}
       params={@params}
       id="team-form"
     />

--- a/lib/livebook_web/live/hub/secret_form_component.ex
+++ b/lib/livebook_web/live/hub/secret_form_component.ex
@@ -87,6 +87,12 @@ defmodule LivebookWeb.Hub.SecretFormComponent do
     else
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
+
+      {:transport_error, error} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, error)
+         |> push_patch(to: "/hub/#{socket.assigns.hub.id}/secrets/new")}
     end
   end
 

--- a/lib/livebook_web/live/hub/secret_list_component.ex
+++ b/lib/livebook_web/live/hub/secret_list_component.ex
@@ -1,0 +1,108 @@
+defmodule LivebookWeb.Hub.SecretListComponent do
+  use LivebookWeb, :live_component
+
+  alias Livebook.Hubs
+  alias Livebook.Secrets
+  alias Livebook.Secrets.Secret
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id} class="flex flex-col space-y-4">
+      <div class="flex flex-col space-y-4">
+        <.no_entries :if={@secrets == []}>
+          No secrets in this Hub yet.
+        </.no_entries>
+        <div
+          :for={secret <- @secrets}
+          class="flex items-center justify-between border border-gray-200 rounded-lg p-4"
+        >
+          <div class="grid grid-cols-1 md:grid-cols-2 w-full">
+            <div class="place-content-start">
+              <.labeled_text label="Name">
+                <%= secret.name %>
+              </.labeled_text>
+            </div>
+
+            <div class="flex items-center place-content-end">
+              <.menu id={"hub-secret-#{secret.name}-menu"}>
+                <:toggle>
+                  <button
+                    class="icon-button"
+                    aria-label="open environment variable menu"
+                    type="button"
+                  >
+                    <.remix_icon icon="more-2-fill" class="text-xl" />
+                  </button>
+                </:toggle>
+                <.menu_item>
+                  <.link
+                    id={"hub-secret-#{secret.name}-edit"}
+                    patch={~p"/hub/#{secret.hub_id}/secrets/edit/#{secret.name}"}
+                    type="button"
+                    role="menuitem"
+                  >
+                    <.remix_icon icon="file-edit-line" />
+                    <span>Edit</span>
+                  </.link>
+                </.menu_item>
+                <.menu_item variant={:danger}>
+                  <button
+                    id={"hub-secret-#{secret.name}-delete"}
+                    type="button"
+                    phx-click={
+                      JS.push("delete_hub_secret",
+                        value: %{
+                          name: secret.name,
+                          value: secret.value,
+                          hub_id: secret.hub_id
+                        }
+                      )
+                    }
+                    phx-target={@target}
+                    role="menuitem"
+                  >
+                    <.remix_icon icon="delete-bin-line" />
+                    <span>Delete</span>
+                  </button>
+                </.menu_item>
+              </.menu>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex">
+        <.link patch={~p"/hub/#{@hub.id}/secrets/new"} class="button-base button-blue" id="add-secret">
+          Add secret
+        </.link>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("delete_hub_secret", attrs, socket) do
+    on_confirm = fn socket ->
+      {:ok, secret} = Secrets.update_secret(%Secret{}, attrs)
+      hub = Livebook.Hubs.fetch_hub!(secret.hub_id)
+
+      case Hubs.delete_secret(hub, secret) do
+        :ok -> socket
+        {:transport_error, reason} -> put_flash(socket, :error, reason)
+      end
+    end
+
+    {:noreply,
+     confirm(socket, on_confirm,
+       title: "Delete hub secret - #{attrs["name"]}",
+       description: "Are you sure you want to delete this hub secret?",
+       confirm_text: "Delete",
+       confirm_icon: "delete-bin-6-line"
+     )}
+  end
+end

--- a/lib/livebook_web/live/layout_helpers.ex
+++ b/lib/livebook_web/live/layout_helpers.ex
@@ -239,9 +239,10 @@ defmodule LivebookWeb.LayoutHelpers do
       "h-7 flex items-center hover:text-white #{text_color} border-l-4 #{border_color} hover:border-white"
 
     if hub.connected? do
-      [navigate: to, class: class]
+      [id: "hub-#{hub.id}", navigate: to, class: class]
     else
       [
+        id: "hub-#{hub.id}",
         navigate: to,
         data_tooltip: Provider.connection_error(hub.provider),
         class: "tooltip right " <> class

--- a/lib/livebook_web/live/layout_helpers.ex
+++ b/lib/livebook_web/live/layout_helpers.ex
@@ -164,6 +164,7 @@ defmodule LivebookWeb.LayoutHelpers do
   defp sidebar_hub_link(assigns) do
     ~H"""
     <.link
+      id={"hub-#{@hub.id}"}
       navigate={@to}
       class={[
         "h-7 flex items-center hover:text-white border-l-4 hover:border-white",

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -37,7 +37,7 @@ defmodule LivebookWeb.Hub.EditLiveTest do
       id = hub.id
       assert_receive {:hub_changed, ^id}
 
-      assert_sidebar_hub(view, id, "/hub/#{hub.id}", hub.hub_name, attrs["hub_emoji"])
+      assert_sidebar_hub(view, id, hub.hub_name, attrs["hub_emoji"])
       refute Hubs.fetch_hub!(hub.id) == hub
     end
 

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -9,7 +9,7 @@ defmodule LivebookWeb.Hub.EditLiveTest do
 
   describe "personal" do
     setup do
-      Livebook.Hubs.subscribe([:secrets])
+      Livebook.Hubs.subscribe([:crud, :secrets])
       {:ok, hub: Hubs.fetch_hub!(Hubs.Personal.id())}
     end
 
@@ -34,7 +34,10 @@ defmodule LivebookWeb.Hub.EditLiveTest do
 
       assert render(view) =~ "Hub updated successfully"
 
-      assert_sidebar_hub(view, "/hub/#{hub.id}", hub.hub_name, attrs["hub_emoji"])
+      id = hub.id
+      assert_receive {:hub_changed, ^id}
+
+      assert_sidebar_hub(view, id, "/hub/#{hub.id}", hub.hub_name, attrs["hub_emoji"])
       refute Hubs.fetch_hub!(hub.id) == hub
     end
 

--- a/test/livebook_web/live/hub/new_live_test.exs
+++ b/test/livebook_web/live/hub/new_live_test.exs
@@ -3,6 +3,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
 
   alias Livebook.Teams.Org
 
+  import Livebook.HubHelpers
   import Phoenix.LiveViewTest
 
   test "render hub selection cards", %{conn: conn} do
@@ -59,7 +60,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       refute has_element?(view, "#show-key-modal")
 
       # checks if the hub is in the sidebar
-      assert_hub(view, "/hub/team-#{name}", name)
+      assert_sidebar_hub(view, "/hub/team-#{name}", name)
     end
   end
 
@@ -120,17 +121,9 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       refute has_element?(view, "#show-key-modal")
 
       # checks if the hub is in the sidebar
-      assert_hub(view, "/hub/team-#{name}", name)
+      assert_sidebar_hub(view, "/hub/team-#{name}", name)
     end
   end
 
   defp check_completion_data_interval(), do: 2000
-
-  defp assert_hub(view, path, name, emoji \\ "🐈") do
-    hubs_html = view |> element("#hubs") |> render()
-
-    assert hubs_html =~ emoji
-    assert hubs_html =~ path
-    assert hubs_html =~ name
-  end
 end

--- a/test/livebook_web/live/hub/new_live_test.exs
+++ b/test/livebook_web/live/hub/new_live_test.exs
@@ -60,7 +60,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       refute has_element?(view, "#show-key-modal")
 
       # checks if the hub is in the sidebar
-      assert_sidebar_hub(view, "/hub/team-#{name}", name)
+      assert_sidebar_hub(view, "team-#{name}", name)
     end
   end
 
@@ -121,7 +121,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       refute has_element?(view, "#show-key-modal")
 
       # checks if the hub is in the sidebar
-      assert_sidebar_hub(view, "/hub/team-#{name}", name)
+      assert_sidebar_hub(view, "team-#{name}", name)
     end
   end
 

--- a/test/livebook_web/live/integration/hub/edit_live_test.exs
+++ b/test/livebook_web/live/integration/hub/edit_live_test.exs
@@ -42,7 +42,7 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
       id = hub.id
       assert_receive {:hub_changed, ^id}
 
-      assert_sidebar_hub(view, id, "/hub/#{hub.id}", hub.hub_name, attrs["hub_emoji"])
+      assert_sidebar_hub(view, id, hub.hub_name, attrs["hub_emoji"])
       refute Hubs.fetch_hub!(hub.id) == hub
     end
 

--- a/test/livebook_web/live/integration/hub/edit_live_test.exs
+++ b/test/livebook_web/live/integration/hub/edit_live_test.exs
@@ -1,0 +1,177 @@
+defmodule LivebookWeb.Integration.Hub.EditLiveTest do
+  use Livebook.TeamsIntegrationCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Livebook.HubHelpers
+  import Livebook.TestHelpers
+
+  alias Livebook.Hubs
+
+  describe "team" do
+    setup %{user: user, node: node} do
+      Livebook.Hubs.subscribe([:crud, :connection, :secrets])
+      hub = create_team_hub(user, node)
+      id = hub.id
+
+      assert_receive {:hub_connected, ^id}
+
+      {:ok, hub: hub}
+    end
+
+    test "updates the hub", %{conn: conn, hub: hub} do
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+
+      attrs = %{"hub_emoji" => "🐈"}
+
+      view
+      |> element("#team-form")
+      |> render_change(%{"team" => attrs})
+
+      refute view
+             |> element("#team-form .invalid-feedback")
+             |> has_element?()
+
+      assert {:ok, view, _html} =
+               view
+               |> element("#team-form")
+               |> render_submit(%{"team" => attrs})
+               |> follow_redirect(conn)
+
+      assert render(view) =~ "Hub updated successfully"
+
+      id = hub.id
+      assert_receive {:hub_changed, ^id}
+
+      assert_sidebar_hub(view, id, "/hub/#{hub.id}", hub.hub_name, attrs["hub_emoji"])
+      refute Hubs.fetch_hub!(hub.id) == hub
+    end
+
+    test "deletes the hub", %{conn: conn, hub: hub} do
+      id = hub.id
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+
+      view
+      |> element("#delete-hub", "Delete hub")
+      |> render_click()
+
+      render_confirm(view)
+
+      assert_receive {:hub_changed, ^id}
+      %{"success" => "Hub deleted successfully"} = assert_redirect(view, "/")
+
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      refute_sidebar_hub(view, id)
+      assert_raise Livebook.Storage.NotFoundError, fn -> Hubs.fetch_hub!(id) end
+    end
+
+    test "creates a secret", %{conn: conn, hub: hub} do
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+      secret = build(:secret, name: "TEAM_ADD_SECRET", hub_id: hub.id, readonly: true)
+
+      attrs = %{
+        secret: %{
+          name: secret.name,
+          value: secret.value,
+          hub_id: secret.hub_id
+        }
+      }
+
+      refute render(view) =~ secret.name
+
+      view
+      |> element("#add-secret")
+      |> render_click(%{})
+
+      assert_patch(view, ~p"/hub/#{hub.id}/secrets/new")
+      assert render(view) =~ "Add secret"
+
+      view
+      |> element("#secrets-form")
+      |> render_change(attrs)
+
+      refute view
+             |> element("#secrets-form button[disabled]")
+             |> has_element?()
+
+      view
+      |> element("#secrets-form")
+      |> render_submit(attrs)
+
+      assert_receive {:secret_created, ^secret}
+      %{"success" => "Secret created successfully"} = assert_redirect(view, "/hub/#{hub.id}")
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+
+      assert render(element(view, "#hub-secrets-list")) =~ secret.name
+      assert secret in Livebook.Hubs.get_secrets(hub)
+    end
+
+    test "updates existing secret", %{conn: conn, hub: hub} do
+      secret = insert_secret(name: "TEAM_EDIT_SECRET", hub_id: hub.id, readonly: true)
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+
+      attrs = %{
+        secret: %{
+          name: secret.name,
+          value: secret.value,
+          hub_id: secret.hub_id
+        }
+      }
+
+      new_value = "new_value"
+
+      view
+      |> element("#hub-secret-#{secret.name}-edit")
+      |> render_click(%{"secret_name" => secret.name})
+
+      assert_patch(view, ~p"/hub/#{hub.id}/secrets/edit/#{secret.name}")
+      assert render(view) =~ "Edit secret"
+
+      view
+      |> element("#secrets-form")
+      |> render_change(attrs)
+
+      refute view
+             |> element("#secrets-form button[disabled]")
+             |> has_element?()
+
+      view
+      |> element("#secrets-form")
+      |> render_submit(put_in(attrs.secret.value, new_value))
+
+      updated_secret = %{secret | value: new_value}
+
+      assert_receive {:secret_updated, ^updated_secret}
+      %{"success" => "Secret updated successfully"} = assert_redirect(view, "/hub/#{hub.id}")
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+      assert render(element(view, "#hub-secrets-list")) =~ secret.name
+      assert updated_secret in Livebook.Hubs.get_secrets(hub)
+    end
+
+    test "deletes existing secret", %{conn: conn, hub: hub} do
+      secret = insert_secret(name: "TEAM_DELETE_SECRET", hub_id: hub.id, readonly: true)
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+
+      refute view
+             |> element("#secrets-form button[disabled]")
+             |> has_element?()
+
+      view
+      |> element("#hub-secret-#{secret.name}-delete", "Delete")
+      |> render_click()
+
+      render_confirm(view)
+
+      assert_receive {:secret_deleted, ^secret}
+      %{"success" => "Secret deleted successfully"} = assert_redirect(view, "/hub/#{hub.id}")
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+      refute render(element(view, "#hub-secrets-list")) =~ secret.name
+      refute secret in Livebook.Hubs.get_secrets(hub)
+    end
+  end
+end

--- a/test/livebook_web/live/integration/session_live_test.exs
+++ b/test/livebook_web/live/integration/session_live_test.exs
@@ -1,6 +1,7 @@
 defmodule LivebookWeb.Integration.SessionLiveTest do
   use Livebook.TeamsIntegrationCase, async: true
 
+  import Livebook.HubHelpers
   import Livebook.SessionHelpers
   import Phoenix.LiveViewTest
 
@@ -241,31 +242,5 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
 
       assert output == "\e[32m\"#{secret.value}\"\e[0m"
     end
-  end
-
-  defp create_team_hub(user, node) do
-    teams_org = build(:org)
-    teams_key = teams_org.teams_key
-    key_hash = Livebook.Teams.Org.key_hash(teams_org)
-
-    org = erpc_call(node, :create_org, [])
-    org_key = erpc_call(node, :create_org_key, [[org: org, key_hash: key_hash]])
-    org_key_pair = erpc_call(node, :create_org_key_pair, [[org: org]])
-    token = erpc_call(node, :associate_user_with_org, [user, org])
-
-    insert_hub(:team,
-      id: "team-#{org.name}",
-      hub_name: org.name,
-      user_id: user.id,
-      org_id: org.id,
-      org_key_id: org_key.id,
-      org_public_key: org_key_pair.public_key,
-      session_token: token,
-      teams_key: teams_key
-    )
-  end
-
-  defp erpc_call(node, fun, args) do
-    :erpc.call(node, Hub.Integration, fun, args)
   end
 end

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -1,7 +1,9 @@
 defmodule Livebook.HubHelpers do
   @moduledoc false
 
+  import ExUnit.Assertions
   import Livebook.Factory
+  import Phoenix.LiveViewTest
 
   def create_team_hub(user, node) do
     hub = build_team_hub(user, node)
@@ -41,6 +43,14 @@ defmodule Livebook.HubHelpers do
       session_token: token,
       teams_key: teams_key
     )
+  end
+
+  def assert_sidebar_hub(view, path, name, emoji \\ "🐈") do
+    hubs_html = view |> element("#hubs") |> render()
+
+    assert hubs_html =~ emoji
+    assert hubs_html =~ path
+    assert hubs_html =~ name
   end
 
   defp erpc_call(node, fun, args) do

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -1,0 +1,49 @@
+defmodule Livebook.HubHelpers do
+  @moduledoc false
+
+  import Livebook.Factory
+
+  def create_team_hub(user, node) do
+    hub = build_team_hub(user, node)
+    Livebook.Hubs.save_hub(hub)
+  end
+
+  def build_team_headers(user, node) do
+    hub = build_team_hub(user, node)
+
+    headers = [
+      {"x-user", to_string(hub.user_id)},
+      {"x-org", to_string(hub.org_id)},
+      {"x-org-key", to_string(hub.org_key_id)},
+      {"x-session-token", hub.session_token}
+    ]
+
+    {hub, headers}
+  end
+
+  defp build_team_hub(user, node) do
+    teams_org = build(:org)
+    teams_key = teams_org.teams_key
+    key_hash = Livebook.Teams.Org.key_hash(teams_org)
+
+    org = erpc_call(node, :create_org, [])
+    org_key = erpc_call(node, :create_org_key, [[org: org, key_hash: key_hash]])
+    org_key_pair = erpc_call(node, :create_org_key_pair, [[org: org]])
+    token = erpc_call(node, :associate_user_with_org, [user, org])
+
+    build(:team,
+      id: "team-#{org.name}",
+      hub_name: org.name,
+      user_id: user.id,
+      org_id: org.id,
+      org_key_id: org_key.id,
+      org_public_key: org_key_pair.public_key,
+      session_token: token,
+      teams_key: teams_key
+    )
+  end
+
+  defp erpc_call(node, fun, args) do
+    :erpc.call(node, Hub.Integration, fun, args)
+  end
+end

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -45,13 +45,20 @@ defmodule Livebook.HubHelpers do
     )
   end
 
-  def assert_sidebar_hub(view, path, name, emoji \\ "🐈") do
-    hubs_html = view |> element("#hubs") |> render()
+  def assert_sidebar_hub(view, id, path, name, emoji \\ "🐈") do
+    hub = element(view, hub_element_id(id))
+    hub_html = render(hub)
 
-    assert hubs_html =~ emoji
-    assert hubs_html =~ path
-    assert hubs_html =~ name
+    assert hub_html =~ emoji
+    assert hub_html =~ path
+    assert hub_html =~ name
   end
+
+  def refute_sidebar_hub(view, id) do
+    refute has_element?(view, hub_element_id(id))
+  end
+
+  defp hub_element_id(id), do: "#hubs #hub-#{id}"
 
   defp erpc_call(node, fun, args) do
     :erpc.call(node, Hub.Integration, fun, args)

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -50,7 +50,7 @@ defmodule Livebook.HubHelpers do
     hub_html = render(hub)
 
     assert hub_html =~ emoji
-    assert hub_html =~ "/hub/#{id}" 
+    assert hub_html =~ "/hub/#{id}"
     assert hub_html =~ name
   end
 

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -45,12 +45,12 @@ defmodule Livebook.HubHelpers do
     )
   end
 
-  def assert_sidebar_hub(view, id, path, name, emoji \\ "🐈") do
+  def assert_sidebar_hub(view, id, name, emoji \\ "🐈") do
     hub = element(view, hub_element_id(id))
     hub_html = render(hub)
 
     assert hub_html =~ emoji
-    assert hub_html =~ path
+    assert hub_html =~ "/hub/#{id}" 
     assert hub_html =~ name
   end
 


### PR DESCRIPTION
The new secrets flow (redirect from session to hub page to edit/delete secrets) will be done in the next PR.