### PR TITLE
fix for editor visual mode

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -641,12 +641,12 @@ class LiveEditor {
   /**
    * Sets Monaco editor mode via monaco-emacs or monaco-vim packages.
    */
-  _setEditorMode(settingsMode) {
-    if (settingsMode == "emacs") {
+  _setEditorMode(editorMode) {
+    if (editorMode == "emacs") {
       this.emacsMode = new EmacsExtension(this.editor);
       this.emacsMode.start();
       unregisterKey("Tab");
-    } else if (settingsMode == "vim") {
+    } else if (editorMode == "vim") {
       this.vimMode = initVimMode(this.editor);
       this.vimMode.on("vim-mode-change", ({ mode: mode }) => {
         this.editor.getDomNode().setAttribute("data-vim-mode", mode);

--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -371,16 +371,7 @@ class LiveEditor {
     this._initializeWidgets();
 
     // Set the editor mode
-    if (settings.editor_mode == "emacs") {
-      this.emacsMode = new EmacsExtension(this.editor);
-      this.emacsMode.start();
-      unregisterKey("Tab");
-    } else if (settings.editor_mode == "vim") {
-      this.vimMode = initVimMode(this.editor);
-      this.vimMode.on("vim-mode-change", ({ mode: mode }) => {
-        this.editor.getDomNode().setAttribute("data-vim-mode", mode);
-      });
-    }
+    this._setEditorMode(settings.editor_mode);
   }
 
   /**
@@ -645,6 +636,22 @@ class LiveEditor {
         }
       );
     });
+  }
+
+  /**
+   * Sets Monaco editor mode via monaco-emacs or monaco-vim packages.
+   */
+  _setEditorMode(settingsMode) {
+    if (settingsMode == "emacs") {
+      this.emacsMode = new EmacsExtension(this.editor);
+      this.emacsMode.start();
+      unregisterKey("Tab");
+    } else if (settingsMode == "vim") {
+      this.vimMode = initVimMode(this.editor);
+      this.vimMode.on("vim-mode-change", ({ mode: mode }) => {
+        this.editor.getDomNode().setAttribute("data-vim-mode", mode);
+      });
+    }
   }
 }
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -469,8 +469,8 @@ const Session = {
       return true;
     }
 
-    // Vim insert mode
-    if (editor.dataset.vimMode == "insert") {
+    // Vim insert or visual mode
+    if (["insert", "visual"].indexOf(editor.dataset.vimMode) != -1) {
       return true;
     }
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -470,7 +470,7 @@ const Session = {
     }
 
     // Vim insert or visual mode
-    if (["insert", "visual"].indexOf(editor.dataset.vimMode) != -1) {
+    if (["insert", "visual"].includes(editor.dataset.vimMode)) {
       return true;
     }
 


### PR DESCRIPTION
* adds `visual` to `insert` as "editor modes to not escape the widget from". this is the case where the user has entered visual mode to e.g. select something, but wants to go back to normal mode without escaping the widget.
* extracted the handling to `_setEditorMode` method on `LiveEditor` class.