### PR TITLE
Use topbar.show(delayInMS) instead of implementing the delay ourselves

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -6,17 +6,11 @@ export function registerTopbar() {
     shadowColor: "rgba(0, 0, 0, .3)",
   });
 
-  let topBarScheduled = null;
-
   window.addEventListener("phx:page-loading-start", () => {
-    if (!topBarScheduled) {
-      topBarScheduled = setTimeout(() => topbar.show(), 500);
-    }
+    topbar.show(500);
   });
 
   window.addEventListener("phx:page-loading-stop", () => {
-    clearTimeout(topBarScheduled);
-    topBarScheduled = null;
     topbar.hide();
   });
 }


### PR DESCRIPTION
Since 18a1b0e56c7e95da0d705dc3eb034fe7b686aacd we're using topbar in version `^2.0.1`, which has the delayed showing of the topbar built in (implemented in buunguyen/topbar#15).
