### PR TITLE
Add button for reevaluating apps on change and add retry for errors

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -2182,8 +2182,8 @@ defmodule Livebook.Session do
     state
   end
 
-  defp handle_action(state, {:clean_up_input_values, input_values}) do
-    for {_input_id, value} <- input_values do
+  defp handle_action(state, {:clean_up_input_values, input_infos}) do
+    for {_input_id, %{value: value}} <- input_infos do
       case value do
         value when is_file_input_value(value) ->
           schedule_file_deletion(state, value.file_ref)

--- a/lib/livebook_web/components/core_components.ex
+++ b/lib/livebook_web/components/core_components.ex
@@ -500,28 +500,36 @@ defmodule LivebookWeb.CoreComponents do
     ~H"""
     <span class="relative flex h-3 w-3">
       <span
-        :if={animated_circle_class(@variant)}
+        :if={animated_status_circle_class(@variant)}
         class={[
-          animated_circle_class(@variant),
+          animated_status_circle_class(@variant),
           "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75"
         ]}
       >
       </span>
-      <span class={[circle_class(@variant), "relative inline-flex rounded-full h-3 w-3"]}></span>
+      <span class={[status_circle_class(@variant), "relative inline-flex rounded-full h-3 w-3"]}>
+      </span>
     </span>
     """
   end
 
