### PR TITLE
Do not export setup cell output

### DIFF
--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -62,7 +62,7 @@ defmodule Livebook.LiveMarkdown.Export do
       end)
 
     name = ["# ", notebook.name]
-    setup_cell = render_setup_cell(setup_cell, ctx)
+    setup_cell = render_setup_cell(setup_cell, %{ctx | include_outputs?: false})
     sections = Enum.map(notebook.sections, &render_section(&1, notebook, ctx))
 
     metadata = notebook_metadata(notebook)

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -642,6 +642,35 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       assert expected_document == document
     end
 
+    test "does not include setup cell output" do
+      notebook = %{Notebook.new() | name: "My Notebook"}
+
+      notebook =
+        update_in(notebook.setup_section.cells, fn [setup_cell] ->
+          [
+            %{
+              setup_cell
+              | source: """
+                IO.puts("hey")\
+                """,
+                outputs: [{0, terminal_text("hey", true)}]
+            }
+          ]
+        end)
+
+      expected_document = """
+      # My Notebook
+
+      ```elixir
+      IO.puts("hey")
+      ```
+      """
+
+      {document, []} = Export.notebook_to_livemd(notebook, include_outputs: true)
+
+      assert expected_document == document
+    end
+
     test "removes ANSI escape codes from the output text" do
       notebook = %{
         Notebook.new()


### PR DESCRIPTION
The setup cell may have a long log from `Mix.install`, which is not really relevant, and when cached it's just boring `:ok`. To keep the export clean we can just ignore setup cell output.