### PR TITLE
Update log filter for miscapitalized module loading error

### DIFF
--- a/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
+++ b/lib/livebook/runtime/erl_dist/logger_gl_handler.ex
@@ -18,17 +18,19 @@ defmodule Livebook.Runtime.ErlDist.LoggerGLHandler do
   end
 
   @doc false
-  def filter_code_server_logs(%{meta: meta} = event, _) do
+  def filter_code_server_logs(%{msg: msg} = event, _) do
     # During intellisense we check if certain modules are loaded. If
     # the module name is miscapitalized, such as "Io", and we are on
-    # a case insensitive file system, then :code_serverlogs an error
+    # a case insensitive file system, this results in a log error
     # message: "Error loading module 'Elixir.Io'". We want to ignore
     # such logs
 
-    if Process.whereis(:code_server) == meta.pid do
+    with {~c"~s~n", [content]} when is_list(content) <- msg,
+         true <- :string.str(content, ~c"Error loading module") > 0,
+         true <- :string.str(content, ~c"module name in object code is") > 0 do
       :stop
     else
-      event
+      _ -> event
     end
   end
 end


### PR DESCRIPTION
As of OTP 26 the log event no longer originates in `:code_server`, but in the process doing intellisense. Initially I wanted to use registry, but the process is dead when the logger filter runs. I just changed it to match on the specific error, which is unlikely to change.