### PR TITLE
Show summary on failed doctests

### DIFF
--- a/lib/livebook/runtime/evaluator/doctests.ex
+++ b/lib/livebook/runtime/evaluator/doctests.ex
@@ -53,7 +53,6 @@ defmodule Livebook.Runtime.Evaluator.Doctests do
             report_doctest_running(test)
             test = run_test(test)
             report_doctest_result(test, lines)
-            test
           end)
         end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -2406,6 +2406,7 @@ defmodule LivebookWeb.SessionLive do
   defp eval_info_to_view(cell, eval_info, data) do
     %{
       outputs: cell.outputs,
+      doctest_summary: doctest_summary(eval_info.doctest_reports),
       validity: eval_info.validity,
       status: eval_info.status,
       errored: eval_info.errored,
@@ -2417,6 +2418,16 @@ defmodule LivebookWeb.SessionLive do
       # Pass input values relevant to the given cell
       input_values: input_values_for_cell(cell, data)
     }
+  end
+
+  defp doctest_summary(doctests) do
+    {doctests_count, failures_count} =
+      Enum.reduce(doctests, {0, 0}, fn
+        {_line, %{status: status}}, {total, failed} ->
+          {total + 1, if(status == :failed, do: failed + 1, else: failed)}
+      end)
+
+    %{doctests_count: doctests_count, failures_count: failures_count}
   end
 
   defp input_values_for_cell(cell, data) do

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -97,6 +97,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
           <.cell_status id={@cell_view.id} cell_view={@cell_view} />
         </div>
       </div>
+      <.doctest_summary cell_id={@cell_view.id} doctest_summary={@cell_view.eval.doctest_summary} />
       <.evaluation_outputs
         cell_view={@cell_view}
         session_id={@session_id}
@@ -608,6 +609,27 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp rounded_class(:both), do: "rounded-lg"
   defp rounded_class(:top), do: "rounded-t-lg"
   defp rounded_class(:bottom), do: "rounded-b-lg"
+
+  defp doctest_summary(assigns) do
+    ~H"""
+    <div
+      :if={@doctest_summary.failures_count > 0}
+      class="flex flex-col pt-2 font-medium"
+      id={"doctest-summary-#{@cell_id}"}
+    >
+      <div class="error-box">
+        <%= doctest_summary_message(@doctest_summary) %>
+      </div>
+    </div>
+    """
+  end
+
+  defp doctest_summary_message(%{doctests_count: total, failures_count: failed}) do
+    doctests_pl = pluralize(total, "doctest", "doctests")
+    failures_pl = if failed == 1, do: "failure has", else: "failures have"
+
+    "#{failed} out of #{doctests_pl} failed (#{failures_pl} been reported above)."
+  end
 
   defp evaluation_outputs(assigns) do
     ~H"""

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -612,11 +612,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   defp doctest_summary(assigns) do
     ~H"""
-    <div
-      :if={@doctest_summary.failures_count > 0}
-      class="pt-2"
-      id={"doctest-summary-#{@cell_id}"}
-    >
+    <div :if={@doctest_summary.failures_count > 0} class="pt-2" id={"doctest-summary-#{@cell_id}"}>
       <div class="error-box">
         <%= doctest_summary_message(@doctest_summary) %>
       </div>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -614,7 +614,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     ~H"""
     <div
       :if={@doctest_summary.failures_count > 0}
-      class="flex flex-col pt-2 font-medium"
+      class="pt-2"
       id={"doctest-summary-#{@cell_id}"}
     >
       <div class="error-box">
@@ -628,7 +628,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     doctests_pl = pluralize(total, "doctest", "doctests")
     failures_pl = if failed == 1, do: "failure has", else: "failures have"
 
-    "#{failed} out of #{doctests_pl} failed (#{failures_pl} been reported above)."
+    "#{failed} out of #{doctests_pl} failed (#{failures_pl} been reported above)"
   end
 
   defp evaluation_outputs(assigns) do


### PR DESCRIPTION
Addresses #2049 

I went with the `.error-box` suggested by @jonatanklosko.

Looks fine to me personally, but I'm notoriously bad at UI 😅 Text might be a little too prominent, maybe?

<img width="907" alt="doctest_summary" src="https://github.com/livebook-dev/livebook/assets/15570798/df378a58-647f-4b49-b323-165426003997">
