### PR TITLE
Don't reconnect when WebSocket returns server error

### DIFF
--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -129,7 +129,7 @@ defmodule Livebook.Hubs do
 
   defp disconnect_hub(hub) do
     Task.Supervisor.start_child(Livebook.TaskSupervisor, fn ->
-      Process.sleep(30_000)
+      Process.sleep(10_000)
       :ok = Provider.disconnect(hub)
     end)
 

--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -136,7 +136,7 @@ defmodule Livebook.Hubs do
       # make them crash, so we give it some time to shut down.
       #
       # The default backoff is 5.5s, so we round it down to 5s.
-      Process.sleep(5_000)
+      Process.sleep(30_000)
       :ok = Provider.disconnect(hub)
     end)
 

--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -129,7 +129,7 @@ defmodule Livebook.Hubs do
 
   defp disconnect_hub(hub) do
     Task.Supervisor.start_child(Livebook.TaskSupervisor, fn ->
-      Process.sleep(10_000)
+      Process.sleep(5_500)
       :ok = Provider.disconnect(hub)
     end)
 

--- a/lib/livebook/teams/connection.ex
+++ b/lib/livebook/teams/connection.ex
@@ -52,15 +52,11 @@ defmodule Livebook.Teams.Connection do
         reason = LivebookProto.Error.decode(error).details
         send(data.listener, {:server_error, reason})
 
-        {:keep_state_and_data, {{:timeout, :reconnect}, @backoff, nil}}
+        {:keep_state, data}
     end
   end
 
   def handle_event({:timeout, :backoff}, nil, _state, _data) do
-    {:keep_state_and_data, {:next_event, :internal, :connect}}
-  end
-
-  def handle_event({:timeout, :reconnect}, nil, _state, _data) do
     {:keep_state_and_data, {:next_event, :internal, :connect}}
   end
 


### PR DESCRIPTION
In #1675 we added this sleeping time, but since then we didn't notice that until last week.

If the org credentials are invalid, the `Liveboook.Teams.Connection` gen state will send a server error message to `Livebook.Hubs.TeamClient`, which should send the message only time using the `Livebook.Hubs.Broadcasts` module.

Before this change, it was spamming like 5 times the message and it would keep showing in the frontend. But now it only shows one time and closes the gen server before it sends again.