### PR TITLE
Explicitly allow imported file entries pointing to file system

### DIFF
--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -383,7 +383,11 @@ defmodule Livebook.LiveMarkdown.Export do
     # to make sure the entries are not tampered with. We also want to
     # store the information about file entries already in quarantine
     if Enum.any?(notebook.file_entries, &(&1.type == :file)) do
-      Map.put(metadata, :quarantine_file_entry_names, notebook.quarantine_file_entry_names)
+      Map.put(
+        metadata,
+        :quarantine_file_entry_names,
+        MapSet.to_list(notebook.quarantine_file_entry_names)
+      )
     else
       metadata
     end

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -376,7 +376,17 @@ defmodule Livebook.LiveMarkdown.Export do
 
   defp notebook_stamp_metadata(notebook) do
     keys = [:hub_secret_names]
-    put_unless_default(%{}, Map.take(notebook, keys), Map.take(Notebook.new(), keys))
+
+    metadata = put_unless_default(%{}, Map.take(notebook, keys), Map.take(Notebook.new(), keys))
+
+    # If there are any :file file entries, we want to generate a stamp
+    # to make sure the entries are not tampered with. We also want to
+    # store the information about file entries already in quarantine
+    if Enum.any?(notebook.file_entries, &(&1.type == :file)) do
+      Map.put(metadata, :quarantine_file_entry_names, notebook.quarantine_file_entry_names)
+    else
+      metadata
+    end
   end
 
   defp ensure_order(%{} = map) do

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -646,7 +646,7 @@ defmodule Livebook.LiveMarkdown.Import do
         %{notebook | hub_secret_names: hub_secret_names}
 
       {:quarantine_file_entry_names, quarantine_file_entry_names}, notebook ->
-        %{notebook | quarantine_file_entry_names: quarantine_file_entry_names}
+        %{notebook | quarantine_file_entry_names: MapSet.new(quarantine_file_entry_names)}
 
       _entry, notebook ->
         notebook

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -428,8 +428,17 @@ defmodule Livebook.LiveMarkdown.Import do
               end
           end
 
-        {Map.put(attrs, :file_entries, file_entries), stamp_hub_id,
-         messages ++ file_entry_messages}
+        # By default we put all :file entries in quarantine, if there
+        # is a valid stamp, we override this later
+        quarantine_file_entry_names =
+          for entry <- file_entries, entry.type == :file, into: MapSet.new(), do: entry.name
+
+        attrs =
+          attrs
+          |> Map.put(:file_entries, file_entries)
+          |> Map.put(:quarantine_file_entry_names, quarantine_file_entry_names)
+
+        {attrs, stamp_hub_id, messages ++ file_entry_messages}
 
       _entry, {attrs, stamp_hub_id, messages} ->
         {attrs, stamp_hub_id, messages}
@@ -635,6 +644,9 @@ defmodule Livebook.LiveMarkdown.Import do
     Enum.reduce(metadata, notebook, fn
       {:hub_secret_names, hub_secret_names}, notebook ->
         %{notebook | hub_secret_names: hub_secret_names}
+
+      {:quarantine_file_entry_names, quarantine_file_entry_names}, notebook ->
+        %{notebook | quarantine_file_entry_names: quarantine_file_entry_names}
 
       _entry, notebook ->
         notebook

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -27,6 +27,7 @@ defmodule Livebook.Notebook do
     :hub_id,
     :hub_secret_names,
     :file_entries,
+    :quarantine_file_entry_names,
     :teams_enabled
   ]
 
@@ -48,6 +49,7 @@ defmodule Livebook.Notebook do
           hub_id: String.t(),
           hub_secret_names: list(String.t()),
           file_entries: list(file_entry()),
+          quarantine_file_entry_names: MapSet.new(String.t()),
           teams_enabled: boolean()
         }
 
@@ -88,6 +90,7 @@ defmodule Livebook.Notebook do
       hub_id: Livebook.Hubs.Personal.id(),
       hub_secret_names: [],
       file_entries: [],
