### PR TITLE
Add user-visible version on macOS

### DIFF
--- a/elixirkit/elixirkit_swift/Scripts/build_macos_app.sh
+++ b/elixirkit/elixirkit_swift/Scripts/build_macos_app.sh
@@ -18,6 +18,7 @@ if [ -f Info.plist ]; then
   cp Info.plist $app_dir/Contents/Info.plist
 
   plutil -replace CFBundleVersion -string "${app_version}" $app_dir/Contents/Info.plist
+  plutil -replace CFBundleShortVersionString -string "${app_version}" $app_dir/Contents/Info.plist
 fi
 
 cp $target_dir/$app_name $app_dir/Contents/MacOS/$app_name

--- a/rel/app/macos/Info.plist
+++ b/rel/app/macos/Info.plist
@@ -8,6 +8,8 @@
   <string>dev.livebook.Livebook</string>
   <key>CFBundleVersion</key>
   <string>$(app_version)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(app_version)</string>
   <key>CFBundleIconFile</key>
   <string>AppIcon</string>
   <key>CFBundleExecutable</key>


### PR DESCRIPTION
Add the [CFBundleShortVersionString field][CFBundleShortVersionString] to Info.plist, which makes the version visible to users in the Finder’s Get Info panel:

After:
<img width="266" alt="Screenshot 2023-07-11 at 10 10 01 pm" src="https://github.com/livebook-dev/livebook/assets/2635733/10f53830-88df-4b4f-b078-441ab4e0f324">

Before:
<img width="271" alt="image" src="https://github.com/livebook-dev/livebook/assets/2635733/759d48d4-7eaf-40ef-882f-1e116876d258">


[CFBundleShortVersionString]: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring