### PR TITLE
Restructure output format

### DIFF
--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -195,7 +195,7 @@ defmodule Livebook.LiveMarkdown.Import do
          [{"pre", _, [{"code", [{"class", "output"}], [output], %{}}], %{}} | ast],
          outputs
        ) do
-    take_outputs(ast, [{:terminal_text, output, %{chunk: false}} | outputs])
+    take_outputs(ast, [%{type: :terminal_text, text: output, chunk: false} | outputs])
   end
 
   defp take_outputs(
@@ -206,7 +206,7 @@ defmodule Livebook.LiveMarkdown.Import do
          ],
          outputs
        ) do
-    take_outputs(ast, [{:terminal_text, output, %{chunk: false}} | outputs])
+    take_outputs(ast, [%{type: :terminal_text, text: output, chunk: false} | outputs])
   end
 
   # Ignore other exported outputs

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -51,19 +51,19 @@ defmodule Livebook.Notebook.Cell do
   @doc """
   Extracts all inputs from the given indexed output.
   """
-  @spec find_inputs_in_output(indexed_output()) :: list(input_attrs :: map())
+  @spec find_inputs_in_output(indexed_output()) :: list(Livebook.Runtime.input_output())
   def find_inputs_in_output(output)
 
-  def find_inputs_in_output({_idx, {:input, attrs}}) do
-    [attrs]
+  def find_inputs_in_output({_idx, %{type: :input} = input}) do
+    [input]
   end
 
-  def find_inputs_in_output({_idx, {:control, %{type: :form, fields: fields}}}) do
+  def find_inputs_in_output({_idx, %{type: :control, attrs: %{type: :form, fields: fields}}}) do
     Keyword.values(fields)
   end
 
-  def find_inputs_in_output({_idx, {type, outputs, _}}) when type in [:frame, :tabs, :grid] do
-    Enum.flat_map(outputs, &find_inputs_in_output/1)
+  def find_inputs_in_output({_idx, output}) when output.type in [:frame, :tabs, :grid] do
+    Enum.flat_map(output.outputs, &find_inputs_in_output/1)
   end
 
   def find_inputs_in_output(_output), do: []
@@ -74,13 +74,13 @@ defmodule Livebook.Notebook.Cell do
   @spec find_assets_in_output(Livebook.Runtime.output()) :: list(asset_info :: map())
   def find_assets_in_output(output)
 
-  def find_assets_in_output({:js, %{js_view: %{assets: assets_info}}}), do: [assets_info]
+  def find_assets_in_output(%{type: :js} = output), do: [output.js_view.assets]
 
-  def find_assets_in_output({type, outputs, _}) when type in [:frame, :tabs, :grid] do
-    Enum.flat_map(outputs, &find_assets_in_output/1)
+  def find_assets_in_output(output) when output.type in [:frame, :tabs, :grid] do
+    Enum.flat_map(output.outputs, &find_assets_in_output/1)
   end
 
-  def find_assets_in_output(_), do: []
+  def find_assets_in_output(_output), do: []
 
   @setup_cell_id "setup"
 

--- a/lib/livebook/runtime/evaluator/formatter.ex
+++ b/lib/livebook/runtime/evaluator/formatter.ex
@@ -20,7 +20,7 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
     # Functions in the `IEx.Helpers` module return this specific value
     # to indicate no result should be printed in the iex shell,
     # so we respect that as well.
-    :ignored
+    %{type: :ignored}
   end
 
   def format_result({:ok, {:module, _, _, _} = value}, :elixir) do
@@ -40,13 +40,13 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
         |> error_color
         |> :erlang.list_to_binary()
 
-      {:error, formatted, error_type(error)}
+      %{type: :error, message: formatted, known_reason: error_known_reason(error)}
     end
   end
 
   def format_result({:error, kind, error, stacktrace}, _language) do
     formatted = format_error(kind, error, stacktrace)
-    {:error, formatted, error_type(error)}
+    %{type: :error, message: formatted, known_reason: error_known_reason(error)}
   end
 
   def format_result({:ok, value}, :erlang) do
@@ -76,11 +76,11 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
   defp to_inspect_output(value, opts \\ []) do
     try do
       inspected = inspect(value, inspect_opts(opts))
-      {:terminal_text, inspected, %{chunk: false}}
+      %{type: :terminal_text, text: inspected, chunk: false}
     catch
       kind, error ->
         formatted = format_error(kind, error, __STACKTRACE__)
-        {:error, formatted, error_type(error)}
+        %{type: :error, message: formatted, known_reason: error_known_reason(error)}
     end
   end
 
@@ -159,19 +159,19 @@ defmodule Livebook.Runtime.Evaluator.Formatter do
     IO.ANSI.format([:red, string], true)
   end
 
-  defp error_type(%System.EnvError{env: "LB_" <> secret_name}),
+  defp error_known_reason(%System.EnvError{env: "LB_" <> secret_name}),
     do: {:missing_secret, secret_name}
 
-  defp error_type(error) when is_struct(error, Kino.InterruptError),
+  defp error_known_reason(error) when is_struct(error, Kino.InterruptError),
     do: {:interrupt, error.variant, error.message}
 
-  defp error_type(error) when is_struct(error, Kino.FS.ForbiddenError),
+  defp error_known_reason(error) when is_struct(error, Kino.FS.ForbiddenError),
     do: {:file_entry_forbidden, error.name}
 
-  defp error_type(_), do: :other
+  defp error_known_reason(_), do: :other
 
   defp erlang_to_output(value) do
     text = :io_lib.format("~p", [value]) |> IO.iodata_to_binary()
-    {:terminal_text, text, %{chunk: false}}
+    %{type: :terminal_text, text: text, chunk: false}
   end
 end

--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -438,10 +438,8 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
     string = state.buffer |> Enum.reverse() |> Enum.join()
 
     if state.send_to != nil and string != "" do
-      send(
-        state.send_to,
-        {:runtime_evaluation_output, state.ref, {:terminal_text, string, %{chunk: true}}}
-      )
+      output = %{type: :terminal_text, text: string, chunk: true}
+      send(state.send_to, {:runtime_evaluation_output, state.ref, output})
     end
 
     %{state | buffer: []}

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1450,11 +1450,14 @@ defmodule Livebook.Session do
   end
 
   def handle_info({:runtime_evaluation_output, cell_id, output}, state) do
+    output = normalize_runtime_output(output)
     operation = {:add_cell_evaluation_output, @client_id, cell_id, output}
     {:noreply, handle_operation(state, operation)}
   end
 
   def handle_info({:runtime_evaluation_output_to, client_id, cell_id, output}, state) do
+    output = normalize_runtime_output(output)
+
     client_pid =
       Enum.find_value(state.client_pids_with_id, fn {pid, id} ->
         id == client_id && pid
@@ -1485,6 +1488,7 @@ defmodule Livebook.Session do
   end
 
   def handle_info({:runtime_evaluation_output_to_clients, cell_id, output}, state) do
+    output = normalize_runtime_output(output)
     operation = {:add_cell_evaluation_output, @client_id, cell_id, output}
     broadcast_operation(state.session_id, operation)
 
@@ -1505,9 +1509,10 @@ defmodule Livebook.Session do
     {:noreply, state}
   end
 
-  def handle_info({:runtime_evaluation_response, cell_id, response, metadata}, state) do
+  def handle_info({:runtime_evaluation_response, cell_id, output, metadata}, state) do
     {memory_usage, metadata} = Map.pop(metadata, :memory_usage)
-    operation = {:add_cell_evaluation_response, @client_id, cell_id, response, metadata}
+    output = normalize_runtime_output(output)
+    operation = {:add_cell_evaluation_response, @client_id, cell_id, output, metadata}
 
     {:noreply,
      state
@@ -2864,5 +2869,113 @@ defmodule Livebook.Session do
       {:error, message, status} ->
         {:error, "download failed, " <> message, status}
     end
+  end
+
+  # Maps legacy outputs and adds missing attributes
+  defp normalize_runtime_output(output) when is_map(output), do: output
+
+  defp normalize_runtime_output(:ignored) do
+    %{type: :ignored}
+  end
+
+  defp normalize_runtime_output({:text, text}) do
+    %{type: :terminal_text, text: text, chunk: false}
+  end
+
+  defp normalize_runtime_output({:plain_text, text}) do
+    %{type: :plain_text, text: text, chunk: false}
+  end
+
+  defp normalize_runtime_output({:markdown, text}) do
+    %{type: :markdown, text: text, chunk: false}
+  end
+
+  defp normalize_runtime_output({:image, content, mime_type}) do
+    %{type: :image, content: content, mime_type: mime_type}
+  end
+
+  defp normalize_runtime_output({:js, info}) do
+    %{type: :js, js_view: info.js_view, export: info.export}
+  end
+
+  defp normalize_runtime_output({:frame, outputs, %{ref: ref, type: :default} = info}) do
+    %{
+      type: :frame,
+      ref: ref,
+      outputs: Enum.map(outputs, &normalize_runtime_output/1),
+      placeholder: Map.get(info, :placeholder, true)
+    }
+  end
+
+  defp normalize_runtime_output({:frame, outputs, %{ref: ref, type: :replace}}) do
+    %{
+      type: :frame_update,
+      ref: ref,
+      update: {:replace, Enum.map(outputs, &normalize_runtime_output/1)}
+    }
+  end
+
+  defp normalize_runtime_output({:frame, outputs, %{ref: ref, type: :append}}) do
+    %{
+      type: :frame_update,
+      ref: ref,
+      update: {:append, Enum.map(outputs, &normalize_runtime_output/1)}
+    }
+  end
+
+  defp normalize_runtime_output({:tabs, outputs, %{labels: labels}}) do
+    %{type: :tabs, outputs: Enum.map(outputs, &normalize_runtime_output/1), labels: labels}
+  end
+
+  defp normalize_runtime_output({:grid, outputs, info}) do
+    %{
+      type: :grid,
+      outputs: Enum.map(outputs, &normalize_runtime_output/1),
+      columns: Map.get(info, :columns, 1),
+      gap: Map.get(info, :gap, 8),
+      boxed: Map.get(info, :boxed, false)
+    }
+  end
+
+  defp normalize_runtime_output({:input, attrs}) do
+    {fields, attrs} = Map.split(attrs, [:ref, :id, :destination])
+
+    attrs =
+      case attrs.type do
+        :textarea -> Map.put_new(attrs, :monospace, false)
+        _other -> attrs
+      end
+
+    Map.merge(fields, %{type: :input, attrs: attrs})
+  end
+
+  defp normalize_runtime_output({:control, attrs}) do
+    {fields, attrs} = Map.split(attrs, [:ref, :destination])
+
+    attrs =
+      case attrs.type do
+        :keyboard ->
+          Map.put_new(attrs, :default_handlers, :off)
+
+        :form ->
+          Map.update!(attrs, :fields, fn fields ->
+            Enum.map(fields, fn {field, attrs} ->
+              {field, normalize_runtime_output({:input, attrs})}
+            end)
+          end)
+
+        _other ->
+          attrs
+      end
+
+    Map.merge(fields, %{type: :control, attrs: attrs})
+  end
+
+  defp normalize_runtime_output({:error, message, type}) do
+    %{type: :error, message: message, known_reason: type}
+  end
+
+  defp normalize_runtime_output(other) do
+    %{type: :unknown, output: other}
   end
 end

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -333,9 +333,9 @@ defmodule Livebook.Session.Data do
         cell <- section.cells,
         Cell.evaluable?(cell),
         output <- cell.outputs,
-        attrs <- Cell.find_inputs_in_output(output),
+        input <- Cell.find_inputs_in_output(output),
         into: %{},
-        do: {attrs.id, input_info(attrs.default)}
+        do: {input.id, input_info(input.attrs.default)}
   end
 
   @doc """
@@ -1245,7 +1245,7 @@ defmodule Livebook.Session.Data do
     new_input_infos =
       indexed_output
       |> Cell.find_inputs_in_output()
-      |> Map.new(fn attrs -> {attrs.id, input_info(attrs.default)} end)
+      |> Map.new(fn input -> {input.id, input_info(input.attrs.default)} end)
 
     {data, _} =
       data_actions =

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -37,47 +37,50 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp border?({:terminal_text, _text, _info}), do: true
-  defp border?({:plain_text, _text, _info}), do: true
-  defp border?({:error, _message, {:interrupt, _, _}}), do: false
-  defp border?({:error, _message, _type}), do: true
-  defp border?({:grid, _, info}), do: Map.get(info, :boxed, false)
+  defp border?(%{type: type}) when type in [:terminal_text, :plain_text], do: true
+  defp border?(%{type: :error, known_reason: {:interrupt, _, _}}), do: false
+  defp border?(%{type: :error}), do: true
+  defp border?(%{type: :grid, boxed: boxed}), do: boxed
   defp border?(_output), do: false
 
-  defp render_output({:terminal_text, text, _info}, %{id: id}) do
+  defp render_output(%{type: :terminal_text, text: text}, %{id: id}) do
     text = if(text == :__pruned__, do: nil, else: text)
     live_component(Output.TerminalTextComponent, id: id, text: text)
   end
 
-  defp render_output({:plain_text, text, _info}, %{id: id}) do
+  defp render_output(%{type: :plain_text, text: text}, %{id: id}) do
     text = if(text == :__pruned__, do: nil, else: text)
     live_component(Output.PlainTextComponent, id: id, text: text)
   end
 
-  defp render_output({:markdown, text, _info}, %{id: id, session_id: session_id}) do
+  defp render_output(%{type: :markdown, text: text}, %{id: id, session_id: session_id}) do
     text = if(text == :__pruned__, do: nil, else: text)
     live_component(Output.MarkdownComponent, id: id, session_id: session_id, text: text)
   end
 
-  defp render_output({:image, content, mime_type}, %{id: id}) do
-    assigns = %{id: id, content: content, mime_type: mime_type}
+  defp render_output(%{type: :image} = output, %{id: id}) do
+    assigns = %{id: id, content: output.content, mime_type: output.mime_type}
 
     ~H"""
     <Output.ImageComponent.render id={@id} content={@content} mime_type={@mime_type} />
     """
   end
 
-  defp render_output({:js, js_info}, %{id: id, session_id: session_id, client_id: client_id}) do
+  defp render_output(%{type: :js} = output, %{
+         id: id,
+         session_id: session_id,
+         client_id: client_id
+       }) do
     live_component(LivebookWeb.JSViewComponent,
       id: id,
-      js_view: js_info.js_view,
+      js_view: output.js_view,
       session_id: session_id,
       client_id: client_id,
       timeout_message: "Output data no longer available, please reevaluate this cell"
     )
   end
 
-  defp render_output({:frame, outputs, info}, %{
+  defp render_output(%{type: :frame} = output, %{
          id: id,
          session_id: session_id,
          session_pid: session_pid,
@@ -87,8 +90,8 @@ defmodule LivebookWeb.Output do
        }) do
     live_component(Output.FrameComponent,
       id: id,
-      outputs: outputs,
-      placeholder: Map.get(info, :placeholder, true),
+      outputs: output.outputs,
+      placeholder: output.placeholder,
       session_id: session_id,
       session_pid: session_pid,
       input_views: input_views,
@@ -97,7 +100,7 @@ defmodule LivebookWeb.Output do
     )
   end
 
-  defp render_output({:tabs, outputs, info}, %{
+  defp render_output(%{type: :tabs, outputs: outputs, labels: labels}, %{
          id: id,
          session_id: session_id,
          session_pid: session_pid,
@@ -106,11 +109,11 @@ defmodule LivebookWeb.Output do
          cell_id: cell_id
        }) do
     {labels, active_idx} =
-      if info.labels == :__pruned__ do
+      if labels == :__pruned__ do
         {[], nil}
       else
         labels =
-          Enum.zip_with(info.labels, outputs, fn label, {output_idx, _} -> {output_idx, label} end)
+          Enum.zip_with(labels, outputs, fn label, {output_idx, _} -> {output_idx, label} end)
 
         active_idx = get_in(outputs, [Access.at(0), Access.elem(0)])
 
@@ -173,7 +176,7 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:grid, outputs, info}, %{
+  defp render_output(%{type: :grid} = grid, %{
          id: id,
          session_id: session_id,
          session_pid: session_pid,
@@ -181,14 +184,11 @@ defmodule LivebookWeb.Output do
          client_id: client_id,
          cell_id: cell_id
        }) do
-    columns = info[:columns] || 1
-    gap = info[:gap] || 8
-
     assigns = %{
       id: id,
-      columns: columns,
-      gap: gap,
-      outputs: outputs,
+      columns: grid.columns,
+      gap: grid.gap,
+      outputs: grid.outputs,
       session_id: session_id,
       session_pid: session_pid,
       input_views: input_views,
@@ -220,7 +220,7 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:input, attrs}, %{
+  defp render_output(%{type: :input} = input, %{
          id: id,
          input_views: input_views,
          session_pid: session_pid,
@@ -228,14 +228,14 @@ defmodule LivebookWeb.Output do
        }) do
     live_component(Output.InputComponent,
       id: id,
-      attrs: attrs,
+      input: input,
       input_views: input_views,
       session_pid: session_pid,
       client_id: client_id
     )
   end
 
-  defp render_output({:control, attrs}, %{
+  defp render_output(%{type: :control} = control, %{
          id: id,
          input_views: input_views,
          session_pid: session_pid,
@@ -244,7 +244,7 @@ defmodule LivebookWeb.Output do
        }) do
     live_component(Output.ControlComponent,
       id: id,
-      attrs: attrs,
+      control: control,
       input_views: input_views,
       session_pid: session_pid,
       client_id: client_id,
@@ -252,14 +252,11 @@ defmodule LivebookWeb.Output do
     )
   end
 
-  defp render_output({:error, formatted, {:missing_secret, secret_name}}, %{
-         session_id: session_id
-       }) do
-    assigns = %{
-      message: formatted,
-      secret_name: secret_name,
-      session_id: session_id
-    }
+  defp render_output(
+         %{type: :error, known_reason: {:missing_secret, secret_name}} = output,
+         %{session_id: session_id}
+       ) do
+    assigns = %{message: output.message, secret_name: secret_name, session_id: session_id}
 
     ~H"""
     <div class="-m-4 space-x-4 py-4">
@@ -283,14 +280,11 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:error, formatted, {:file_entry_forbidden, file_entry_name}}, %{
-         session_id: session_id
-       }) do
-    assigns = %{
-      message: formatted,
-      file_entry_name: file_entry_name,
-      session_id: session_id
-    }
+  defp render_output(
+         %{type: :error, known_reason: {:file_entry_forbidden, file_entry_name}} = output,
+         %{session_id: session_id}
+       ) do
+    assigns = %{message: output.message, file_entry_name: file_entry_name, session_id: session_id}
 
     ~H"""
     <div class="-m-4 space-x-4 py-4">
@@ -314,7 +308,10 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:error, _formatted, {:interrupt, variant, message}}, %{cell_id: cell_id}) do
+  defp render_output(
+         %{type: :error, known_reason: {:interrupt, variant, message}},
+         %{cell_id: cell_id}
+       ) do
     assigns = %{variant: variant, message: message, cell_id: cell_id}
 
     ~H"""
@@ -346,8 +343,8 @@ defmodule LivebookWeb.Output do
     """
   end
 
-  defp render_output({:error, formatted, _type}, %{}) do
-    render_formatted_error_message(formatted)
+  defp render_output(%{type: :error, message: message}, %{}) do
+    render_formatted_error_message(message)
   end
 
   defp render_output(output, %{}) do

--- a/lib/livebook_web/live/output/control_component.ex
+++ b/lib/livebook_web/live/output/control_component.ex
@@ -7,16 +7,16 @@ defmodule LivebookWeb.Output.ControlComponent do
   end
 
   @impl true
-  def render(%{attrs: %{type: :keyboard}} = assigns) do
+  def render(assigns) when assigns.control.attrs.type == :keyboard do
     ~H"""
     <div
       class="flex"
       id={"#{@id}-root"}
       phx-hook="KeyboardControl"
       data-cell-id={@cell_id}
-      data-default-handlers={Map.get(@attrs, :default_handlers, :off)}
-      data-keydown-enabled={to_string(@keyboard_enabled and :keydown in @attrs.events)}
-      data-keyup-enabled={to_string(@keyboard_enabled and :keyup in @attrs.events)}
+      data-default-handlers={@control.default_handlers.attrs}
+      data-keydown-enabled={to_string(@keyboard_enabled and :keydown in @control.attrs.events)}
+      data-keyup-enabled={to_string(@keyboard_enabled and :keyup in @control.attrs.events)}
       data-target={@myself}
     >
       <span class="tooltip right" data-tooltip="Toggle keyboard control">
@@ -35,7 +35,7 @@ defmodule LivebookWeb.Output.ControlComponent do
     """
   end
 
-  def render(%{attrs: %{type: :button}} = assigns) do
+  def render(assigns) when assigns.control.attrs.type == :button do
     ~H"""
     <div class="flex">
       <button
@@ -43,19 +43,19 @@ defmodule LivebookWeb.Output.ControlComponent do
         type="button"
         phx-click={JS.push("button_click", target: @myself)}
       >
-        <%= @attrs.label %>
+        <%= @control.attrs.label %>
       </button>
     </div>
     """
   end
 
-  def render(%{attrs: %{type: :form}} = assigns) do
+  def render(assigns) when assigns.control.attrs.type == :form do
     ~H"""
     <div>
       <.live_component
         module={LivebookWeb.Output.ControlFormComponent}
         id={@id}
-        attrs={@attrs}
+        control={@control}
         input_views={@input_views}
         session_pid={@session_pid}
         client_id={@client_id}
@@ -67,7 +67,7 @@ defmodule LivebookWeb.Output.ControlComponent do
   def render(assigns) do
     ~H"""
     <div class="text-red-600">
-      Unknown control type <%= @attrs.type %>
+      Unknown control type <%= @control.attrs.type %>
     </div>
     """
   end
@@ -113,8 +113,8 @@ defmodule LivebookWeb.Output.ControlComponent do
   end
 
   defp report_event(socket, attrs) do
-    topic = socket.assigns.attrs.ref
+    topic = socket.assigns.control.ref
     event = Map.merge(%{origin: socket.assigns.client_id}, attrs)
-    send(socket.assigns.attrs.destination, {:event, topic, event})
+    send(socket.assigns.control.destination, {:event, topic, event})
   end
 end

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -12,7 +12,7 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   def update(assigns, socket) do
-    %{value: value, changed: changed} = assigns.input_views[assigns.attrs.id]
+    %{value: value, changed: changed} = assigns.input_views[assigns.input.id]
 
     socket =
       socket
@@ -23,51 +23,51 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   @impl true
-  def render(%{attrs: %{type: :image}} = assigns) do
+  def render(assigns) when assigns.input.attrs.type == :image do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.input_label label={@attrs.label} changed={@changed} />
+      <.input_label label={@input.attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.ImageInputComponent}
         id={"#{@id}-input"}
         input_component_id={@id}
         value={@value}
-        height={@attrs.size && elem(@attrs.size, 0)}
-        width={@attrs.size && elem(@attrs.size, 1)}
-        format={@attrs.format}
-        fit={@attrs.fit}
+        height={@input.attrs.size && elem(@input.attrs.size, 0)}
+        width={@input.attrs.size && elem(@input.attrs.size, 1)}
+        format={@input.attrs.format}
+        fit={@input.attrs.fit}
       />
     </div>
     """
   end
 
-  def render(%{attrs: %{type: :audio}} = assigns) do
+  def render(assigns) when assigns.input.attrs.type == :audio do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.input_label label={@attrs.label} changed={@changed} />
+      <.input_label label={@input.attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.AudioInputComponent}
         id={"#{@id}-input"}
         input_component_id={@id}
         value={@value}
-        format={@attrs.format}
-        sampling_rate={@attrs.sampling_rate}
+        format={@input.attrs.format}
+        sampling_rate={@input.attrs.sampling_rate}
       />
     </div>
     """
   end
 
-  def render(%{attrs: %{type: :file}} = assigns) do
+  def render(assigns) when assigns.input.attrs.type == :file do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
-      <.input_label label={@attrs.label} changed={@changed} />
+      <.input_label label={@input.attrs.label} changed={@changed} />
       <.live_component
         module={LivebookWeb.Output.FileInputComponent}
         id={"#{@id}-input"}
         input_component_id={@id}
         value={@value}
-        accept={@attrs.accept}
-        input_id={@attrs.id}
+        accept={@input.attrs.accept}
+        input_id={@input.id}
         session_pid={@session_pid}
         client_id={@client_id}
         local={@local}
