### PR TITLE
Refactor code based on Credo suggestions

### DIFF
--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -331,7 +331,7 @@ defmodule Livebook.LiveMarkdown.Export do
     |> Enum.map(fn {_modifiers, string} -> string end)
   end
 
-  defp render_notebook_footer(_notebook, _notebook_source, _include_stamp? = false), do: {[], []}
+  defp render_notebook_footer(_notebook, _notebook_source, false = _include_stamp?), do: {[], []}
 
   defp render_notebook_footer(notebook, notebook_source, true) do
     metadata = notebook_stamp_metadata(notebook)


### PR DESCRIPTION
This pull request includes code refactoring based on the suggestions from running the Credo static code analysis tool. The following changes were made:

1. Updated pattern matching in function arguments for clarity.
    - In `render_notebook_footer/3`, changed `_include_stamp? = false` to `false = _include_stamp?`.

2. Modified variable assignment to avoid reassigning function parameters.
    - In `handle_cast/2`, replaced the reassignment of `state` with a new variable `new_state` and updated the subsequent `broadcast_changes/2` call to use `new_state` and `state`.

These changes are aimed at improving the readability and maintainability of the code by adhering to Elixir best practices and Credo's suggestions.
wdyt?