-  defp circle_class(:success), do: "bg-green-bright-400"
-  defp circle_class(:warning), do: "bg-yellow-bright-200"
-  defp circle_class(:error), do: "bg-red-400"
-  defp circle_class(:inactive), do: "bg-gray-500"
-  defp circle_class(:waiting), do: "bg-gray-400"
-  defp circle_class(:progressing), do: "bg-blue-500"
+  @doc """
+  Returns background class based on the given variant.
 
-  defp animated_circle_class(:waiting), do: "bg-gray-300"
-  defp animated_circle_class(:progressing), do: "bg-blue-400"
-  defp animated_circle_class(_other), do: nil
+  See `status_indicator/1` for available variants.
+  """
+  def status_circle_class(variant)
+
+  def status_circle_class(:success), do: "bg-green-bright-400"
+  def status_circle_class(:warning), do: "bg-yellow-bright-200"
+  def status_circle_class(:error), do: "bg-red-400"
+  def status_circle_class(:inactive), do: "bg-gray-500"
+  def status_circle_class(:waiting), do: "bg-gray-400"
+  def status_circle_class(:progressing), do: "bg-blue-500"
+
+  defp animated_status_circle_class(:waiting), do: "bg-gray-300"
+  defp animated_status_circle_class(:progressing), do: "bg-blue-400"
+  defp animated_status_circle_class(_other), do: nil
 
   @doc """
   Renders an informative box as a placeholder for a list.

--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -187,7 +187,12 @@ defmodule LivebookWeb.AppSessionLive do
         <span
           :if={@data_view.app_status.execution != :executing and @data_view.any_stale?}
           class="tooltip left"
-          data-tooltip="Process changes"
+          data-tooltip={
+            ~S'''
+            Some inputs have changed since they were last processed.
+            Click this button to reprocess with latest values.
+            '''
+          }
         >
           <button phx-click="queue_full_evaluation" class="icon-button">
             <.remix_icon icon="play-circle-fill" class="text-3xl" />

--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -147,29 +147,53 @@ defmodule LivebookWeb.AppSessionLive do
               session_pid={@session.pid}
               client_id={@client_id}
               cell_id={output_view.cell_id}
-              input_values={output_view.input_values}
+              input_views={output_view.input_views}
             />
           </div>
           <%= if @data_view.app_status.execution == :error do %>
-            <div class="error-box flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <.remix_icon icon="error-warning-line" class="text-xl" />
-                <span>Something went wrong</span>
+            <div class={[
+              "flex justify-between items-center px-4 py-2 border-l-4 shadow-custom-1",
+              "text-red-400 border-red-400"
+            ]}>
+              <div>
+                Something went wrong
               </div>
-              <.link
-                :if={@livebook_authenticated?}
-                navigate={~p"/sessions/#{@session.id}" <> "#cell-#{@data_view.errored_cell_id}"}
-              >
-                <span>Debug</span>
-                <.remix_icon icon="arrow-right-line" />
-              </.link>
+              <div class="flex items-center gap-6">
+                <span class="tooltip top" data-tooltip="Debug">
+                  <.link
+                    :if={@livebook_authenticated?}
+                    navigate={~p"/sessions/#{@session.id}" <> "#cell-#{@data_view.errored_cell_id}"}
+                  >
+                    <.remix_icon icon="terminal-line" />
+                  </.link>
+                </span>
+                <button
+                  class={[
+                    "button-base bg-transparent",
+                    "border-red-400 text-red-400 hover:bg-red-50 focus:bg-red-50"
+                  ]}
+                  phx-click="queue_errored_cells_evaluation"
+                >
+                  <.remix_icon icon="play-circle-fill" class="align-middle mr-1" />
+                  <span>Retry</span>
+                </button>
+              </div>
             </div>
           <% end %>
         </div>
         <div style="height: 80vh"></div>
       </div>
-      <div :if={show_app_status?(@data_view.app_status)} class="fixed right-6 bottom-4">
-        <.app_status status={@data_view.app_status} />
+      <div class="fixed right-3 bottom-4 flex flex-col gap-2 items-center text-gray-600 w-10">
+        <span
+          :if={@data_view.app_status.execution != :executing and @data_view.any_stale?}
+          class="tooltip left"
+          data-tooltip="Process changes"
+        >
+          <button phx-click="queue_full_evaluation" class="icon-button">
+            <.remix_icon icon="play-circle-fill" class="text-3xl" />
+          </button>
+        </span>
+        <.app_status_circle status={@data_view.app_status} />
       </div>
     </div>
 
@@ -191,6 +215,64 @@ defmodule LivebookWeb.AppSessionLive do
 
   def render(assigns), do: auth_placeholder(assigns)
 
+  attr :status, :map, required: true
+
+  defp app_status_circle(%{status: %{lifecycle: :shutting_down}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Shutting down" variant={:inactive} icon="stop-line" />
+    """
+  end
+
+  defp app_status_circle(%{status: %{lifecycle: :deactivated}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Deactivated" variant={:inactive} icon="stop-line" />
+    """
+  end
+
+  defp app_status_circle(%{status: %{execution: :executing}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Executing" variant={:progressing} icon="loader-3-line" spinning />
+    """
+  end
+
+  defp app_status_circle(%{status: %{execution: :executed}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Executed" variant={:success} icon="check-line" />
+    """
+  end
+
+  defp app_status_circle(%{status: %{execution: :error}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Error" variant={:error} icon="close-line" />
+    """
+  end
+
+  defp app_status_circle(%{status: %{execution: :interrupted}} = assigns) do
+    ~H"""
+    <.app_status_indicator text="Interrupted" variant={:waiting} icon="pause-line" />
+    """
+  end
+
+  attr :text, :string, required: true
+  attr :variant, :atom, required: true
+  attr :icon, :string, required: true
+  attr :spinning, :boolean, default: false
+
+  defp app_status_indicator(assigns) do
+    ~H"""
+    <span class="tooltip left" data-tooltip={@text}>
+      <span class={[
+        status_circle_class(@variant),
+        "opacity-75",
+        "w-6 h-6 rounded-full flex items-center justify-center",
+        @spinning && "animate-spin"
+      ]}>
+        <.remix_icon icon={@icon} class="text-white font-bold" />
+      </span>
+    </span>
+    """
+  end
+
   defp get_page_title(notebook_name) do
     "Livebook - #{notebook_name}"
   end
@@ -207,6 +289,22 @@ defmodule LivebookWeb.AppSessionLive do
       Session.queue_full_evaluation(socket.assigns.session.pid, [cell_id])
     end
 
+    {:noreply, socket}
+  end
+
+  def handle_event("queue_errored_cells_evaluation", %{}, socket) do
+    data = socket.private.data
+
+    errored_cell_ids =
+      for {cell_id, %{eval: eval_info}} <- data.cell_infos, eval_info.errored, do: cell_id
+
+    Session.queue_full_evaluation(socket.assigns.session.pid, errored_cell_ids)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("queue_full_evaluation", %{}, socket) do
+    Session.queue_full_evaluation(socket.assigns.session.pid, [])
     {:noreply, socket}
   end
 
@@ -297,6 +395,8 @@ defmodule LivebookWeb.AppSessionLive do
   end
 
   defp data_to_view(data) do
+    changed_input_ids = Session.Data.changed_input_ids(data)
+
     %{
       notebook_name: data.notebook.name,
       output_views:
@@ -304,7 +404,7 @@ defmodule LivebookWeb.AppSessionLive do
           {cell_id, output} <- visible_outputs(data.notebook),
           do: %{
             output: output,
-            input_values: input_values_for_output(output, data),
+            input_views: input_views_for_output(output, data, changed_input_ids),
             cell_id: cell_id
           }
         ),
@@ -312,7 +412,8 @@ defmodule LivebookWeb.AppSessionLive do
       show_source: data.notebook.app_settings.show_source,
       slug: data.notebook.app_settings.slug,
       multi_session: data.notebook.app_settings.multi_session,
-      errored_cell_id: errored_cell_id(data)
+      errored_cell_id: errored_cell_id(data),
+      any_stale?: any_stale?(data)
     }
   end
 
@@ -324,9 +425,18 @@ defmodule LivebookWeb.AppSessionLive do
     end)
   end
 
-  defp input_values_for_output(output, data) do
+  defp any_stale?(data) do
+    Enum.any?(data.cell_infos, &match?({_, %{eval: %{validity: :stale}}}, &1))
+  end
+
+  defp input_views_for_output(output, data, changed_input_ids) do
     input_ids = for attrs <- Cell.find_inputs_in_output(output), do: attrs.id
-    Map.take(data.input_values, input_ids)
+
+    data.input_infos
+    |> Map.take(input_ids)
+    |> Map.new(fn {input_id, %{value: value}} ->
+      {input_id, %{value: value, changed: MapSet.member?(changed_input_ids, input_id)}}
+    end)
   end
 
   defp visible_outputs(notebook) do
@@ -376,7 +486,4 @@ defmodule LivebookWeb.AppSessionLive do
     do: {idx, output}
 
   defp filter_output(_output), do: nil
-
-  defp show_app_status?(%{execution: :executed, lifecycle: :active}), do: false
-  defp show_app_status?(_status), do: true
 end

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -11,7 +11,7 @@ defmodule LivebookWeb.Output do
   attr :outputs, :list, required: true
   attr :session_id, :string, required: true
   attr :session_pid, :any, required: true
-  attr :input_values, :map, required: true
+  attr :input_views, :map, required: true
   attr :dom_id_map, :map, required: true
   attr :client_id, :string, required: true
   attr :cell_id, :string, required: true
@@ -29,7 +29,7 @@ defmodule LivebookWeb.Output do
         id: "output-#{idx}",
         session_id: @session_id,
         session_pid: @session_pid,
-        input_values: @input_values,
+        input_views: @input_views,
         client_id: @client_id,
         cell_id: @cell_id
       }) %>