@@ -76,11 +76,11 @@ defmodule LivebookWeb.Output.InputComponent do
     """
   end
 
-  def render(%{attrs: %{type: :utc_datetime}} = assigns) do
+  def render(assigns) when assigns.input.attrs.type == :utc_datetime do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
       <.input_label
-        label={@attrs.label}
+        label={@input.attrs.label}
         changed={@changed}
         help="Choose the time in your local time zone"
       />
@@ -94,19 +94,19 @@ defmodule LivebookWeb.Output.InputComponent do
         autocomplete="off"
         phx-hook="UtcDateTimeInput"
         data-utc-value={@value && NaiveDateTime.to_iso8601(@value)}
-        data-utc-min={@attrs.min && NaiveDateTime.to_iso8601(@attrs.min)}
-        data-utc-max={@attrs.max && NaiveDateTime.to_iso8601(@attrs.max)}
+        data-utc-min={@input.attrs.min && NaiveDateTime.to_iso8601(@input.attrs.min)}
+        data-utc-max={@input.attrs.max && NaiveDateTime.to_iso8601(@input.attrs.max)}
         data-phx-target={@myself}
       />
     </div>
     """
   end
 
-  def render(%{attrs: %{type: :utc_time}} = assigns) do
+  def render(assigns) when assigns.input.attrs.type == :utc_time do
     ~H"""
     <div id={"#{@id}-form-#{@counter}"}>
       <.input_label
-        label={@attrs.label}
+        label={@input.attrs.label}
         changed={@changed}
         help="Choose the time in your local time zone"
       />
@@ -120,8 +120,8 @@ defmodule LivebookWeb.Output.InputComponent do
         autocomplete="off"
         phx-hook="UtcTimeInput"
         data-utc-value={@value && Time.to_iso8601(@value)}
-        data-utc-min={@attrs.min && Time.to_iso8601(@attrs.min)}
-        data-utc-max={@attrs.max && Time.to_iso8601(@attrs.max)}
+        data-utc-min={@input.attrs.min && Time.to_iso8601(@input.attrs.min)}
+        data-utc-max={@input.attrs.max && Time.to_iso8601(@input.attrs.max)}
         data-phx-target={@myself}
       />
     </div>
@@ -131,8 +131,8 @@ defmodule LivebookWeb.Output.InputComponent do
   def render(assigns) do
     ~H"""
     <form id={"#{@id}-form-#{@counter}"} phx-change="change" phx-submit="submit" phx-target={@myself}>
-      <.input_label label={@attrs.label} changed={@changed} />
-      <.input_output id={"#{@id}-input"} attrs={@attrs} value={@value} myself={@myself} />
+      <.input_label label={@input.attrs.label} changed={@changed} />
+      <.input_output id={"#{@id}-input"} attrs={@input.attrs} value={@value} myself={@myself} />
     </form>
     """
   end
@@ -187,7 +187,7 @@ defmodule LivebookWeb.Output.InputComponent do
     <textarea
       id={@id}
       data-el-input
-      class={["input min-h-[38px] max-h-[300px] tiny-scrollbar", @attrs[:monospace] && "font-mono"]}
+      class={["input min-h-[38px] max-h-[300px] tiny-scrollbar", @attrs.monospace && "font-mono"]}
       name="html_value"
       phx-hook="TextareaAutosize"
       phx-debounce="blur"
@@ -252,7 +252,7 @@ defmodule LivebookWeb.Output.InputComponent do
   defp input_output(assigns) do
     ~H"""
     <div class="text-red-600">
-      Unknown input type <%= @attrs.type %>
+      Unknown input type <%= @input.attrs.type %>
     </div>
     """
   end
@@ -281,7 +281,7 @@ defmodule LivebookWeb.Output.InputComponent do
 
   @impl true
   def handle_event("change", %{"html_value" => html_value}, socket) do
-    case parse(html_value, socket.assigns.attrs) do
+    case parse(html_value, socket.assigns.input.attrs) do
       {:ok, value} ->
         {:noreply, handle_change(socket, value)}
 
@@ -292,10 +292,10 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   def handle_event("submit", %{"html_value" => html_value}, socket) do
-    case parse(html_value, socket.assigns.attrs) do
+    case parse(html_value, socket.assigns.input.attrs) do
       {:ok, value} ->
         socket = handle_change(socket, value)
-        send(self(), {:queue_bound_cells_evaluation, socket.assigns.attrs.id})
+        send(self(), {:queue_bound_cells_evaluation, socket.assigns.input.id})
         {:noreply, socket}
 
       :error ->
@@ -316,7 +316,7 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   defp report_change(%{assigns: assigns} = socket) do
-    send(self(), {:set_input_values, [{assigns.attrs.id, assigns.value}], assigns.local})
+    send(self(), {:set_input_values, [{assigns.input.id, assigns.value}], assigns.local})
 
     unless assigns.local do
       report_event(socket, assigns.value)
@@ -443,8 +443,8 @@ defmodule LivebookWeb.Output.InputComponent do
   end
 
   defp report_event(socket, value) do
-    topic = socket.assigns.attrs.ref
+    topic = socket.assigns.input.ref
     event = %{value: value, origin: socket.assigns.client_id, type: :change}
-    send(socket.assigns.attrs.destination, {:event, topic, event})
+    send(socket.assigns.input.destination, {:event, topic, event})
   end
 end

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -577,7 +577,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                       IO.puts("hey")\
                       """,
                       outputs: [
-                        {0, {:terminal_text, "hey", %{chunk: true}}}
+                        {0, terminal_text("hey", true)}
                       ]
                   }
                 ]
@@ -614,7 +614,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: """
                       IO.puts("hey")\
                       """,
-                      outputs: [{0, {:terminal_text, "hey", %{chunk: true}}}]
+                      outputs: [{0, terminal_text("hey", true)}]
                   }
                 ]
             }
@@ -657,8 +657,8 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                       IO.puts("hey")\
                       """,
                       outputs: [
-                        {0, {:terminal_text, "\e[34m:ok\e[0m", %{chunk: false}}},
-                        {1, {:terminal_text, "hey", %{chunk: true}}}
+                        {0, terminal_text("\e[34m:ok\e[0m")},
+                        {1, terminal_text("hey", true)}
                       ]
                   }
                 ]
@@ -707,7 +707,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: """
                       IO.puts("hey")\
                       """,
-                      outputs: [{0, {:markdown, "some **Markdown**"}}]
+                      outputs: [{0, %{type: :markdown, text: "some **Markdown**", chunk: false}}]
                   }
                 ]
             }
@@ -788,15 +788,15 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: ":ok",
                       outputs: [
                         {0,
-                         {:js,
-                          %{
-                            js_view: %{
-                              ref: "1",
-                              pid: spawn_widget_with_data("1", "graph TD;\nA-->B;"),
-                              assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
-                            },
-                            export: %{info_string: "mermaid", key: nil}
-                          }}}
+                         %{
+                           type: :js,
+                           js_view: %{
+                             ref: "1",
+                             pid: spawn_widget_with_data("1", "graph TD;\nA-->B;"),
+                             assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
+                           },
+                           export: %{info_string: "mermaid", key: nil}
+                         }}
                       ]
                   }
                 ]
@@ -840,15 +840,15 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: ":ok",
                       outputs: [
                         {0,
-                         {:js,
-                          %{
-                            js_view: %{
-                              ref: "1",
-                              pid: spawn_widget_with_data("1", %{height: 50, width: 50}),
-                              assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
-                            },
-                            export: %{info_string: "box", key: nil}
-                          }}}
+                         %{
+                           type: :js,
+                           js_view: %{
+                             ref: "1",
+                             pid: spawn_widget_with_data("1", %{height: 50, width: 50}),
+                             assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
+                           },
+                           export: %{info_string: "box", key: nil}
+                         }}
                       ]
                   }
                 ]
@@ -891,19 +891,19 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                     | source: ":ok",
                       outputs: [
                         {0,
-                         {:js,
-                          %{
-                            js_view: %{
-                              ref: "1",
-                              pid:
-                                spawn_widget_with_data("1", %{
-                                  spec: %{"height" => 50, "width" => 50},
-                                  datasets: []
-                                }),
-                              assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
-                            },
-                            export: %{info_string: "vega-lite", key: :spec}
-                          }}}
+                         %{
+                           type: :js,
+                           js_view: %{
+                             ref: "1",
+                             pid:
+                               spawn_widget_with_data("1", %{
+                                 spec: %{"height" => 50, "width" => 50},
+                                 datasets: []
+                               }),
+                             assets: %{archive_path: "", hash: "abcd", js_path: "main.js"}
+                           },
+                           export: %{info_string: "vega-lite", key: :spec}
+                         }}
                       ]
                   }
                 ]
@@ -947,12 +947,15 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                   | source: ":ok",
                     outputs: [
                       {0,
-                       {:tabs,
-                        [
-                          {1, {:markdown, "a"}},
-                          {2, {:terminal_text, "b", %{chunk: false}}},
-                          {3, {:terminal_text, "c", %{chunk: false}}}
-                        ], %{labels: ["A", "B", "C"]}}}
+                       %{
+                         type: :tabs,
+                         outputs: [
+                           {1, %{type: :markdown, text: "a", chunk: false}},
+                           {2, terminal_text("b")},
+                           {3, terminal_text("c")}
+                         ],
+                         labels: ["A", "B", "C"]
+                       }}
                     ]
                 }
               ]
@@ -995,12 +998,17 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                   | source: ":ok",
                     outputs: [
                       {0,
-                       {:grid,
-                        [
-                          {1, {:terminal_text, "a", %{chunk: false}}},
-                          {2, {:markdown, "b"}},
-                          {3, {:terminal_text, "c", %{chunk: false}}}
-                        ], %{columns: 2}}}
+                       %{
+                         type: :grid,
+                         outputs: [
+                           {1, terminal_text("a")},
+                           {2, %{type: :markdown, text: "b", chunk: false}},
+                           {3, terminal_text("c")}
+                         ],
+                         columns: 2,
+                         gap: 8,
+                         boxed: false
+                       }}
                     ]
                 }
               ]
@@ -1050,7 +1058,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                   | source: """
                     IO.puts("hey")\
                     """,
-                    outputs: [{0, {:terminal_text, "hey", %{chunk: true}}}]
+                    outputs: [{0, terminal_text("hey", true)}]
                 }
               ]
           }
@@ -1095,7 +1103,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
                   | source: """
                     IO.puts("hey")\
                     """,
-                    outputs: [{0, {:terminal_text, "hey", %{chunk: true}}}]
+                    outputs: [{0, terminal_text("hey", true)}]
                 }
               ]
           }

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -643,8 +643,8 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                        IO.puts("hey")\
                        """,
                        outputs: [
-                         {0, {:terminal_text, ":ok", %{chunk: false}}},
-                         {1, {:terminal_text, "hey", %{chunk: false}}}
+                         {0, terminal_text(":ok")},
+                         {1, terminal_text("hey")}
                        ]
                      }
                    ]
