### PR TITLE
Usability improvements for custom keyboard controls

### DIFF
--- a/assets/js/hooks/keyboard_control.js
+++ b/assets/js/hooks/keyboard_control.js
@@ -97,10 +97,6 @@ const KeyboardControl = {
         cancelEvent(event);
       }
 
-      if (event.repeat) {
-        return;
-      }
-
       if (this.props.isKeyupEnabled) {
         const { key } = event;
         this.pushEventTo(this.props.target, "keyup", { key });

--- a/assets/js/hooks/keyboard_control.js
+++ b/assets/js/hooks/keyboard_control.js
@@ -73,7 +73,10 @@ const KeyboardControl = {
   },
 
   handleDocumentKeyDown(event) {
-    if (this.isKeyboardToggle(event)) {
+    if (
+      this.isKeyboardToggle(event) &&
+      !isEditableElement(document.activeElement)
+    ) {
       cancelEvent(event);
       this.keyboardEnabled() ? this.disableKeyboard() : this.enableKeyboard();
       return;

--- a/assets/js/hooks/keyboard_control.js
+++ b/assets/js/hooks/keyboard_control.js
@@ -1,6 +1,5 @@
 import { getAttributeOrThrow, parseBoolean } from "../lib/attribute";
 import { cancelEvent, isEditableElement, isMacOS } from "../lib/utils";
-import { globalPubSub } from "../lib/pub_sub";
 
 /**
  * A hook for ControlComponent to handle user keyboard interactions.
@@ -137,7 +136,7 @@ const KeyboardControl = {
     if (cmd && key === "k" && this.isCellFocused()) {
       return (
         !this.keyboardEnabled() ||
-        (this.keyboardEnabled() && this.props.defaultHandlers !== "off")
+        ["on", "disable_only"].includes(this.props.defaultHandlers)
       );
     } else {
       return false;
@@ -146,7 +145,10 @@ const KeyboardControl = {
 
   isCellFocused() {
     const sessionEl = this.el.closest("[data-el-session]");
-    return sessionEl && sessionEl.dataset.focusedId === this.props.cellId;
+    return (
+      sessionEl &&
+      sessionEl.getAttribute("data-js-focused-id") === this.props.cellId
+    );
   },
 };
 

--- a/assets/js/hooks/keyboard_control.js
+++ b/assets/js/hooks/keyboard_control.js
@@ -1,20 +1,28 @@
 import { getAttributeOrThrow, parseBoolean } from "../lib/attribute";
-import { cancelEvent, isEditableElement } from "../lib/utils";
+import { cancelEvent, isEditableElement, isMacOS } from "../lib/utils";
+import { globalPubSub } from "../lib/pub_sub";
 
 /**
  * A hook for ControlComponent to handle user keyboard interactions.
  *
  * ## Configuration
  *
- *   * `data-keydown-enabled` - whether keydown events should be intercepted
+ *   * `data-cell-id` - id of the cell in which the control is rendered
  *
- *   * `data-keyup-enabled` - whether keyup events should be intercepted
+ *   * `data-default-handlers` - whether keyboard events should be
+ *     intercepted and canceled, disabling session shortcuts. Must be
+ *     one of "off", "on", or "disable_only"
+ *
+ *   * `data-keydown-enabled` - whether keydown events should be listened to
+ *
+ *   * `data-keyup-enabled` - whether keyup events should be listened to
  *
  *   * `data-target` - the target to send live events to
  */
 const KeyboardControl = {
   mounted() {
     this.props = this.getProps();
+    this.cellFocused = false;
 
     this._handleDocumentKeyDown = this.handleDocumentKeyDown.bind(this);
     this._handleDocumentKeyUp = this.handleDocumentKeyUp.bind(this);
@@ -28,6 +36,11 @@ const KeyboardControl = {
     // Note: the focus event doesn't bubble, so we register for the
     // capture phase
     window.addEventListener("focus", this._handleDocumentFocus, true);
+
+    this.unsubscribeFromNavigationEvents = globalPubSub.subscribe(
+      "navigation",
+      (event) => this.handleNavigationEvent(event)
+    );
   },
 
   updated() {
@@ -38,10 +51,13 @@ const KeyboardControl = {
     window.removeEventListener("keydown", this._handleDocumentKeyDown, true);
     window.removeEventListener("keyup", this._handleDocumentKeyUp, true);
     window.removeEventListener("focus", this._handleDocumentFocus, true);
+    this.unsubscribeFromNavigationEvents();
   },
 
   getProps() {
     return {
+      cellId: getAttributeOrThrow(this.el, "data-cell-id"),
+      defaultHandlers: getAttributeOrThrow(this.el, "data-default-handlers"),
       isKeydownEnabled: getAttributeOrThrow(
         this.el,
         "data-keydown-enabled",
@@ -57,39 +73,84 @@ const KeyboardControl = {
   },
 
   handleDocumentKeyDown(event) {
-    if (this.keyboardEnabled()) {
+    if (this.isKeyboardToggle(event)) {
       cancelEvent(event);
+      this.keyboardEnabled() ? this.disableKeyboard() : this.enableKeyboard();
+      return;
     }
 
-    if (this.props.isKeydownEnabled) {
+    if (this.keyboardEnabled()) {
+      if (this.props.defaultHandlers !== "on") {
+        cancelEvent(event);
+      }
+
       if (event.repeat) {
         return;
       }
 
-      const { key } = event;
-      this.pushEventTo(this.props.target, "keydown", { key });
+      if (this.props.isKeydownEnabled) {
+        const { key } = event;
+        this.pushEventTo(this.props.target, "keydown", { key });
+      }
     }
   },
 
   handleDocumentKeyUp(event) {
     if (this.keyboardEnabled()) {
-      cancelEvent(event);
-    }
+      if (this.props.defaultHandlers !== "on") {
+        cancelEvent(event);
+      }
 
-    if (this.props.isKeyupEnabled) {
-      const { key } = event;
-      this.pushEventTo(this.props.target, "keyup", { key });
+      if (event.repeat) {
+        return;
+      }
+
+      if (this.props.isKeyupEnabled) {
+        const { key } = event;
+        this.pushEventTo(this.props.target, "keyup", { key });
+      }
     }
   },
 
   handleDocumentFocus(event) {
     if (this.props.isKeydownEnabled && isEditableElement(event.target)) {
+      this.disableKeyboard();
+    }
+  },
+
+  handleNavigationEvent(event) {
+    if (event.type === "element_focused") {
+      this.cellFocused = event.focusableId === this.props.cellId;
+    }
+  },
+
+  enableKeyboard() {
+    if (!this.keyboardEnabled()) {
+      this.pushEventTo(this.props.target, "enable_keyboard", {});
+    }
+  },
+
+  disableKeyboard() {
+    if (this.keyboardEnabled()) {
       this.pushEventTo(this.props.target, "disable_keyboard", {});
     }
   },
 
   keyboardEnabled() {
     return this.props.isKeydownEnabled || this.props.isKeyupEnabled;
+  },
+
+  isKeyboardToggle({ key, metaKey, ctrlKey }) {
+    const cmd = isMacOS() ? metaKey : ctrlKey;
+
+    if (cmd && key === "k" && this.cellFocused) {
+      return (
+        !this.keyboardEnabled() ||
+        (this.keyboardEnabled() && this.props.defaultHandlers !== "off")
+      );
+    } else {
+      return false;
+    }
   },
 };
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -245,7 +245,7 @@ const Session = {
     }
 
     if (this.focusedId) {
-      this.broadcastElementFocused(this.focusedId, false);
+      this.el.dataset.focusedId = this.focusedId;
     }
   },
 
@@ -1036,6 +1036,7 @@ const Session = {
 
   setFocusedEl(focusableId, { scroll = true, focusElement = true } = {}) {
     this.focusedId = focusableId;
+    this.el.dataset.focusedId = focusableId;
 
     if (focusableId) {
       // If the element is inside collapsed section, expand that section
@@ -1060,7 +1061,12 @@ const Session = {
       }
     }
 
-    this.broadcastElementFocused(focusableId, scroll);
+    globalPubSub.broadcast("navigation", {
+      type: "element_focused",
+      focusableId: focusableId,
+      scroll,
+    });
+
     this.setInsertMode(false);
   },
 
@@ -1081,14 +1087,6 @@ const Session = {
     globalPubSub.broadcast("navigation", {
       type: "insert_mode_changed",
       enabled: insertModeEnabled,
-    });
-  },
-
-  broadcastElementFocused(focusableId, scroll) {
-    globalPubSub.broadcast("navigation", {
-      type: "element_focused",
-      focusableId: focusableId,
-      scroll,
     });
   },
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -243,10 +243,6 @@ const Session = {
     if (this.props.globalStatus !== prevProps.globalStatus) {
       setFavicon(this.faviconForEvaluationStatus(this.props.globalStatus));
     }
-
-    if (this.focusedId) {
-      this.el.dataset.focusedId = this.focusedId;
-    }
   },
 
   disconnected() {
@@ -1036,7 +1032,12 @@ const Session = {
 
   setFocusedEl(focusableId, { scroll = true, focusElement = true } = {}) {
     this.focusedId = focusableId;
-    this.el.dataset.focusedId = focusableId;
+
+    if (focusableId) {
+      this.el.setAttribute("data-js-focused-id", focusableId);
+    } else {
+      this.el.removeAttribute("data-js-focused-id");
+    }
 
     if (focusableId) {
       // If the element is inside collapsed section, expand that section

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -243,6 +243,10 @@ const Session = {
     if (this.props.globalStatus !== prevProps.globalStatus) {
       setFavicon(this.faviconForEvaluationStatus(this.props.globalStatus));
     }
+
+    if (this.focusedId) {
+      this.broadcastElementFocused(this.focusedId, false);
+    }
   },
 
   disconnected() {
@@ -1056,12 +1060,7 @@ const Session = {
       }
     }
 
-    globalPubSub.broadcast("navigation", {
-      type: "element_focused",
-      focusableId: focusableId,
-      scroll,
-    });
-
+    this.broadcastElementFocused(focusableId, scroll);
     this.setInsertMode(false);
   },
 
@@ -1082,6 +1081,14 @@ const Session = {
     globalPubSub.broadcast("navigation", {
       type: "insert_mode_changed",
       enabled: insertModeEnabled,
+    });
+  },
+
+  broadcastElementFocused(focusableId, scroll) {
+    globalPubSub.broadcast("navigation", {
+      type: "element_focused",
+      focusableId: focusableId,
+      scroll,
     });
   },
 

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -253,14 +253,16 @@ defmodule LivebookWeb.Output do
          id: id,
          input_views: input_views,
          session_pid: session_pid,
-         client_id: client_id
+         client_id: client_id,
+         cell_id: cell_id
        }) do
     live_component(Output.ControlComponent,
       id: id,
       attrs: attrs,
       input_views: input_views,
       session_pid: session_pid,
-      client_id: client_id
+      client_id: client_id,
+      cell_id: cell_id
     )
   end
 

--- a/lib/livebook_web/live/output/control_component.ex
+++ b/lib/livebook_web/live/output/control_component.ex
@@ -14,7 +14,7 @@ defmodule LivebookWeb.Output.ControlComponent do
       id={"#{@id}-root"}
       phx-hook="KeyboardControl"
       data-cell-id={@cell_id}
-      data-default-handlers={to_string(Map.get(@attrs, :default_handlers, :off))}
+      data-default-handlers={Map.get(@attrs, :default_handlers, :off)}
       data-keydown-enabled={to_string(@keyboard_enabled and :keydown in @attrs.events)}
       data-keyup-enabled={to_string(@keyboard_enabled and :keyup in @attrs.events)}
       data-target={@myself}

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -107,7 +107,13 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["s", "r"], desc: "Show runtime panel"},
       %{seq: ["s", "b"], desc: "Show bin"},
       %{seq: ["s", "p"], desc: "Show package search"},
-      %{seq: ["0", "0"], desc: "Reconnect current runtime"}
+      %{seq: ["0", "0"], desc: "Reconnect current runtime"},
+      %{
+        seq: ["ctrl", "k"],
+        seq_mac: ["⌘", "k"],
+        press_all: true,
+        desc: "Toggle Kino keyboard control"
+      }
     ],
     universal: [
       %{

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -112,7 +112,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         seq: ["ctrl", "k"],
         seq_mac: ["⌘", "k"],
         press_all: true,
-        desc: "Toggle Kino keyboard control"
+        desc: "Toggle keyboard control in cell output"
       }
     ],
     universal: [


### PR DESCRIPTION
[See discussion for context.](https://github.com/livebook-dev/livebook/discussions/2129)

* Add `:default_handlers` option to control whether the default Livebook shortcuts are enabled/disabled when the keyboard control is active.
* Add `ctrl/cmd + k` session shortcut to toggle keyboard controls.

Basic notebook for testing: [gist](https://gist.github.com/zachallaun/230df0ec4afcedc1518e33447f98eca2)

Corresponding PR in Kino: livebook-dev/kino#312