### PR TITLE
Raise exception when trying to edit a secret that does not exist

### DIFF
--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -5,6 +5,16 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
   alias Livebook.Hubs.Personal
   alias LivebookWeb.LayoutHelpers
 
+  defmodule NotFoundError do
+    @moduledoc false
+
+    defexception [:secret, plug_status: 404]
+
+    def message(%{secret: secret}) do
+      "could not find secret matching \"#{secret}\""
+    end
+  end
+
   @impl true
   def update(assigns, socket) do
     socket = assign(socket, assigns)
@@ -14,9 +24,10 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
 
     secret_value =
       if assigns.live_action == :edit_secret do
-        secrets
-        |> Enum.find(&(&1.name == secret_name))
-        |> Map.get(:value)
+        case Enum.find_value(secrets, &(&1.name == secret_name and &1.value)) do
+          nil -> raise NotFoundError, secret: secret_name
+          value -> value
+        end
       end
 
     {:ok,

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -24,10 +24,8 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
 
     secret_value =
       if assigns.live_action == :edit_secret do
-        case Enum.find_value(secrets, &(&1.name == secret_name and &1.value)) do
-          nil -> raise NotFoundError, secret: secret_name
-          value -> value
-        end
+        Enum.find_value(secrets, &(&1.name == secret_name and &1.value)) ||
+          raise(NotFoundError, secret: secret_name)
       end
 
     {:ok,
@@ -209,11 +207,7 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
 
     on_confirm = fn socket ->
       {:ok, secret} = Livebook.Secrets.update_secret(%Livebook.Secrets.Secret{}, attrs)
-
-      case Livebook.Hubs.delete_secret(hub, secret) do
-        :ok -> :ok
-        _ -> raise NotFoundError, secret: secret.name
-      end
+      _ = Livebook.Hubs.delete_secret(hub, secret)
 
       socket
       |> put_flash(:success, "Secret deleted successfully")

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -209,7 +209,11 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
 
     on_confirm = fn socket ->
       {:ok, secret} = Livebook.Secrets.update_secret(%Livebook.Secrets.Secret{}, attrs)
-      :ok = Livebook.Hubs.delete_secret(hub, secret)
+
+      case Livebook.Hubs.delete_secret(hub, secret) do
+        :ok -> :ok
+        _ -> raise NotFoundError, secret: secret.name
+      end
 
       socket
       |> put_flash(:success, "Secret deleted successfully")

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -41,6 +41,12 @@ defmodule LivebookWeb.Hub.EditLiveTest do
       refute Hubs.fetch_hub!(hub.id) == hub
     end
 
+    test "raises an error if does not exist secret", %{conn: conn, hub: hub} do
+      assert_raise LivebookWeb.Hub.Edit.PersonalComponent.NotFoundError, fn ->
+        live(conn, ~p"/hub/#{hub.id}/secrets/edit/HELLO")
+      end
+    end
+
     test "creates secret", %{conn: conn, hub: hub} do
       {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
       secret = build(:secret, name: "PERSONAL_ADD_SECRET")


### PR DESCRIPTION
via. https://github.com/livebook-dev/livebook/issues/2054

raise an exception with plug_status: 404 when trying to edit a secret that does not exist