@@ -886,8 +886,8 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                        IO.puts("hey")\
                        """,
                        outputs: [
-                         {0, {:terminal_text, ":ok", %{chunk: false}}},
-                         {1, {:terminal_text, "hey", %{chunk: false}}}
+                         {0, terminal_text(":ok")},
+                         {1, terminal_text("hey")}
                        ]
                      }
                    ]

--- a/test/livebook/runtime/erl_dist/runtime_server_test.exs
+++ b/test/livebook/runtime/erl_dist/runtime_server_test.exs
@@ -9,6 +9,12 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
     {:ok, %{pid: runtime_server_pid}}
   end
 
+  defmacrop terminal_text(text, chunk \\ false) do
+    quote do
+      %{type: :terminal_text, text: unquote(text), chunk: unquote(chunk)}
+    end
+  end
+
   describe "attach/2" do
     test "starts watching the given process and terminates as soon as it terminates" do
       owner =
@@ -63,7 +69,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
         []
       )
 
-      assert_receive {:runtime_evaluation_output, :e1, {:terminal_text, output, %{chunk: true}}}
+      assert_receive {:runtime_evaluation_output, :e1, terminal_text(output, true)}
 
       assert output =~ "error to stdout\n"
     end
@@ -77,8 +83,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
 
       RuntimeServer.evaluate_code(pid, :elixir, code, {:c1, :e1}, [])
 
-      assert_receive {:runtime_evaluation_output, :e1,
-                      {:terminal_text, log_message, %{chunk: true}}}
+      assert_receive {:runtime_evaluation_output, :e1, terminal_text(log_message, true)}
 
       assert log_message =~ "[error] hey"
     end
@@ -89,7 +94,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
 
       RuntimeServer.evaluate_code(pid, :elixir, "x", {:c2, :e2}, [{:c1, :e1}])
 
-      assert_receive {:runtime_evaluation_response, :e2, {:terminal_text, "\e[34m1\e[0m", %{}},
+      assert_receive {:runtime_evaluation_response, :e2, terminal_text("\e[34m1\e[0m"),
                       %{evaluation_time_ms: _time_ms}}
     end
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -39,6 +39,18 @@ defmodule Livebook.Runtime.EvaluatorTest do
   defmacrop ansi_number(number), do: "\e[34m#{number}\e[0m"
   defmacrop ansi_string(string), do: "\e[32m\"#{string}\"\e[0m"
 
+  defmacrop terminal_text(text, chunk \\ false) do
+    quote do
+      %{type: :terminal_text, text: unquote(text), chunk: unquote(chunk)}
+    end
+  end
+
+  defmacrop error(message) do
+    quote do
+      %{type: :error, message: unquote(message), known_reason: :other}
+    end
+  end
+
   describe "evaluate_code/6" do
     test "given a valid code returns evaluation result", %{evaluator: evaluator} do
       code = """
@@ -49,8 +61,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, ansi_number(3), %{}}, metadata() = metadata}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(ansi_number(3)),
+                      metadata() = metadata}
 
       assert metadata.evaluation_time_ms >= 0
 
@@ -65,9 +77,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, "x", :code_2, [])
 
       assert_receive {:runtime_evaluation_response, :code_2,
-                      {:error,
-                       "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m",
-                       :other}, metadata()}
+                      error(
+                        "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m"
+                      ), metadata()}
     end
 
     test "given parent refs sees previous evaluation context", %{evaluator: evaluator} do
@@ -76,15 +88,15 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, "x", :code_2, [:code_1])
 
-      assert_receive {:runtime_evaluation_response, :code_2,
-                      {:terminal_text, ansi_number(1), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(ansi_number(1)),
+                      metadata()}
     end
 
     test "given invalid parent ref uses the default context", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, :elixir, "1", :code_1, [:code_nonexistent])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, ansi_number(1), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(ansi_number(1)),
+                      metadata()}
     end
 
     test "given parent refs sees previous process dictionary", %{evaluator: evaluator} do
@@ -95,13 +107,13 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, "Process.get(:x)", :code_3, [:code_1])
 
-      assert_receive {:runtime_evaluation_response, :code_3,
-                      {:terminal_text, ansi_number(1), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_3, terminal_text(ansi_number(1)),
+                      metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, "Process.get(:x)", :code_3, [:code_2])
 
-      assert_receive {:runtime_evaluation_response, :code_3,
-                      {:terminal_text, ansi_number(2), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_3, terminal_text(ansi_number(2)),
+                      metadata()}
     end
 
     test "keeps :rand state intact in process dictionary", %{evaluator: evaluator} do
@@ -110,13 +122,11 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, ":rand.uniform()", :code_2, [])
 
-      assert_receive {:runtime_evaluation_response, :code_2, {:terminal_text, result1, %{}},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(result1), metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, ":rand.uniform()", :code_2, [])
 
-      assert_receive {:runtime_evaluation_response, :code_2, {:terminal_text, result2, %{}},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(result2), metadata()}
 
       assert result1 != result2
 
@@ -125,20 +135,17 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, ":rand.uniform()", :code_2, [])
 
-      assert_receive {:runtime_evaluation_response, :code_2, {:terminal_text, ^result1, %{}},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(^result1), metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, ":rand.uniform()", :code_2, [])
 
-      assert_receive {:runtime_evaluation_response, :code_2, {:terminal_text, ^result2, %{}},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(^result2), metadata()}
     end
 
     test "captures standard output and sends it to the caller", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, :elixir, ~s{IO.puts("hey")}, :code_1, [])
 
-      assert_receive {:runtime_evaluation_output, :code_1,
-                      {:terminal_text, "hey\n", %{chunk: true}}}
+      assert_receive {:runtime_evaluation_output, :code_1, terminal_text("hey\n", true)}
     end
 
     test "using livebook input sends input request to the caller", %{evaluator: evaluator} do