+      quarantine_file_entry_names: MapSet.new(),
       teams_enabled: false
     }
     |> put_setup_cell(Cell.new(:code))

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -16,9 +16,9 @@ defprotocol Livebook.Runtime do
   #
   # to which the runtime owner is supposed to reply with
   # `{:runtime_file_entry_path_reply, reply}` where `reply` is either
-  # `{:ok, path}` or `{:error, message}` if accessing the file rails.
-  # Note that `path` should be accessible within the runtime and can
-  # be obtained using `transfer_file/4`.
+  # `{:ok, path}` or `{:error, message | :forbidden}` if accessing the
+  # file fails. Note that `path` should be accessible within the runtime
+  # and can be obtained using `transfer_file/4`.
   #
   # Similarly the runtime can request details about the file source:
   #

--- a/lib/livebook/runtime/evaluator/formatter.ex
+++ b/lib/livebook/runtime/evaluator/formatter.ex
@@ -165,6 +165,9 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
   defp error_type(error) when is_struct(error, Kino.InterruptError),
     do: {:interrupt, error.variant, error.message}
 
+  defp error_type(error) when is_struct(error, Kino.FS.ForbiddenError),
+    do: {:file_entry_forbidden, error.name}
+
   defp error_type(_), do: :other
 
   defp erlang_to_output(value) do

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -295,6 +295,37 @@ defmodule LivebookWeb.Output do
     """
   end
 
+  defp render_output({:error, formatted, {:file_entry_forbidden, file_entry_name}}, %{
+         session_id: session_id
+       }) do
+    assigns = %{
+      message: formatted,
+      file_entry_name: file_entry_name,
+      session_id: session_id
+    }
+
+    ~H"""
+    <div class="-m-4 space-x-4 py-4">
+      <div
+        class="flex items-center justify-between border-b px-4 pb-4 mb-4"
+        style="color: var(--ansi-color-red);"
+      >
+        <div class="flex space-x-2 font-editor">
+          <.remix_icon icon="close-circle-line" />
+          <span>Forbidden access to file <%= inspect(@file_entry_name) %></span>
+        </div>
+        <button
+          class="button-base button-gray"
+          phx-click={JS.push("review_file_entry_access", value: %{name: @file_entry_name})}
+        >
+          Review access
+        </button>
+      </div>
+      <%= render_formatted_error_message(@message) %>
+    </div>
+    """
+  end
+
   defp render_output({:error, _formatted, {:interrupt, variant, message}}, %{cell_id: cell_id}) do
     assigns = %{variant: variant, message: message, cell_id: cell_id}
 

--- a/lib/livebook_web/live/session_live/files_list_component.ex
+++ b/lib/livebook_web/live/session_live/files_list_component.ex
@@ -31,11 +31,25 @@ defmodule LivebookWeb.SessionLive.FilesListComponent do
         <.files_info_icon />
       </div>
       <div class="mt-5 flex flex-col gap-1">
-        <div :for={{file_entry, idx} <- Enum.with_index(@file_entries)} class="flex justify-between">
-          <div class="flex items-center text-gray-500">
-            <.remix_icon icon={file_entry_icon(file_entry.type)} class="text-lg align-middle mr-2" />
-            <span><%= file_entry.name %></span>
-          </div>
+        <div
+          :for={{file_entry, idx} <- Enum.with_index(@file_entries)}
+          class="flex items-center justify-between"
+        >
+          <%= if file_entry.name in @quarantine_file_entry_names do %>
+            <button
+              class="flex items-center text-yellow-bright-500 cursor-pointer tooltip top"
+              data-tooltip="Click to review access"
+              phx-click={JS.push("review_file_entry_access", value: %{name: file_entry.name})}
+            >
+              <.remix_icon icon="alert-line" class="text-lg align-middle mr-2" />
+              <span class="break-all"><%= file_entry.name %></span>
+            </button>
+          <% else %>
+            <div class="flex items-center text-gray-500">
+              <.remix_icon icon={file_entry_icon(file_entry.type)} class="text-lg align-middle mr-2" />
+              <span class="break-all"><%= file_entry.name %></span>
+            </div>
+          <% end %>
           <.menu id={"file-entry-#{idx}-menu"} position={:bottom_right}>
             <:toggle>
               <button class="icon-button" aria-label="menu">
@@ -51,7 +65,7 @@ defmodule LivebookWeb.SessionLive.FilesListComponent do
                 }
               >
                 <.remix_icon icon="file-transfer-line" />
-                <span>Copy to files</span>
+                <span>Copy to files directory</span>
               </button>
             </.menu_item>
             <.menu_item disabled={not Livebook.Session.file_entry_cacheable?(@session, file_entry)}>

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1367,7 +1367,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
 
       {document, []} = Export.notebook_to_livemd(notebook)
 
-      assert stamp_metadata(notebook, document) == %{quarantine_file_entry_names: MapSet.new()}
+      assert stamp_metadata(notebook, document) == %{quarantine_file_entry_names: []}
 
       # Subset allowed
 
@@ -1384,7 +1384,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       {document, []} = Export.notebook_to_livemd(notebook)
 
       assert stamp_metadata(notebook, document) == %{
-               quarantine_file_entry_names: MapSet.new(["document1.pdf"])
+               quarantine_file_entry_names: ["document1.pdf"]
              }
     end
   end

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1347,10 +1347,56 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       # My Notebook
       """
 
