### PR TITLE
Add Offline Deployment section on the Hub Teams page

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor/monaco.js
+++ b/assets/js/hooks/cell_editor/live_editor/monaco.js
@@ -94,7 +94,6 @@ import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution";
 import "monaco-editor/esm/vs/basic-languages/css/css.contribution";
 import "monaco-editor/esm/vs/basic-languages/html/html.contribution";
 import "monaco-editor/esm/vs/basic-languages/xml/xml.contribution";
-
 import "monaco-editor/esm/vs/basic-languages/dockerfile/dockerfile.contribution";
 
 // === Configuration ===

--- a/assets/js/hooks/cell_editor/live_editor/monaco.js
+++ b/assets/js/hooks/cell_editor/live_editor/monaco.js
@@ -95,6 +95,8 @@ import "monaco-editor/esm/vs/basic-languages/css/css.contribution";
 import "monaco-editor/esm/vs/basic-languages/html/html.contribution";
 import "monaco-editor/esm/vs/basic-languages/xml/xml.contribution";
 
+import "monaco-editor/esm/vs/basic-languages/dockerfile/dockerfile.contribution";
+
 // === Configuration ===
 
 import { CommandsRegistry } from "monaco-editor/esm/vs/platform/commands/common/commands";

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,7 @@ config :mime, :types, %{
 config :plug_cowboy, :log_exceptions_with_status_code, [407..599]
 
 config :livebook,
-  teams_url: nil,
+  teams_url: "http://localhost:4100",
   app_service_name: nil,
   app_service_url: nil,
   authentication_mode: :token,

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -212,7 +212,7 @@ defmodule Livebook.Application do
     if name && public_key do
       teams_key =
         System.get_env("LIVEBOOK_TEAMS_KEY") ||
-          raise "Environment variable LIVEBOOK_TEAMS_KEY must be specified. Exiting."
+          Livebook.Config.abort!("You specified LIVEBOOK_TEAMS_NAME, but LIVEBOOK_TEAMS_KEY is missing.")
 
       Livebook.Hubs.set_offline_hub(%Livebook.Hubs.Team{
         id: "team-#{name}",

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -212,7 +212,9 @@ defmodule Livebook.Application do
     if name && public_key do
       teams_key =
         System.get_env("LIVEBOOK_TEAMS_KEY") ||
-          Livebook.Config.abort!("You specified LIVEBOOK_TEAMS_NAME, but LIVEBOOK_TEAMS_KEY is missing.")
+          Livebook.Config.abort!(
+            "You specified LIVEBOOK_TEAMS_NAME, but LIVEBOOK_TEAMS_KEY is missing."
+          )
 
       Livebook.Hubs.set_offline_hub(%Livebook.Hubs.Team{
         id: "team-#{name}",

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -207,10 +207,13 @@ defmodule Livebook.Application do
 
   def create_offline_hub() do
     name = System.get_env("LIVEBOOK_TEAMS_NAME")
-    teams_key = System.get_env("LIVEBOOK_TEAMS_KEY")
     public_key = System.get_env("LIVEBOOK_TEAMS_OFFLINE_KEY")
 
-    if name && teams_key && public_key do
+    if name && public_key do
+      teams_key =
+        System.get_env("LIVEBOOK_TEAMS_KEY") ||
+          raise "Environment variable LIVEBOOK_TEAMS_KEY must be specified. Exiting."
+
       Livebook.Hubs.set_offline_hub(%Livebook.Hubs.Team{
         id: "team-#{name}",
         hub_name: name,

--- a/lib/livebook_web/errors/not_found_error.ex
+++ b/lib/livebook_web/errors/not_found_error.ex
@@ -1,0 +1,4 @@
+defmodule LivebookWeb.NotFoundError do
+  @moduledoc false
+  defexception [:message, plug_status: 404]
+end

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -4,11 +4,7 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
   alias Livebook.Hubs
   alias Livebook.Hubs.Personal
   alias LivebookWeb.LayoutHelpers
-
-  defmodule NotFoundError do
-    @moduledoc false
-    defexception [:message, plug_status: 404]
-  end
+  alias LivebookWeb.NotFoundError
 
   @impl true
   def update(assigns, socket) do

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -4,6 +4,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
   alias Livebook.Hubs.Team
   alias Livebook.Teams
   alias LivebookWeb.LayoutHelpers
+  alias LivebookWeb.NotFoundError
 
   @dockerfile_form %{"apps_path" => "/apps"}
 
@@ -17,7 +18,8 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
 
     secret_value =
       if assigns.live_action == :edit_secret do
-        Enum.find_value(secrets, &(&1.name == secret_name && &1.value))
+        Enum.find_value(secrets, &(&1.name == secret_name and &1.value)) ||
+          raise(NotFoundError, "could not find secret matching #{inspect(secret_name)}")
       end
 
     {:ok,

--- a/test/livebook_teams/web/hub/edit_live_test.exs
+++ b/test/livebook_teams/web/hub/edit_live_test.exs
@@ -175,5 +175,11 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
       refute render(element(view, "#hub-secrets-list")) =~ secret.name
       refute secret in Livebook.Hubs.get_secrets(hub)
     end
+
+    test "raises an error if does not exist secret", %{conn: conn, hub: hub} do
+      assert_raise LivebookWeb.NotFoundError, fn ->
+        live(conn, ~p"/hub/#{hub.id}/secrets/edit/HELLO")
+      end
+    end
   end
 end

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -42,7 +42,7 @@ defmodule LivebookWeb.Hub.EditLiveTest do
     end
 
     test "raises an error if does not exist secret", %{conn: conn, hub: hub} do
-      assert_raise LivebookWeb.Hub.Edit.PersonalComponent.NotFoundError, fn ->
+      assert_raise LivebookWeb.NotFoundError, fn ->
         live(conn, ~p"/hub/#{hub.id}/secrets/edit/HELLO")
       end
     end


### PR DESCRIPTION
- Following the changes to Personal Hub from #2054, adds the same behaviour for Team hub.
- Following the suggestion from #2056, defaults the Teams URL to localhost
- Following the task from #1956, adds the Offline Deployment section to Team hub page