@@ -95,7 +95,7 @@ defmodule LivebookWeb.Output do
          id: id,
          session_id: session_id,
          session_pid: session_pid,
-         input_values: input_values,
+         input_views: input_views,
          client_id: client_id,
          cell_id: cell_id
        }) do
@@ -105,7 +105,7 @@ defmodule LivebookWeb.Output do
       placeholder: Map.get(info, :placeholder, true),
       session_id: session_id,
       session_pid: session_pid,
-      input_values: input_values,
+      input_views: input_views,
       client_id: client_id,
       cell_id: cell_id
     )
@@ -115,7 +115,7 @@ defmodule LivebookWeb.Output do
          id: id,
          session_id: session_id,
          session_pid: session_pid,
-         input_values: input_values,
+         input_views: input_views,
          client_id: client_id,
          cell_id: cell_id
        }) do
@@ -138,7 +138,7 @@ defmodule LivebookWeb.Output do
       outputs: outputs,
       session_id: session_id,
       session_pid: session_pid,
-      input_values: input_values,
+      input_views: input_views,
       client_id: client_id,
       cell_id: cell_id
     }
@@ -177,7 +177,7 @@ defmodule LivebookWeb.Output do
             dom_id_map={%{}}
             session_id={@session_id}
             session_pid={@session_pid}
-            input_values={@input_values}
+            input_views={@input_views}
             client_id={@client_id}
             cell_id={@cell_id}
           />
@@ -191,7 +191,7 @@ defmodule LivebookWeb.Output do
          id: id,
          session_id: session_id,
          session_pid: session_pid,
