### PR TITLE
Change copy of Teams key modal

### DIFF
--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -327,7 +327,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
         Teams Key
       </h3>
       <div class="justify-center">
-        This is your <strong>Teams Key</strong>. If you want to join or invite others
+        This is your <strong>Teams Key</strong>. If you want invite others
         to your organization, you will need to share your Teams Key with them. We
         recommend storing it somewhere safe:
       </div>

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -327,7 +327,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
         Teams Key
       </h3>
       <div class="justify-center">
-        This is your <strong>Teams Key</strong>. If you want invite others
+        This is your <strong>Teams Key</strong>. If you want to invite others
         to your organization, you will need to share your Teams Key with them. We
         recommend storing it somewhere safe:
       </div>

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -327,9 +327,9 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
         Teams Key
       </h3>
       <div class="justify-center">
-        This is your <strong>Teams Key</strong>. If you want to invite others
-        to your organization, you will need to share your Teams Key with them. We
-        recommend storing it somewhere safe:
+        This is your <strong>Teams Key</strong>. This key is
+        required for you and invited users to join this organization.
+        We recommend storing it somewhere safe:
       </div>
       <div class=" w-full">
         <div id="teams-key-toggle" class="relative flex">


### PR DESCRIPTION
The current copy made me think that if I wanted to join an org, I'd need to my Teams key. It's a little bit confusing.

### Before

![CleanShot 2023-08-03 at 16 21 51](https://github.com/livebook-dev/livebook/assets/2719/4d012701-efb0-4a11-a42c-46ff4442f4b1)

### After

![CleanShot 2023-08-03 at 16 38 47](https://github.com/livebook-dev/livebook/assets/2719/739306e3-d45a-4dcf-aa53-6ac63bb2c758)