-      {document, []} = Export.notebook_to_livemd(notebook)
+      {document, []} = Export.notebook_to_livemd(notebook, include_stamp: false)
 
       assert expected_document == document
     end
+
+    test "stores quarantine file entry names if there are any :file file entries" do
+      file = Livebook.FileSystem.File.new(Livebook.FileSystem.Local.new(), p("/document.pdf"))
+
+      # All allowed
+
+      notebook = %{
+        Notebook.new()
+        | name: "My Notebook",
+          file_entries: [
+            %{type: :file, name: "document.pdf", file: file}
+          ]
+      }
+
+      {document, []} = Export.notebook_to_livemd(notebook)
+
+      assert stamp_metadata(notebook, document) == %{quarantine_file_entry_names: MapSet.new()}
+
+      # Subset allowed
+
+      notebook = %{
+        Notebook.new()
+        | name: "My Notebook",
+          file_entries: [
+            %{type: :file, name: "document1.pdf", file: file},
+            %{type: :file, name: "document2.pdf", file: file}
+          ],
+          quarantine_file_entry_names: MapSet.new(["document1.pdf"])
+      }
+
+      {document, []} = Export.notebook_to_livemd(notebook)
+
+      assert stamp_metadata(notebook, document) == %{
+               quarantine_file_entry_names: MapSet.new(["document1.pdf"])
+             }
+    end
+  end
+
+  defp stamp_metadata(notebook, source) do
+    [_, json] = Regex.run(~r/<!-- livebook:(.*) -->\n$/, source)
+    %{"offset" => offset, "stamp" => stamp} = Jason.decode!(json)
+
+    hub = Livebook.Hubs.fetch_hub!(notebook.hub_id)
+    source = binary_slice(source, 0, offset)
+    {:ok, metadata} = Livebook.Hubs.verify_notebook_stamp(hub, source, stamp)
+    metadata
   end
 
   defp spawn_widget_with_data(ref, data) do


### PR DESCRIPTION
If there are any files that point directly to a file system, we always stamp the notebook. When importing, if the stamp is invalid we put those files in quarantine and require the user to explicitly allow them.

This prevents the scenario where the user imports a valid-looking notebook that does something with a local/s3 file, except the file points somewhere they not expect.

https://github.com/livebook-dev/livebook/assets/17034772/6233b710-8290-47c0-bcd8-3d48e7211c83