-         input_values: input_values,
+         input_views: input_views,
          client_id: client_id,
          cell_id: cell_id
        }) do
@@ -205,7 +205,7 @@ defmodule LivebookWeb.Output do
       outputs: outputs,
       session_id: session_id,
       session_pid: session_pid,
-      input_values: input_values,
+      input_views: input_views,
       client_id: client_id,
       cell_id: cell_id
     }
@@ -224,7 +224,7 @@ defmodule LivebookWeb.Output do
             dom_id_map={%{}}
             session_id={@session_id}
             session_pid={@session_pid}
-            input_values={@input_values}
+            input_views={@input_views}
             client_id={@client_id}
             cell_id={@cell_id}
           />
@@ -236,14 +236,14 @@ defmodule LivebookWeb.Output do
 
   defp render_output({:input, attrs}, %{
          id: id,
-         input_values: input_values,
+         input_views: input_views,
          session_pid: session_pid,
          client_id: client_id
        }) do
     live_component(Output.InputComponent,
       id: id,
       attrs: attrs,
-      input_values: input_values,
+      input_views: input_views,
       session_pid: session_pid,
       client_id: client_id
     )
@@ -251,14 +251,14 @@ defmodule LivebookWeb.Output do
 
   defp render_output({:control, attrs}, %{
          id: id,
-         input_values: input_values,
+         input_views: input_views,
          session_pid: session_pid,
          client_id: client_id
        }) do
     live_component(Output.ControlComponent,
       id: id,
       attrs: attrs,
-      input_values: input_values,
+      input_views: input_views,
       session_pid: session_pid,
       client_id: client_id
     )

--- a/lib/livebook_web/live/output/control_component.ex
+++ b/lib/livebook_web/live/output/control_component.ex
@@ -54,7 +54,7 @@ defmodule LivebookWeb.Output.ControlComponent do
         module={LivebookWeb.Output.ControlFormComponent}
         id={@id}
         attrs={@attrs}
-        input_values={@input_values}
+        input_views={@input_views}
         session_pid={@session_pid}
         client_id={@client_id}
       />

--- a/lib/livebook_web/live/output/control_form_component.ex
+++ b/lib/livebook_web/live/output/control_form_component.ex
@@ -14,7 +14,7 @@ defmodule LivebookWeb.Output.ControlFormComponent do
 
     data =
       Map.new(assigns.attrs.fields, fn {field, input_attrs} ->
-        {field, assigns.input_values[input_attrs.id]}
+        {field, assigns.input_views[input_attrs.id].value}
       end)
 
     if data != prev_data do
@@ -41,7 +41,7 @@ defmodule LivebookWeb.Output.ControlFormComponent do
         module={LivebookWeb.Output.InputComponent}
         id={"#{@id}-#{input_attrs.id}"}
         attrs={input_attrs}
-        input_values={@input_values}
+        input_views={@input_views}
         session_pid={@session_pid}
         client_id={@client_id}
         local={true}

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -85,7 +85,7 @@ defmodule LivebookWeb.Output.FrameComponent do
             dom_id_map={@persistent_id_map}
             session_id={@session_id}
             session_pid={@session_pid}
-            input_values={@input_values}
+            input_views={@input_views}
             client_id={@client_id}
             cell_id={@cell_id}
           />

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -269,9 +269,9 @@ defmodule LivebookWeb.Output.InputComponent do
         <span
           :if={@changed}
           class="cursor-pointer tooltip top"
-          data-tooltip="This input has changed since it's been processed."
+          data-tooltip="This input has changed since it was last processed."
         >
-          <.remix_icon icon="error-warning-line" />
+          <.remix_icon icon="error-warning-line text-gray-500" />
         </span>
       </div>
     </.label>

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -12,12 +12,12 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   def update(assigns, socket) do
-    value = assigns.input_values[assigns.attrs.id]
+    %{value: value, changed: changed} = assigns.input_views[assigns.attrs.id]
 
     socket =
       socket
       |> assign(assigns)
-      |> assign(value: value)
+      |> assign(value: value, changed: changed)
 
     {:ok, socket}
   end
@@ -26,9 +26,7 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(%{attrs: %{type: :image}} = assigns) do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.label>
-        <%= @attrs.label %>
-      </.label>
+      <.input_label label={@attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.ImageInputComponent}
         id={"#{@id}-input"}
