### PR TITLE
Run migrations early in the supervision tree

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -18,6 +18,8 @@ defmodule Livebook.Application do
         {Task.Supervisor, name: Livebook.TaskSupervisor},
         # Start the storage module
         Livebook.Storage,
+        # Run migrations as soon as the storage is running
+        Livebook.Migration,
         # Start the periodic version check
         Livebook.UpdateCheck,
         # Periodic measurement of system resources
@@ -57,7 +59,6 @@ defmodule Livebook.Application do
 
     case Supervisor.start_link(children, opts) do
       {:ok, _} = result ->
-        Livebook.Migration.migrate()
         load_lb_env_vars()
         create_offline_hub()
         clear_env_vars()

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -86,10 +86,7 @@ defmodule Livebook.FileSystem.S3 do
 
   def id(_, nil), do: nil
   def id(nil, bucket_url), do: hashed_id(bucket_url)
-
-  # For Personal hub we keep unprefixed ids
   def id(@personal_id, bucket_url), do: hashed_id(bucket_url)
-
   def id(hub_id, bucket_url), do: "#{hub_id}-#{hashed_id(bucket_url)}"
 
   defp hashed_id(bucket_url) do

--- a/lib/livebook/migration.ex
+++ b/lib/livebook/migration.ex
@@ -1,11 +1,13 @@
 defmodule Livebook.Migration do
   use GenServer, restart: :temporary
 
-  # We version our storage so we can remove migrations in the future.
-  # We also documented tables and IDs used in previous versions,
+  # We version our storage so we can remove migrations in the future
+  # by deleting the whole storage when finding too old versions.
+  #
+  # We also document tables and IDs used in previous versions,
   # as those must be avoided in the future.
   #
-  # ## v1 (Livebook v0.11)
+  # ## v1 (Livebook v0.11, Oct 2023)
   #
   # * Deleted hubs.local-host
   # * Migrated secrets to hub_secrets
@@ -20,9 +22,9 @@ defmodule Livebook.Migration do
 
   def init(:ok) do
     insert_personal_hub()
-    add_personal_hub_secret_key()
 
     # v1
+    add_personal_hub_secret_key()
     delete_local_host_hub()
     move_app_secrets_to_personal_hub()
 


### PR DESCRIPTION
Also add a migration version, improve docs,
and document code that actually cannot be
removed.