### PR TITLE
Fix release cookie on Windows

### DIFF
--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -13,7 +13,8 @@ set PATH=!RELEASE_ROOT!\vendor\otp\erts-<%= @release.erts_version%>\bin;!RELEASE
 set cookie_path=!RELEASE_ROOT!\releases\COOKIE
 if not exist %cookie_path% (
   for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
-  echo cookie-!TIMESTAMP:~0,11!-!RANDOM! > %cookie_path%
+  :: '| set /p=""' is so that we don't add ' \r\n' to the cookie
+  echo | set /p="cookie-!TIMESTAMP:~0,11!-!RANDOM!" > %cookie_path%
 )
 
 cd !HOMEDRIVE!!HOMEPATH!

--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -7,6 +7,7 @@ set cookie_path="!RELEASE_ROOT!\releases\COOKIE"
 if not exist %cookie_path% (
   if not defined RELEASE_COOKIE (
     for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
-    echo cookie-!TIMESTAMP:~0,11!-!RANDOM! > %cookie_path%
+    :: '| set /p=""' is so that we don't add ' \r\n' to the cookie
+    echo | set /p="cookie-!TIMESTAMP:~0,11!-!RANDOM!" > %cookie_path%
   )
 )


### PR DESCRIPTION
Livebook Desktop on main started failing when executing code in a notebook because the cookie didn't match.

I noticed `releases/COOKIE` ended up being e.g. `cookie-20230627115-32366 \r\n`, that is, there was a trailing space and CRLF. I think what was happening was this whitespace ended up stripped in `-setcookie x` due to command line parsing and hence the mismatch.
