### PR TITLE
Make reprocess texts more neutral

### DIFF
--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -189,8 +189,8 @@ defmodule LivebookWeb.AppSessionLive do
           class="tooltip left"
           data-tooltip={
             ~S'''
-            Some inputs have changed since they were last processed.
-            Click this button to reprocess with latest values.
+            Some inputs have changed.
+            Click this button to process with latest values.
             '''
           }
         >

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -266,11 +266,7 @@ defmodule LivebookWeb.Output.InputComponent do
     <.label help={@help}>
       <div class="flex items-center justify-between gap-1">
         <span><%= @label %></span>
-        <span
-          :if={@changed}
-          class="cursor-pointer tooltip top"
-          data-tooltip="This input has changed since it was last processed."
-        >
+        <span :if={@changed} class="cursor-pointer tooltip top" data-tooltip="This input has changed.">
           <.remix_icon icon="error-warning-line text-gray-500" />
         </span>
       </div>

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -708,12 +708,12 @@ defmodule LivebookWeb.SessionLiveTest do
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
-      refute render(view) =~ "This input has changed since it was last processed."
+      refute render(view) =~ "This input has changed."
 
       Session.set_input_value(session.pid, input.id, 10)
       wait_for_session_update(session.pid)
 
-      assert render(view) =~ "This input has changed since it was last processed."
+      assert render(view) =~ "This input has changed."
     end
   end
 


### PR DESCRIPTION
As they may also happen if the user did not process anything at all.