@@ -46,9 +44,7 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(%{attrs: %{type: :audio}} = assigns) do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.label>
-        <%= @attrs.label %>
-      </.label>
+      <.input_label label={@attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.AudioInputComponent}
         id={"#{@id}-input"}
@@ -64,9 +60,7 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(%{attrs: %{type: :file}} = assigns) do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.label>
-        <%= @attrs.label %>
-      </.label>
+      <.input_label label={@attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.FileInputComponent}
         id={"#{@id}-input"}
@@ -85,9 +79,11 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(%{attrs: %{type: :utc_datetime}} = assigns) do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.label help="Choose the time in your local time zone">
-        <%= @attrs.label %>
-      </.label>
+      <.input_label
+        label={@attrs.label}
+        changed={@changed}
+        help="Choose the time in your local time zone"
+      />
       <input
         id={@id}
         type="datetime-local"
@@ -109,9 +105,11 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(%{attrs: %{type: :utc_time}} = assigns) do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.label help="Choose the time in your local time zone">
-        <%= @attrs.label %>
-      </.label>
+      <.input_label
+        label={@attrs.label}
+        changed={@changed}
+        help="Choose the time in your local time zone"
+      />
       <input
         id={@id}
         type="time"
@@ -133,9 +131,7 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(assigns) do
     ~H"""
     <form id={"#{@id}-form-#{@counter}"} phx-change="change" phx-submit="submit" phx-target={@myself}>
-      <.label>
-        <%= @attrs.label %>
-      </.label>
+      <.input_label label={@attrs.label} changed={@changed} />
       <.input_output id={"#{@id}-input"} attrs={@attrs} value={@value} myself={@myself} />
     </form>
     """
@@ -258,6 +254,27 @@ defmodule LivebookWeb.Output.InputComponent do
     <div class="text-red-600">
       Unknown input type <%= @attrs.type %>
     </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :changed, :boolean, required: true
+  attr :help, :string, default: nil
+
+  defp input_label(assigns) do
+    ~H"""
+    <.label help={@help}>
+      <div class="flex items-center justify-between gap-1">
+        <span><%= @label %></span>
+        <span
+          :if={@changed}
+          class="cursor-pointer tooltip top"
+          data-tooltip="This input has changed since it's been processed."
+        >
+          <.remix_icon icon="error-warning-line" />
+        </span>
+      </div>
+    </.label>
     """
   end
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -642,7 +642,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         session_pid={@session_pid}
         client_id={@client_id}
         cell_id={@cell_view.id}
-        input_values={@cell_view.eval.input_values}
+        input_views={@cell_view.eval.input_views}
       />
     </div>
     """

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -239,7 +239,7 @@ defmodule Livebook.SessionTest do
 
       Session.convert_smart_cell(session.pid, smart_cell.id)
 
-      assert %{input_values: %{"input1" => "hey"}} = Session.get_data(session.pid)
+      assert %{input_infos: %{"input1" => %{value: "hey"}}} = Session.get_data(session.pid)
     end
   end
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -625,11 +625,11 @@ defmodule LivebookWeb.SessionLiveTest do
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
-      refute render(view) =~ "This input has changed since it&#39;s been processed."
+      refute render(view) =~ "This input has changed since it was last processed."
 
       Session.set_input_value(session.pid, input.id, 10)
 
-      assert render(view) =~ "This input has changed since it&#39;s been processed."
+      assert render(view) =~ "This input has changed since it was last processed."
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -76,6 +76,19 @@ defmodule Livebook.TestHelpers do
   end
 
   @doc """
+  Builds code that renders the given output as part of evaluation.
+  """
+  def source_for_input_read(input_id) do
+    quote do
+      send(
+        Process.group_leader(),
+        {:io_request, self(), make_ref(), {:livebook_get_input_value, unquote(input_id)}}
+      )
+    end
+    |> Macro.to_string()
+  end
+
+  @doc """
   Builds code that awaits for a messages before finishing.
 
   Returns `{code, continue_fun}`, where calling `continue_fun` should


### PR DESCRIPTION
* apps no longer reevaluate automatically; when an input changes we show an indicator on the input and a button to process the changes
* on error we show a retry button alongside "Something went wrong", consistently with interrupt
* new status indicator in the corner

https://github.com/livebook-dev/livebook/assets/17034772/92bd5044-491a-46ff-9957-601ee189e8c4