### PR TITLE
Add New Notebook menu item

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -390,6 +390,8 @@ const Session = {
         this.reconnectRuntime();
       } else if (keyBuffer.tryMatch(["Escape", "Escape"])) {
         this.setFocusedEl(null);
+      } else if (keyBuffer.tryMatch(["g", "n"])) {
+        this.newNotebook();
       } else if (keyBuffer.tryMatch(["?"])) {
         this.showShortcuts();
       } else if (
@@ -872,6 +874,10 @@ const Session = {
 
     const actionEl = this.el.querySelector(`[data-btn-package-search]`);
     actionEl && actionEl.click();
+  },
+
+  newNotebook() {
+    this.pushEvent("new", {});
   },
 
   saveNotebook() {

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -305,6 +305,12 @@ defmodule LivebookWeb.SessionLive do
                   </button>
                 </:toggle>
                 <.menu_item>
+                  <.link patch={~p"/new"} role="menuitem">
+                    <.remix_icon icon="add-line" />
+                    <span>New Notebook</span>
+                  </.link>
+                </.menu_item>
+                <.menu_item>
                   <.link patch={~p"/sessions/#{@session.id}/export/livemd"} role="menuitem">
                     <.remix_icon icon="download-2-line" />
                     <span>Export</span>

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -305,12 +305,6 @@ defmodule LivebookWeb.SessionLive do
                   </button>
                 </:toggle>
                 <.menu_item>
-                  <.link patch={~p"/new"} role="menuitem">
-                    <.remix_icon icon="add-line" />
-                    <span>New Notebook</span>
-                  </.link>
-                </.menu_item>
-                <.menu_item>
                   <.link patch={~p"/sessions/#{@session.id}/export/livemd"} role="menuitem">
                     <.remix_icon icon="download-2-line" />
                     <span>Export</span>
@@ -1404,6 +1398,10 @@ defmodule LivebookWeb.SessionLive do
     })
 
     {:noreply, socket}
+  end
+
+  def handle_event("new", %{}, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/new")}
   end
 
   def handle_event("save", %{}, socket) do


### PR DESCRIPTION
Recently, I had a need to create notebooks in rapid succession. I thought having the action on the same screen would save some navigation time. I know `Fork` is a similar option but I didn't need the previous notebook's cells to clear out.

I didn't add a keyboard shortcut as I wouldn't be the greatest at picking one. Opening a new window could be useful since I could see this as a slightly different action than the home screen.