### PR TITLE
Support debounce option for inputs

### DIFF
--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -223,7 +223,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class="input w-auto invalid:input--error"
       name="html_value"
       value={@value}
-      phx-debounce={@attrs[:debounce] || "blur"}
+      phx-debounce="blur"
       phx-target={@myself}
       min={@attrs.min}
       max={@attrs.max}

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -169,7 +169,7 @@ defmodule LivebookWeb.Output.InputComponent do
         class="input-range"
         name="html_value"
         value={@value}
-        phx-debounce="blur"
+        phx-debounce={@attrs[:debounce] || "blur"}
         phx-target={@myself}
         spellcheck="false"
         autocomplete="off"
@@ -190,7 +190,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class={["input min-h-[38px] max-h-[300px] tiny-scrollbar", @attrs.monospace && "font-mono"]}
       name="html_value"
       phx-hook="TextareaAutosize"
-      phx-debounce="blur"
+      phx-debounce={@attrs[:debounce] || "blur"}
       phx-target={@myself}
       spellcheck="false"
     ><%= [?\n, @value] %></textarea>
@@ -206,7 +206,7 @@ defmodule LivebookWeb.Output.InputComponent do
         class="input w-auto bg-gray-50"
         name="html_value"
         value={@value}
-        phx-debounce="blur"
+        phx-debounce={@attrs[:debounce] || "blur"}
         phx-target={@myself}
         spellcheck="false"
         autocomplete="off"
@@ -223,7 +223,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class="input w-auto invalid:input--error"
       name="html_value"
       value={@value}
-      phx-debounce="blur"
+      phx-debounce={@attrs[:debounce] || "blur"}
       phx-target={@myself}
       min={@attrs.min}
       max={@attrs.max}
@@ -241,7 +241,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class="input w-auto invalid:input--error"
       name="html_value"
       value={to_string(@value)}
-      phx-debounce="blur"
+      phx-debounce={@attrs[:debounce] || "blur"}
       phx-target={@myself}
       spellcheck="false"
       autocomplete="off"


### PR DESCRIPTION
i would like to have control over the `phx-debounce` setting as a user for an input.

Right now it defaults to `blur`. I would expect an options same as [Phoenix LiveView offers it](https://hexdocs.pm/phoenix_live_view/bindings.html#rate-limiting-events-with-debounce-and-throttle)

This is relevant for the inputs of type
* `range`
* `textarea`
* `password`
* `date`
* `number`
* `color`
* `url`
* `text`

each gets a `:debounce` option working the same as phoenix, but with a default value of `"blur"`.

This change is accompanied by a change in Kino, see https://github.com/livebook-dev/kino/pull/347

I chose to add a fallback to `"blur"` here as well, so there is no hard dependency on the Kino change:
`@attrs[:debounce] || "blur"`

This was a show stopper for me, when i tried to create a little type racing game in Livebook.