### PR TITLE
Pass only the session PID to child LiveViews

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -554,7 +554,7 @@ defmodule LivebookWeb.SessionLive do
       <%= live_render(@socket, LivebookWeb.SessionLive.PackageSearchLive,
         id: "package-search",
         session: %{
-          "session" => @session,
+          "session_pid" => @session.pid,
           "runtime" => @data_view.runtime,
           "return_to" => @self_path
         }

--- a/lib/livebook_web/live/session_live/attached_live.ex
+++ b/lib/livebook_web/live/session_live/attached_live.ex
@@ -4,7 +4,13 @@ defmodule LivebookWeb.SessionLive.AttachedLive do
   alias Livebook.{Session, Runtime}
 
   @impl true
-  def mount(_params, %{"session" => session, "current_runtime" => current_runtime}, socket) do
+  def mount(
+        _params,
+        %{"session_pid" => session_pid, "current_runtime" => current_runtime},
+        socket
+      ) do
+    session = Session.get_by_pid(session_pid)
+
     unless Livebook.Config.runtime_enabled?(Livebook.Runtime.Attached) do
       raise "runtime module not allowed"
     end

--- a/lib/livebook_web/live/session_live/elixir_standalone_live.ex
+++ b/lib/livebook_web/live/session_live/elixir_standalone_live.ex
@@ -4,7 +4,13 @@ defmodule LivebookWeb.SessionLive.ElixirStandaloneLive do
   alias Livebook.{Session, Runtime}
 
   @impl true
-  def mount(_params, %{"session" => session, "current_runtime" => current_runtime}, socket) do
+  def mount(
+        _params,
+        %{"session_pid" => session_pid, "current_runtime" => current_runtime},
+        socket
+      ) do
+    session = Session.get_by_pid(session_pid)
+
     unless Livebook.Config.runtime_enabled?(Livebook.Runtime.ElixirStandalone) do
       raise "runtime module not allowed"
     end

--- a/lib/livebook_web/live/session_live/embedded_live.ex
+++ b/lib/livebook_web/live/session_live/embedded_live.ex
@@ -4,7 +4,13 @@ defmodule LivebookWeb.SessionLive.EmbeddedLive do
   alias Livebook.{Session, Runtime}
 
   @impl true
-  def mount(_params, %{"session" => session, "current_runtime" => current_runtime}, socket) do
+  def mount(
+        _params,
+        %{"session_pid" => session_pid, "current_runtime" => current_runtime},
+        socket
+      ) do
+    session = Session.get_by_pid(session_pid)
+
     unless Livebook.Config.runtime_enabled?(Livebook.Runtime.Embedded) do
       raise "runtime module not allowed"
     end

--- a/lib/livebook_web/live/session_live/package_search_live.ex
+++ b/lib/livebook_web/live/session_live/package_search_live.ex
@@ -4,12 +4,12 @@ defmodule LivebookWeb.SessionLive.PackageSearchLive do
   @impl true
   def mount(
         _params,
-        %{"session" => session, "runtime" => runtime, "return_to" => return_to},
+        %{"session_pid" => session_pid, "runtime" => runtime, "return_to" => return_to},
         socket
       ) do
     socket =
       assign(socket,
-        session: session,
+        session: Livebook.Session.get_by_pid(session_pid),
         runtime: runtime,
         return_to: return_to,
         search: "",

--- a/lib/livebook_web/live/session_live/runtime_component.ex
+++ b/lib/livebook_web/live/session_live/runtime_component.ex
@@ -61,7 +61,7 @@ defmodule LivebookWeb.SessionLive.RuntimeComponent do
         <div>
           <%= live_render(@socket, live_view_for_type(@type),
             id: "runtime-config-#{@type}",
-            session: %{"session" => @session, "current_runtime" => @runtime}
+            session: %{"session_pid" => @session.pid, "current_runtime" => @runtime}
           ) %>
         </div>
       </div>


### PR DESCRIPTION
I am not sure how much this matters but generally speaking we want to reduce the amount of serialized data in the session.