### PR TITLE
Fix arity and link

### DIFF
--- a/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
+++ b/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
@@ -795,9 +795,6 @@ To learn more about Elixir, we welcome you to explore our [website](http://elixi
 [read our Getting Started guide](https://elixir-lang.org/getting-started/introduction.html),
 and [many of the available learning resources](https://elixir-lang.org/learning.html).
 
-You can also learn how to use some of Elixir and Livebook's unique features together
-in the [Welcome to Livebook](/learn/notebooks/intro-to-livebook) notebook.
-
 Finally, huge thanks to Augie De Blieck Jr. for the drawings in this tutorial.
 
 See you around!

--- a/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
+++ b/lib/livebook/notebook/learn/distributed_portals_with_elixir.livemd
@@ -514,7 +514,7 @@ end
 The `Portal` modules defines a struct followed by a `shoot/1` function.
 The function is just a wrapper around `Portal.Door.start_link/1`. Then
 we define the `transfer/3` function, which loads the given data into the
-left door and returns a Portal struct. Finally, `push_right/3` gets data
+left door and returns a Portal struct. Finally, `push_right/1` gets data
 from the door on the left and puts it on the right door. Let's give it a try:
 
 ```elixir
@@ -796,7 +796,7 @@ To learn more about Elixir, we welcome you to explore our [website](http://elixi
 and [many of the available learning resources](https://elixir-lang.org/learning.html).
 
 You can also learn how to use some of Elixir and Livebook's unique features together
-in the [Elixir and Livebook](/learn/notebooks/elixir-and-livebook) notebook.
+in the [Welcome to Livebook](/learn/notebooks/intro-to-livebook) notebook.
 
 Finally, huge thanks to Augie De Blieck Jr. for the drawings in this tutorial.
 


### PR DESCRIPTION
Arity is not matching the number of arguments from the `push_right` function.

Also, the link in the end of the notebook doesn't work because the referenced notebook was removed on https://github.com/livebook-dev/livebook/commit/764d775ed35b558539507f95f8bc94f7e2666245.