### PR TITLE
Add :debounce to input outputs when missing

### DIFF
--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -298,28 +298,33 @@ defprotocol Livebook.Runtime do
           %{
             type: :text,
             default: String.t(),
-            label: String.t()
+            label: String.t(),
+            debounce: :blur | non_neg_integer()
           }
           | %{
               type: :textarea,
               default: String.t(),
               label: String.t(),
+              debounce: :blur | non_neg_integer(),
               monospace: boolean()
             }
           | %{
               type: :password,
               default: String.t(),
-              label: String.t()
+              label: String.t(),
+              debounce: :blur | non_neg_integer()
             }
           | %{
               type: :number,
               default: number() | nil,
-              label: String.t()
+              label: String.t(),
+              debounce: :blur | non_neg_integer()
             }
           | %{
               type: :url,
               default: String.t() | nil,
-              label: String.t()
+              label: String.t(),
+              debounce: :blur | non_neg_integer()
             }
           | %{
               type: :select,
@@ -336,6 +341,7 @@ defprotocol Livebook.Runtime do
               type: :range,
               default: number(),
               label: String.t(),
+              debounce: :blur | non_neg_integer(),
               min: number(),
               max: number(),
               step: number()
@@ -364,7 +370,8 @@ defprotocol Livebook.Runtime do
           | %{
               type: :color,
               default: String.t(),
-              label: String.t()
+              label: String.t(),
+              debounce: :blur | non_neg_integer()
             }
           | %{
               type: :image,

--- a/lib/livebook_web/live/output/input_component.ex
+++ b/lib/livebook_web/live/output/input_component.ex
@@ -169,7 +169,7 @@ defmodule LivebookWeb.Output.InputComponent do
         class="input-range"
         name="html_value"
         value={@value}
-        phx-debounce={@attrs[:debounce] || "blur"}
+        phx-debounce={@attrs.debounce}
         phx-target={@myself}
         spellcheck="false"
         autocomplete="off"
@@ -190,7 +190,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class={["input min-h-[38px] max-h-[300px] tiny-scrollbar", @attrs.monospace && "font-mono"]}
       name="html_value"
       phx-hook="TextareaAutosize"
-      phx-debounce={@attrs[:debounce] || "blur"}
+      phx-debounce={@attrs.debounce}
       phx-target={@myself}
       spellcheck="false"
     ><%= [?\n, @value] %></textarea>
@@ -206,7 +206,7 @@ defmodule LivebookWeb.Output.InputComponent do
         class="input w-auto bg-gray-50"
         name="html_value"
         value={@value}
-        phx-debounce={@attrs[:debounce] || "blur"}
+        phx-debounce={@attrs.debounce}
         phx-target={@myself}
         spellcheck="false"
         autocomplete="off"
@@ -241,7 +241,7 @@ defmodule LivebookWeb.Output.InputComponent do
       class="input w-auto invalid:input--error"
       name="html_value"
       value={to_string(@value)}
-      phx-debounce={@attrs[:debounce] || "blur"}
+      phx-debounce={@attrs.debounce}
       phx-target={@myself}
       spellcheck="false"
       autocomplete="off"

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -18,7 +18,7 @@ defmodule Livebook.Session.DataTest do
     ref: "ref1",
     id: "i1",
     destination: nil,
-    attrs: %{type: :text, default: "hey", label: "Text"}
+    attrs: %{type: :text, default: "hey", label: "Text", debounce: :blur}
   }
 
   defp eval_meta(opts \\ []) do
@@ -4510,7 +4510,7 @@ defmodule Livebook.Session.DataTest do
         ref: "ref1",
         id: "i1",
         destination: nil,
-        attrs: %{type: :text, default: "hey", label: "Text"}
+        attrs: %{type: :text, default: "hey", label: "Text", debounce: :blur}
       }
 
       input2 = %{
@@ -4518,7 +4518,7 @@ defmodule Livebook.Session.DataTest do
         ref: "ref2",
         id: "i2",
         destination: nil,
-        attrs: %{type: :text, default: "hey", label: "Text"}
+        attrs: %{type: :text, default: "hey", label: "Text", debounce: :blur}
       }
 
       data =

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -219,7 +219,7 @@ defmodule Livebook.SessionTest do
         ref: "ref",
         id: "input1",
         destination: :noop,
-        attrs: %{type: :text, default: "hey", label: "Name"}
+        attrs: %{type: :text, default: "hey", label: "Name", debounce: :blur}
       }
 
       smart_cell = %{
@@ -1899,7 +1899,7 @@ defmodule Livebook.SessionTest do
         ref: "ref",
         id: "input1",
         destination: :noop,
-        attrs: %{type: :text, default: "hey", label: "Name"}
+        attrs: %{type: :text, default: "hey", label: "Name", debounce: :blur}
       }
 
     send(session.pid, {:runtime_evaluation_output, cell_id, legacy_output})

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -518,7 +518,13 @@ defmodule LivebookWeb.SessionLiveTest do
         ref: "ref1",
         id: "input1",
         destination: test,
-        attrs: %{type: :textarea, default: "hey", label: "Name", monospace: false}
+        attrs: %{
+          type: :textarea,
+          default: "hey",
+          label: "Name",
+          debounce: :blur,
+          monospace: false
+        }
       }
 
       Session.subscribe(session.id)
@@ -552,7 +558,7 @@ defmodule LivebookWeb.SessionLiveTest do
               ref: "input_ref1",
               id: "input1",
               destination: test,
-              attrs: %{type: :text, default: "initial", label: "Name"}
+              attrs: %{type: :text, default: "initial", label: "Name", debounce: :blur}
             }
           ],
           submit: "Send",
@@ -781,7 +787,7 @@ defmodule LivebookWeb.SessionLiveTest do
         ref: "ref1",
         id: "input1",
         destination: test,
-        attrs: %{type: :number, default: 1, label: "Input inside frame"}
+        attrs: %{type: :number, default: 1, label: "Input inside frame", debounce: :blur}
       }
 
       frame_update = %{


### PR DESCRIPTION
Follow up to #2224. Instead of remembering, which attributes may be missing, we want to rewrite outputs to match the latest format as soon as we receive them :)