@@ -156,8 +163,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
       assert_receive {:runtime_evaluation_input_request, :code_1, reply_to, "input1"}
       send(reply_to, {:runtime_evaluation_input_reply, {:ok, 10}})
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, ansi_number(10), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(ansi_number(10)),
+                      metadata()}
     end
 
     test "returns error along with its kind and stacktrace", %{evaluator: evaluator} do
@@ -167,8 +174,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, :other},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()}
 
       assert """
              ** (FunctionClauseError) no function clause matching in List.first/2
@@ -194,7 +200,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, :other},
+      assert_receive {:runtime_evaluation_response, :code_1, error(message),
                       %{
                         code_markers: [
                           %{
@@ -219,9 +225,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
-                      {:error,
-                       "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m",
-                       :other},
+                      error(
+                        "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m"
+                      ),
                       %{
                         code_markers: [
                           %{
@@ -245,9 +251,10 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
-                      {:error,
-                       "\e[31m** (CompileError) file.ex: cannot compile module Livebook.Runtime.EvaluatorTest.Invalid " <>
-                         "(errors have been logged)\e[0m" <> _, :other},
+                      error(
+                        "\e[31m** (CompileError) file.ex: cannot compile module Livebook.Runtime.EvaluatorTest.Invalid " <>
+                          "(errors have been logged)\e[0m" <> _
+                      ),
                       %{
                         code_markers: [
                           %{
@@ -267,9 +274,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_1,
-                      {:error,
-                       "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m",
-                       :other}, %{code_markers: []}}
+                      error(
+                        "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m"
+                      ), %{code_markers: []}}
     end
 
     test "in case of an error returns only the relevant part of stacktrace",
@@ -295,8 +302,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
 
       # Note: evaluating module definitions is relatively slow, so we use a higher wait timeout.
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, :other},
-                      metadata()},
+      assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()},
                      2_000
 
       assert clean_message(message) ==
@@ -324,17 +330,17 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, code1, :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, ansi_number(2), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(ansi_number(2)),
+                      metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, code2, :code_2, [:code_1])
 
-      assert_receive {:runtime_evaluation_response, :code_2, {:error, _, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, error(_), metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, code3, :code_3, [:code_2, :code_1])
 
-      assert_receive {:runtime_evaluation_response, :code_3,
-                      {:terminal_text, ansi_number(4), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_3, terminal_text(ansi_number(4)),
+                      metadata()}
     end
 
     test "given file option sets it in evaluation environment", %{evaluator: evaluator} do
@@ -346,7 +352,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], opts)
 
       assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, ansi_string("/path/dir"), %{}}, metadata()}
+                      terminal_text(ansi_string("/path/dir")), metadata()}
     end
 
     test "kills widgets that that no evaluation points to", %{evaluator: evaluator} do
@@ -356,8 +362,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, spawn_widget_code(), :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, widget_pid1_string, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(widget_pid1_string),
+                      metadata()}
 
       widget_pid1 = IEx.Helpers.pid(widget_pid1_string)
 
@@ -365,8 +371,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, spawn_widget_code(), :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, widget_pid2_string, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(widget_pid2_string),
+                      metadata()}
 
       widget_pid2 = IEx.Helpers.pid(widget_pid2_string)
 
@@ -387,8 +393,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
         []
       )
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, widget_pid1_string, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(widget_pid1_string),
+                      metadata()}
 
       widget_pid1 = IEx.Helpers.pid(widget_pid1_string)
 
@@ -404,18 +410,18 @@ defmodule Livebook.Runtime.EvaluatorTest do
       """
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, _, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(_), metadata()}
 
       # Redefining in the same evaluation works
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, _, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(_), metadata()}
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_2, [], file: "file.ex")
 
       assert_receive {:runtime_evaluation_response, :code_2,
-                      {:error,
-                       "\e[31m** (CompileError) file.ex:1: module Livebook.Runtime.EvaluatorTest.Redefinition is already defined\e[0m",
-                       :other},
+                      error(
+                        "\e[31m** (CompileError) file.ex:1: module Livebook.Runtime.EvaluatorTest.Redefinition is already defined\e[0m"
+                      ),
                       %{
                         code_markers: [
                           %{
@@ -438,7 +444,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       """
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, _, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(_), metadata()}
 
       assert File.exists?(Path.join(ebin_path, "Elixir.Livebook.Runtime.EvaluatorTest.Disk.beam"))
 
@@ -454,7 +460,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       """
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, _, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, error(_), metadata()}
 
       refute Code.ensure_loaded?(Livebook.Runtime.EvaluatorTest.Raised)
     end
@@ -742,7 +748,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       ref = eval_idx
       parent_refs = Enum.to_list((eval_idx - 1)..0//-1)
       Evaluator.evaluate_code(evaluator, :elixir, code, ref, parent_refs)
-      assert_receive {:runtime_evaluation_response, ^ref, {:terminal_text, _, %{}}, metadata}
+      assert_receive {:runtime_evaluation_response, ^ref, terminal_text(_), metadata}
       %{used: metadata.identifiers_used, defined: metadata.identifiers_defined}
     end
 
@@ -1150,16 +1156,16 @@ defmodule Livebook.Runtime.EvaluatorTest do
       Evaluator.evaluate_code(evaluator, :elixir, "x", :code_2, [:code_1])
 
       assert_receive {:runtime_evaluation_response, :code_2,
-                      {:error,
-                       "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m",
-                       :other}, metadata()}
+                      error(
+                        "\e[31m** (CompileError) cannot compile cell (errors have been logged)\e[0m"
+                      ), metadata()}
     end
 
     test "kills widgets that no evaluation points to", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, :elixir, spawn_widget_code(), :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1,
-                      {:terminal_text, widget_pid1_string, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(widget_pid1_string),
+                      metadata()}
 
       widget_pid1 = IEx.Helpers.pid(widget_pid1_string)
 
@@ -1177,13 +1183,13 @@ defmodule Livebook.Runtime.EvaluatorTest do
       """
 
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, _, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(_), metadata()}
 
       Evaluator.forget_evaluation(evaluator, :code_1)
 
       # Define the module in a different evaluation
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_2, [])
-      assert_receive {:runtime_evaluation_response, :code_2, {:terminal_text, _, %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(_), metadata()}
     end
   end
 
@@ -1206,8 +1212,8 @@ defmodule Livebook.Runtime.EvaluatorTest do
 
       Evaluator.evaluate_code(evaluator, :elixir, "x", :code_2, [])
 
-      assert_receive {:runtime_evaluation_response, :code_2,
-                      {:terminal_text, ansi_number(1), %{}}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, terminal_text(ansi_number(1)),
+                      metadata()}
     end
   end
 
@@ -1246,8 +1252,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
         []
       )
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, "6", %{}},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text("6"), metadata()}
     end
 
     test "mixed erlang/elixir bindings", %{evaluator: evaluator} do
@@ -1265,15 +1270,14 @@ defmodule Livebook.Runtime.EvaluatorTest do
       code = ~S"#{x=>1}."
       Evaluator.evaluate_code(evaluator, :erlang, code, :code_1, [], file: "file.ex")
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:terminal_text, ~S"#{x => 1}", %{}},
+      assert_receive {:runtime_evaluation_response, :code_1, terminal_text(~S"#{x => 1}"),
                       metadata()}
     end
 
     test "does not return error marker on empty source", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, :erlang, "", :code_1, [])
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, _, _},
-                      metadata() = metadata}
+      assert_receive {:runtime_evaluation_response, :code_1, error(_), metadata() = metadata}
 
       assert metadata.code_markers == []
     end
@@ -1281,22 +1285,22 @@ defmodule Livebook.Runtime.EvaluatorTest do
     test "syntax and tokenizer errors are converted", %{evaluator: evaluator} do
       # Incomplete input
       Evaluator.evaluate_code(evaluator, :erlang, "X =", :code_1, [])
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()}
       assert "\e[31m** (TokenMissingError)" <> _ = message
 
       # Parser error
       Evaluator.evaluate_code(evaluator, :erlang, "X ==/== a.", :code_2, [])
-      assert_receive {:runtime_evaluation_response, :code_2, {:error, message, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_2, error(message), metadata()}
       assert "\e[31m** (SyntaxError)" <> _ = message
 
       # Tokenizer error
       Evaluator.evaluate_code(evaluator, :erlang, "$a$", :code_3, [])
-      assert_receive {:runtime_evaluation_response, :code_3, {:error, message, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_3, error(message), metadata()}
       assert "\e[31m** (SyntaxError)" <> _ = message
 
       # Erlang exception
       Evaluator.evaluate_code(evaluator, :erlang, "list_to_binary(1).", :code_4, [])
-      assert_receive {:runtime_evaluation_response, :code_4, {:error, message, _}, metadata()}
+      assert_receive {:runtime_evaluation_response, :code_4, error(message), metadata()}
       assert "\e[31mexception error: bad argument" <> _ = message
     end
   end
@@ -1306,8 +1310,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
       code = "%Livebook.TestModules.BadInspect{}"
       Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex")
 
-      assert_receive {:runtime_evaluation_response, :code_1, {:error, message, :other},
-                      metadata()}
+      assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()}
 
       assert message =~ ":bad_return"
     end

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -207,8 +207,8 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       Session.queue_cell_evaluation(session.pid, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:terminal_text, output, %{}},
-                       _}}
+                      {:add_cell_evaluation_response, _, ^cell_id,
+                       %{type: :terminal_text, text: output}, _}}
 
       assert output == "\e[32m\"#{secret.value}\"\e[0m"
     end
@@ -272,8 +272,8 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       Session.queue_cell_evaluation(session.pid, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:terminal_text, output, %{}},
-                       _}}
+                      {:add_cell_evaluation_response, _, ^cell_id,
+                       %{type: :terminal_text, text: output}, _}}
 
       assert output == "\e[32m\"#{secret.value}\"\e[0m"
     end

--- a/test/livebook_web/controllers/session_controller_test.exs
+++ b/test/livebook_web/controllers/session_controller_test.exs
@@ -221,7 +221,7 @@ defmodule LivebookWeb.SessionControllerTest do
                     | source: """
                       IO.puts("hey")\
                       """,
-                      outputs: [{0, {:terminal_text, "hey", %{chunk: true}}}]
+                      outputs: [{0, %{type: :terminal_text, text: "hey", chunk: true}}]
                   }
                 ]
             }
@@ -373,7 +373,7 @@ defmodule LivebookWeb.SessionControllerTest do
     archive_path = Path.expand("../../support/assets.tar.gz", __DIR__)
     hash = "test-" <> Livebook.Utils.random_id()
     assets_info = %{archive_path: archive_path, hash: hash, js_path: "main.js"}
-    output = {:js, %{js_view: %{assets: assets_info}}}
+    output = %{type: :js, js_view: %{assets: assets_info}, export: nil}
 
     notebook = %{
       Notebook.new()

--- a/test/livebook_web/live/app_session_live_test.exs
+++ b/test/livebook_web/live/app_session_live_test.exs
@@ -81,11 +81,17 @@ defmodule LivebookWeb.AppSessionLiveTest do
             | cells: [
                 %{
                   Livebook.Notebook.Cell.new(:code)
-                  | source: source_for_output({:terminal_text, "Printed output", %{chunk: false}})
+                  | source:
+                      source_for_output(%{
+                        type: :terminal_text,
+                        text: "Printed output",
+                        chunk: false
+                      })
                 },
                 %{
                   Livebook.Notebook.Cell.new(:code)
-                  | source: source_for_output({:plain_text, "Custom text", %{chunk: false}})
+                  | source:
+                      source_for_output(%{type: :plain_text, text: "Custom text", chunk: false})
                 }
               ]
           }
@@ -121,7 +127,12 @@ defmodule LivebookWeb.AppSessionLiveTest do
             | cells: [
                 %{
                   Livebook.Notebook.Cell.new(:code)
-                  | source: source_for_output({:terminal_text, "Printed output", %{chunk: false}})
+                  | source:
+                      source_for_output(%{
+                        type: :terminal_text,
+                        text: "Printed output",
+                        chunk: false
+                      })
                 },
                 %{
                   Livebook.Notebook.Cell.new(:code)
@@ -174,12 +185,11 @@ defmodule LivebookWeb.AppSessionLiveTest do
     Process.register(self(), test)
 
     input = %{
-      ref: :input_ref,
+      type: :input,
+      ref: "ref1",
       id: "input1",
-      type: :number,
-      label: "Name",
-      default: 1,
-      destination: test
+      destination: test,
+      attrs: %{type: :number, default: 1, label: "Name"}
     }
 
     notebook = %{
@@ -191,7 +201,7 @@ defmodule LivebookWeb.AppSessionLiveTest do
             | cells: [
                 %{
                   Livebook.Notebook.Cell.new(:code)
-                  | source: source_for_output({:input, input})
+                  | source: source_for_output(input)
                 },
                 %{
                   Livebook.Notebook.Cell.new(:code)

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -177,7 +177,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, "\e[32m\"true\"\e[0m", %{chunk: false}}, _}}
+                       terminal_text("\e[32m\"true\"\e[0m"), _}}
     end
 
     test "cancelling cell evaluation", %{conn: conn, session: session} do
@@ -486,17 +486,16 @@ defmodule LivebookWeb.SessionLiveTest do
       Process.register(self(), test)
 
       input = %{
-        ref: :input_ref,
+        type: :input,
+        ref: "ref1",
         id: "input1",
-        type: :number,
-        label: "Name",
-        default: 1,
-        destination: test
+        destination: test,
+        attrs: %{type: :number, default: 1, label: "Name"}
       }
 
       Session.subscribe(session.id)
 
-      insert_cell_with_output(session.pid, section_id, {:input, input})
+      insert_cell_with_output(session.pid, section_id, input)
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
@@ -506,7 +505,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert %{input_infos: %{"input1" => %{value: 10}}} = Session.get_data(session.pid)
 
-      assert_receive {:event, :input_ref, %{value: 10, type: :change}}
+      assert_receive {:event, "ref1", %{value: 10, type: :change}}
     end
 
     test "newlines in text input are normalized", %{conn: conn, session: session, test: test} do
@@ -515,17 +514,16 @@ defmodule LivebookWeb.SessionLiveTest do
       Process.register(self(), test)
 
       input = %{
-        ref: :input_ref,
+        type: :input,
+        ref: "ref1",
         id: "input1",
-        type: :textarea,
-        label: "Name",
-        default: "hey",
-        destination: test
+        destination: test,
+        attrs: %{type: :textarea, default: "hey", label: "Name", monospace: false}
       }
 
       Session.subscribe(session.id)
 
-      insert_cell_with_output(session.pid, section_id, {:input, input})
+      insert_cell_with_output(session.pid, section_id, input)
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
@@ -543,27 +541,29 @@ defmodule LivebookWeb.SessionLiveTest do
       Process.register(self(), test)
 
       form_control = %{
-        type: :form,
-        ref: :form_ref,
+        type: :control,
+        ref: "control_ref1",
         destination: test,
-        fields: [
-          name: %{
-            ref: :input_ref,
-            id: "input1",
-            type: :text,
-            label: "Name",
-            default: "initial",
-            destination: test
-          }
-        ],
-        submit: "Send",
-        report_changes: %{},
-        reset_on_submit: []
+        attrs: %{
+          type: :form,
+          fields: [
+            name: %{
+              type: :input,
+              ref: "input_ref1",
+              id: "input1",
+              destination: test,
+              attrs: %{type: :text, default: "initial", label: "Name"}
+            }
+          ],
+          submit: "Send",
+          report_changes: %{},
+          reset_on_submit: []
+        }
       }
 
       Session.subscribe(session.id)
 
-      insert_cell_with_output(session.pid, section_id, {:control, form_control})
+      insert_cell_with_output(session.pid, section_id, form_control)
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
@@ -580,7 +580,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> element(~s/[data-el-outputs-container] button/, "Send")
       |> render_click()
 
-      assert_receive {:event, :form_ref, %{data: %{name: "sherlock"}, type: :submit}}
+      assert_receive {:event, "control_ref1", %{data: %{name: "sherlock"}, type: :submit}}
     end
 
     test "file input", %{conn: conn, session: session, test: test} do
@@ -589,18 +589,16 @@ defmodule LivebookWeb.SessionLiveTest do
       Process.register(self(), test)
 
       input = %{
-        ref: :input_ref,
+        type: :input,
+        ref: "ref1",
         id: "input1",
-        type: :file,
-        label: "File",
-        default: nil,
         destination: test,
-        accept: :any
+        attrs: %{type: :file, default: nil, label: "File", accept: :any}
       }
 
       Session.subscribe(session.id)
 
-      insert_cell_with_output(session.pid, section_id, {:input, input})
+      insert_cell_with_output(session.pid, section_id, input)
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
@@ -636,18 +634,12 @@ defmodule LivebookWeb.SessionLiveTest do
 
       Session.queue_cell_evaluation(session.pid, cell_id)
 
-      send(
-        session.pid,
-        {:runtime_evaluation_output, cell_id, {:terminal_text, "line 1\n", %{chunk: true}}}
-      )
+      send(session.pid, {:runtime_evaluation_output, cell_id, terminal_text("line 1\n", true)})
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
       assert render(view) =~ "line 1"
 
-      send(
-        session.pid,
-        {:runtime_evaluation_output, cell_id, {:terminal_text, "line 2\n", %{chunk: true}}}
-      )
+      send(session.pid, {:runtime_evaluation_output, cell_id, terminal_text("line 2\n", true)})
 
       wait_for_session_update(session.pid)
       # Render once, so that the send_update is processed
@@ -664,21 +656,19 @@ defmodule LivebookWeb.SessionLiveTest do
 
       Session.queue_cell_evaluation(session.pid, cell_id)
 
-      send(
-        session.pid,
-        {:runtime_evaluation_output, cell_id,
-         {:frame, [{:terminal_text, "In frame", %{chunk: false}}], %{ref: "1", type: :default}}}
-      )
+      frame = %{type: :frame, ref: "1", outputs: [terminal_text("In frame")], placeholder: true}
+      send(session.pid, {:runtime_evaluation_output, cell_id, frame})
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
       assert render(view) =~ "In frame"
 
-      send(
-        session.pid,
-        {:runtime_evaluation_output, cell_id,
-         {:frame, [{:terminal_text, "Updated frame", %{chunk: false}}],
-          %{ref: "1", type: :replace}}}
-      )
+      frame_update = %{
+        type: :frame_update,
+        ref: "1",
+        update: {:replace, [terminal_text("Updated frame")]}
+      }
+
+      send(session.pid, {:runtime_evaluation_output, cell_id, frame_update})
 
       wait_for_session_update(session.pid)
 
@@ -704,13 +694,11 @@ defmodule LivebookWeb.SessionLiveTest do
 
       send(
         session.pid,
-        {:runtime_evaluation_output_to, client_id, cell_id,
-         {:terminal_text, "line 1\n", %{chunk: true}}}
+        {:runtime_evaluation_output_to, client_id, cell_id, terminal_text("line 1\n", true)}
       )
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_output, _, ^cell_id,
-                       {:terminal_text, "line 1\n", %{chunk: true}}}}
+                      {:add_cell_evaluation_output, _, ^cell_id, terminal_text("line 1\n", true)}}
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
       refute render(view) =~ "line 1"
@@ -731,13 +719,11 @@ defmodule LivebookWeb.SessionLiveTest do
 
       send(
         session.pid,
-        {:runtime_evaluation_output_to_clients, cell_id,
-         {:terminal_text, "line 1\n", %{chunk: false}}}
+        {:runtime_evaluation_output_to_clients, cell_id, terminal_text("line 1\n")}
       )
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_output, _, ^cell_id,
-                       {:terminal_text, "line 1\n", %{chunk: false}}}}
+                      {:add_cell_evaluation_output, _, ^cell_id, terminal_text("line 1\n")}}
 
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
       refute render(view) =~ "line 1"
@@ -750,17 +736,16 @@ defmodule LivebookWeb.SessionLiveTest do
       Process.register(self(), test)
 
       input = %{
-        ref: :input_ref,
+        type: :input,
+        ref: "ref1",
         id: "input1",
-        type: :number,
-        label: "Name",
-        default: 1,
-        destination: test
+        destination: test,
+        attrs: %{type: :number, default: 1, label: "Name"}
       }
 
       Session.subscribe(session.id)
 
-      insert_cell_with_output(session.pid, section_id, {:input, input})
+      insert_cell_with_output(session.pid, section_id, input)
 
       code = source_for_input_read(input.id)
       cell_id = insert_text_cell(session.pid, section_id, :code, code)
@@ -1479,8 +1464,7 @@ defmodule LivebookWeb.SessionLiveTest do
       Session.queue_cell_evaluation(session.pid, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, output, %{chunk: false}}, _}}
+                      {:add_cell_evaluation_response, _, ^cell_id, terminal_text(output), _}}
 
       assert output == "\e[32m\"#{secret.value}\"\e[0m"
     end
@@ -1527,8 +1511,7 @@ defmodule LivebookWeb.SessionLiveTest do
       Session.queue_cell_evaluation(session.pid, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, output, %{chunk: false}}, _}}
+                      {:add_cell_evaluation_response, _, ^cell_id, terminal_text(output), _}}
 
       assert output == "\e[32m\"#{secret.value}\"\e[0m"
     end
@@ -1620,7 +1603,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, "\e[35mnil\e[0m", %{chunk: false}}, _}}
+                       terminal_text("\e[35mnil\e[0m"), _}}
 
       attrs = params_for(:env_var, name: "MY_AWESOME_ENV", value: "MyEnvVarValue")
       Settings.set_env_var(attrs)
@@ -1631,7 +1614,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, "\e[32m\"MyEnvVarValue\"\e[0m", %{chunk: false}}, _}}
+                       terminal_text("\e[32m\"MyEnvVarValue\"\e[0m"), _}}
 
       Settings.set_env_var(%{attrs | value: "OTHER_VALUE"})
 
@@ -1641,7 +1624,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, "\e[32m\"OTHER_VALUE\"\e[0m", %{chunk: false}}, _}}
+                       terminal_text("\e[32m\"OTHER_VALUE\"\e[0m"), _}}
 
       Settings.unset_env_var("MY_AWESOME_ENV")
 
@@ -1651,7 +1634,7 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert_receive {:operation,
                       {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, "\e[35mnil\e[0m", %{chunk: false}}, _}}
+                       terminal_text("\e[35mnil\e[0m"), _}}
     end
 
     @tag :tmp_dir
@@ -1685,8 +1668,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> render_hook("queue_cell_evaluation", %{"cell_id" => cell_id})
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, output, %{chunk: false}}, _}}
+                      {:add_cell_evaluation_response, _, ^cell_id, terminal_text(output), _}}
 
       assert output == "\e[32m\"#{String.replace(expected_path, "\\", "\\\\")}\"\e[0m"
 
@@ -1697,8 +1679,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> render_hook("queue_cell_evaluation", %{"cell_id" => cell_id})
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id,
-                       {:terminal_text, output, %{chunk: false}}, _}}
+                      {:add_cell_evaluation_response, _, ^cell_id, terminal_text(output), _}}
 
       assert output == "\e[32m\"#{String.replace(initial_os_path, "\\", "\\\\")}\"\e[0m"
     end
@@ -2031,7 +2012,7 @@ defmodule LivebookWeb.SessionLiveTest do
       insert_cell_with_output(
         session.pid,
         section_id,
-        {:terminal_text, "Hello from the app!", %{chunk: false}}
+        terminal_text("Hello from the app!")
       )
 
       slug = Livebook.Utils.random_short_id()

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -112,4 +112,13 @@ defmodule Livebook.TestHelpers do
 
     {code, ack_fun}
   end
+
+  @doc """
+  Builds a terminal output map.
+  """
+  defmacro terminal_text(text, chunk \\ false) do
+    quote do
+      %{type: :terminal_text, text: unquote(text), chunk: unquote(chunk)}
+    end
+  end
 end


### PR DESCRIPTION
I've been meaning to do this for a while, but with recent text changes it felt like a good moment.

So far we used tuples for outputs, but that is a bit annoying in certain places and makes pattern matching more verbose if we ignore tuple elements. Given that outputs are data structures that we keep, I should've done it from the start :)

I also moved output types specification from kino here. It's a fairly low-level detail, that doesn't matter for kino users in practice, and it is a part of the runtime specification, so here's a better place. Additionally, here we actually work with the outputs, so detailed typespecs can be more helpful.

I added a normalization function (`Session.normalize_runtime_output/1`) for backward compatibility and it handles all attributes that were added incrementally and may not be present. Going forward we should always normalize outputs there, so that we can assume complete outputs everywhere else.