### PR TITLE
Change copy: from 'Add Hub' to 'Add Organization'

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -361,8 +361,8 @@ defmodule LivebookWeb.SessionLive do
                   </button>
                 </.menu_item>
                 <.menu_item>
-                  <.link navigate={~p"/hub"} aria-label="Add Hub" role="menuitem">
-                    <.remix_icon icon="add-line" class="align-middle mr-1" /> Add Hub
+                  <.link navigate={~p"/hub"} aria-label="Add Organization" role="menuitem">
+                    <.remix_icon icon="add-line" class="align-middle mr-1" /> Add Organization
                   </.link>
                 </.menu_item>
               </.menu>


### PR DESCRIPTION
Since we changed the wording in the sidebar from "Add Hub" to "Add Organization", I think we should change it as well int the "notebook hub menu".

## Before

![CleanShot 2023-08-08 at 11 50 11](https://github.com/livebook-dev/livebook/assets/2719/0f36601c-0526-4f26-afe9-7d7172a858cb)


## After

![CleanShot 2023-08-08 at 11 49 22](https://github.com/livebook-dev/livebook/assets/2719/8c87ff7b-7f8f-4dbb-86b5-acc3e0b1e5db)
