### PR TITLE
Add new user setting: Format Elixir code when evaluated

### DIFF
--- a/assets/js/hooks/cell.js
+++ b/assets/js/hooks/cell.js
@@ -4,6 +4,7 @@ import { globalPubSub } from "../lib/pub_sub";
 import { md5Base64, smoothlyScrollToElement } from "../lib/utils";
 import scrollIntoView from "scroll-into-view-if-needed";
 import { isEvaluable } from "../lib/notebook";
+import { settingsStore } from "../lib/settings";
 
 /**
  * A hook managing a single cell.
@@ -383,6 +384,13 @@ const Cell = {
         type: "sync",
         callback: dispatch,
       });
+    } else if (
+      this.props.type === "code" &&
+      settingsStore.get().editor_auto_format_on_eval
+    ) {
+      this.currentEditor()
+        .asyncIntellisenseFormat()
+        .finally(() => dispatch());
     } else {
       dispatch();
     }

--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -266,6 +266,10 @@ class LiveEditor {
     monaco.editor.setModelMarkers(this.editor.getModel(), owner, editorMarkers);
   }
 
+  asyncIntellisenseFormat() {
+    return this.editor.getAction("editor.action.formatDocument").run();
+  }
+
   _mountEditor() {
     const settings = settingsStore.get();
 

--- a/assets/js/hooks/editor_settings.js
+++ b/assets/js/hooks/editor_settings.js
@@ -26,6 +26,9 @@ const EditorSettings = {
     const editorMarkdownWordWrapCheckbox = this.el.querySelector(
       `[name="editor_markdown_word_wrap"][value="true"]`
     );
+    const editorAutoFormatOnEvalCheckbox = this.el.querySelector(
+      `[name="editor_auto_format_on_eval"][value="true"]`
+    );
 
     editorAutoCompletionCheckbox.checked = settings.editor_auto_completion;
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
@@ -34,6 +37,8 @@ const EditorSettings = {
     editorLightThemeCheckbox.checked =
       settings.editor_theme === EDITOR_THEME.light ? true : false;
     editorMarkdownWordWrapCheckbox.checked = settings.editor_markdown_word_wrap;
+    editorAutoFormatOnEvalCheckbox.checked =
+      settings.editor_auto_format_on_eval;
 
     editorAutoCompletionCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ editor_auto_completion: event.target.checked });
@@ -61,6 +66,12 @@ const EditorSettings = {
 
     editorMarkdownWordWrapCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ editor_markdown_word_wrap: event.target.checked });
+    });
+
+    editorAutoFormatOnEvalCheckbox.addEventListener("change", (event) => {
+      settingsStore.update({
+        editor_auto_format_on_eval: event.target.checked,
+      });
     });
   },
 };

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -774,9 +774,7 @@ const Session = {
 
   queueFocusedCellEvaluation() {
     if (this.focusedId && this.isCell(this.focusedId)) {
-      this.dispatchQueueEvaluation(() => {
-        this.pushEvent("queue_cell_evaluation", { cell_id: this.focusedId });
-      });
+      this.queueCellEvaluation(this.focusedId, false);
     }
   },
 

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS = {
   editor_font_size: EDITOR_FONT_SIZE.normal,
   editor_theme: EDITOR_THEME.default,
   editor_markdown_word_wrap: true,
+  editor_auto_format_on_eval: false,
 };
 
 /**

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -168,6 +168,11 @@ defmodule LivebookWeb.SettingsLive do
                 label="Wrap words in Markdown"
                 value={false}
               />
+              <.switch_field
+                name="editor_auto_format_on_eval"
+                label="Format focused Elixir cell on evaluation"
+                value={false}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR adds a new user setting: Format focused Elixir cell on evaluation. (I went back and forth on 3-4 different labels for this and this was the best I could come up with for now.)

<details>
<summary>Screenshot & GIF</summary>
<p>

![image](https://github.com/livebook-dev/livebook/assets/503938/d6f60cff-ee6f-4263-8acf-7065b0e7c532)

![livebook_autoformat](https://github.com/livebook-dev/livebook/assets/503938/a0cdc833-83ad-4957-b9c0-3676692bb713)

</p>
</details>

Formatting only occurs for the focused cell, so if you eval an entire section, or all stale cells, non-focused cells will not be formatted.

[Discussion thread](https://github.com/livebook-dev/livebook/discussions/2076). I mentioned format-on-save as well, but in addition to being trickier to implement, I don't think it's necessary after playing with format-on-eval, since you're almost always evaluating your cells before saving anyways.