### PR TITLE
desktop: Add "Open .livebookdesktop.sh|bat" menu item

### DIFF
--- a/rel/app/macos/Sources/Livebook/Livebook.swift
+++ b/rel/app/macos/Sources/Livebook/Livebook.swift
@@ -140,11 +140,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !fm.fileExists(atPath: bootScriptURL.path) {
             let data = """
             # This file is used to configure Livebook before booting.
-            #
+            # If you change this file, you must restart Livebook for your changes to take place.
             # See https://hexdocs.pm/livebook/readme.html#environment-variables for all available environment variables.
 
-            # # Run Livebook on port 9999
-            # export LIVEBOOK_PORT=9999
+            # # Allow Livebook to connect to remote machines over IPv6
+            # export LIVEBOOK_DISTRIBUTION=name
+            # export ERL_AFLAGS="-proto_dist inet6_tcp"
 
             # # Add Homebrew to PATH
             # export PATH=/opt/homebrew/bin:$PATH

--- a/rel/app/macos/Sources/Livebook/Livebook.swift
+++ b/rel/app/macos/Sources/Livebook/Livebook.swift
@@ -17,9 +17,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var launchedByOpenURL = false
     private var initialURLs: [URL] = []
     private var url: String?
+    private var bootScriptURL: URL!
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         logPath = "\(NSHomeDirectory())/Library/Logs/Livebook.log"
+        bootScriptURL = NSURL.fileURL(withPath: "\(NSHomeDirectory())/.livebookdesktop.sh")
 
         ElixirKit.API.start(
             name: "app",
@@ -72,6 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSMenuItem(title: "Open", action: #selector(open), keyEquivalent: "o"),
             copyURLItem,
             NSMenuItem(title: "View Logs", action: #selector(viewLogs), keyEquivalent: "l"),
+            NSMenuItem(title: "Open .livebookdesktop.sh", action: #selector(openBootScript), keyEquivalent: ""),
             NSMenuItem(title: "Settings", action: #selector(openSettings), keyEquivalent: ","),
             NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         ]
@@ -128,5 +131,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc
     func openSettings() {
         ElixirKit.API.publish("open", "/settings")
+    }
+
+    @objc
+    func openBootScript() {
+        let fm = FileManager.default
+
+        if !fm.fileExists(atPath: bootScriptURL.path) {
+            let data = """
+            # This file is used to configure Livebook before booting.
+            #
+            # See https://hexdocs.pm/livebook/readme.html#environment-variables for all available environment variables.
+
+            # # Run Livebook on port 9999
+            # export LIVEBOOK_PORT=9999
+
+            # # Add Homebrew to PATH
+            # export PATH=/opt/homebrew/bin:$PATH
+            """.data(using: .utf8)
+
+            fm.createFile(atPath: bootScriptURL.path, contents: data)
+        }
+
+        NSWorkspace.shared.open(bootScriptURL)
     }
 }

--- a/rel/app/windows/Livebook.cs
+++ b/rel/app/windows/Livebook.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
@@ -72,6 +73,7 @@ class LivebookApp : ApplicationContext
         copyURLButton.Enabled = false;
 
         menu.Items.Add("View Logs", null, viewLogsClicked);
+        menu.Items.Add("Open .livebookdesktop.bat", null, openBootScriptClicked);
         menu.Items.Add("Settings", null, openSettingsClicked);
         menu.Items.Add("Quit", null, quitClicked);
         notifyIcon = new NotifyIcon()
@@ -139,7 +141,33 @@ class LivebookApp : ApplicationContext
 
     private void viewLogsClicked(object? sender, EventArgs e)
     {
-        System.Diagnostics.Process.Start(logPath);
+        Process.Start(logPath);
+    }
+
+    private void openBootScriptClicked(object? sender, EventArgs e)
+    {
+        var path =
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".livebookdesktop.bat"
+            );
+
+        if (!File.Exists(path))
+        {
+            File.WriteAllText(path, @"@echo off
+rem This file is used to configure Livebook before booting.
+rem
+rem See https://hexdocs.pm/livebook/readme.html#environment-variables for all available enviornment variables.
+
+rem Run Livebook on port 9999
+rem set LIVEBOOK_PORT=9999
+
+rem Add directory to PATH
+rem set PATH=C:\bin;%PATH%
+");
+        }
+
+        Process.Start("notepad.exe", path);
     }
 
     private void openSettingsClicked(object? sender, EventArgs e)

--- a/rel/app/windows/Livebook.cs
+++ b/rel/app/windows/Livebook.cs
@@ -156,11 +156,12 @@ class LivebookApp : ApplicationContext
         {
             File.WriteAllText(path, @"@echo off
 rem This file is used to configure Livebook before booting.
-rem
+rem If you change this file, you must restart Livebook for your changes to take place.
 rem See https://hexdocs.pm/livebook/readme.html#environment-variables for all available enviornment variables.
 
-rem Run Livebook on port 9999
-rem set LIVEBOOK_PORT=9999
+rem Allow Livebook to connect to remote machines over IPv6
+rem set LIVEBOOK_DISTRIBUTION=name
+rem set ERL_AFLAGS="-proto_dist inet6_tcp"
 
 rem Add directory to PATH
 rem set PATH=C:\bin;%PATH%

--- a/rel/app/windows/build.sh
+++ b/rel/app/windows/build.sh
@@ -4,5 +4,9 @@ set -euo pipefail
 . `dirname $0`/env.sh
 
 rm -rf $target_dir
-dotnet build $build_args
-(cd ../../.. && mix release app --overwrite --path=${target_dir}/rel)
+dotnet build Livebook.csproj $build_args
+
+(
+    cd ../../..
+    mix release app --overwrite --path=${target_dir}/rel
+)

--- a/rel/app/windows/build_installer.sh
+++ b/rel/app/windows/build_installer.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 . `dirname $0`/env.sh
 
 rm -rf $target_dir
-dotnet publish $build_args
-(cd ../../.. && mix release app --overwrite --path=${target_dir}/rel)
+dotnet publish Livebook.csproj $build_args
+
+(
+    cd ../../..
+    mix release app --overwrite --path=${target_dir}/rel
+)
 
 vc_redist_path="bin/vc_redist.x64.exe"
 if [ ! -f $vc_redist_path ]; then


### PR DESCRIPTION
This is especially useful for the ZTA feature because we need to set `LIVEBOOK_IDENTITY_PROVIDER` somewhere.

I've updated nightlies with this branch:

- [macOS](https://livebook.dev/releases/nightly/LivebookInstall-nightly-macos-universal.dmg)
- [Windows](https://livebook.dev/releases/nightly/LivebookInstall-nightly-windows-x86_64.exe)

Demo on macOS:

![Untitled-5](https://github.com/livebook-dev/livebook/assets/76071/d9085d8f-cb53-409f-a1da-39968dfac969)

Demo on Windows:

![Untitled-4](https://github.com/livebook-dev/livebook/assets/76071/d483815b-2da8-49f8-8452-8893bf4be444)
