### PR TITLE
Change new notebook button to link

### DIFF
--- a/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
+++ b/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
@@ -692,7 +692,7 @@ Now we have everything we need to connect across notebooks.
 
 ### Notebook connections
 
-In order to connect across notebooks, open up [a new empty notebook](/learn/notebooks/new)
+In order to connect across notebooks, open up [a new empty notebook](/new)
 in a separate tab, copy and paste the code below to this new notebook,
 and execute it:
 

--- a/lib/livebook_cli/server.ex
+++ b/lib/livebook_cli/server.ex
@@ -157,7 +157,7 @@ defmodule LivebookCLI.Server do
 
   defp open_from_args(base_url, ["@new"]) do
     base_url
-    |> set_path("/learn/notebooks/new")
+    |> set_path("/new")
     |> Livebook.Utils.browser_open()
   end
 

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -48,10 +48,10 @@ defmodule LivebookWeb.HomeLive do
           <.link navigate={~p"/open/file"} class="button-base button-outlined-gray whitespace-nowrap">
             Open
           </.link>
-          <button class="button-base button-blue" phx-click="new">
+          <.link class="button-base button-blue" patch={~p"/new"}>
             <.remix_icon icon="add-line" class="align-middle mr-1" />
             <span>New notebook</span>
-          </button>
+          </.link>
         </div>
       </:topbar_action>
 
@@ -68,10 +68,10 @@ defmodule LivebookWeb.HomeLive do
             >
               Open
             </.link>
-            <button class="button-base button-blue" phx-click="new">
+            <.link class="button-base button-blue" patch={~p"/new"}>
               <.remix_icon icon="add-line" class="align-middle mr-1" />
               <span>New notebook</span>
-            </button>
+            </.link>
           </div>
         </div>
 
@@ -225,13 +225,13 @@ defmodule LivebookWeb.HomeLive do
     {:noreply, assign(socket, session: session)}
   end
 
-  def handle_params(_params, _url, socket), do: {:noreply, socket}
-
-  @impl true
-  def handle_event("new", %{}, socket) do
+  def handle_params(%{}, _url, socket) when socket.assigns.live_action == :public_new_notebook do
     {:noreply, create_session(socket)}
   end
 
+  def handle_params(_params, _url, socket), do: {:noreply, socket}
+
+  @impl true
   def handle_event("unstar_notebook", %{"idx" => idx}, socket) do
     on_confirm = fn socket ->
       %{file: file} = Enum.fetch!(socket.assigns.starred_notebooks, idx)

--- a/lib/livebook_web/live/learn_live.ex
+++ b/lib/livebook_web/live/learn_live.ex
@@ -116,10 +116,6 @@ defmodule LivebookWeb.LearnLive do
   end
 
   @impl true
-  def handle_params(%{"slug" => "new"}, _url, socket) do
-    {:noreply, create_session(socket)}
-  end
-
   def handle_params(%{"slug" => slug}, _url, socket) do
     {notebook, images} = Learn.notebook_by_slug!(slug)
     {:noreply, create_session(socket, notebook: notebook, images: images)}

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -101,6 +101,7 @@ defmodule LivebookWeb.Router do
     scope "/", LivebookWeb do
       pipe_through [:browser, :auth]
 
+      live "/new", HomeLive, :public_new_notebook
       live "/import", OpenLive, :public_import
       live "/open", OpenLive, :public_open
     end

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -18,10 +18,19 @@ defmodule LivebookWeb.HomeLiveTest do
 
     assert {:error, {:live_redirect, %{to: to}}} =
              view
-             |> element(~s/[role="navigation"] button/, "New notebook")
+             |> element(~s/[role="navigation"] a/, "New notebook")
              |> render_click()
 
     assert to =~ "/sessions/"
+
+    close_session_by_path(to)
+  end
+
+  test "public new endpoint creates an empty session", %{conn: conn} do
+    assert {:error, {:live_redirect, %{to: to}}} = result = live(conn, ~p"/new")
+    {:ok, view, _} = follow_redirect(result, conn)
+
+    assert render(view) =~ "Untitled notebook"
 
     close_session_by_path(to)
   end

--- a/test/livebook_web/live/learn_live_test.exs
+++ b/test/livebook_web/live/learn_live_test.exs
@@ -19,15 +19,6 @@ defmodule LivebookWeb.LearnLiveTest do
     close_session_by_path(to)
   end
 
-  test "link to a new notebook creates an empty session", %{conn: conn} do
-    assert {:error, {:live_redirect, %{to: to}}} = result = live(conn, ~p"/learn/notebooks/new")
-    {:ok, view, _} = follow_redirect(result, conn)
-
-    assert render(view) =~ "Untitled notebook"
-
-    close_session_by_path(to)
-  end
-
   defp close_session_by_path("/sessions/" <> session_id) do
     {:ok, session} = Livebook.Sessions.fetch_session(session_id)
     Livebook.Session.close(session.pid)


### PR DESCRIPTION
A number of times I found myself clicking cmd + click on "+ New notebook", but currently it's a button with phx-click. This changes it to a URL so opening in new tab works, and also makes the URL more public since we use it in the CLI and even in one of the notebooks.