### PR TITLE
Add script for building CUDA images manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,50 +103,6 @@ jobs:
           build-args: |
             BASE_IMAGE=hexpm/elixir:${{ env.elixir }}-erlang-${{ env.otp }}-debian-${{ env.debian }}
 
-  docker_extras:
-    if: github.ref_type == 'tag'
-    # The assets job may push new commit, so we wait for it
-    needs: [assets]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cuda: ["11.8", "12.1"]
-    steps:
-      - uses: actions/checkout@v3
-      - run: |
-          . versions
-          echo "elixir=$elixir" >> $GITHUB_ENV
-          echo "otp=$otp" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ghcr.io/livebook-dev/livebook
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}}-cuda${{ matrix.cuda }}
-            type=raw,value=latest-cuda${{ matrix.cuda }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            BASE_IMAGE=ghcr.io/livebook-dev/utils:elixir-${{ env.elixir }}-erlang-${{ env.otp }}-cuda${{ matrix.cuda }}
-
   create_draft_release:
     if: github.ref_type == 'tag'
     permissions:

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,26 +1,57 @@
 #!/bin/bash
 
-# Builds base images used to build extra flavours of Livebook images
+# Builds extra Livebook images.
+#
+# Images are pushed to GHCR, so you need to make sure that the docker
+# client is authenticated.
 
 set -ex
 cd "$(dirname "$0")/.."
 
 . versions
 
-docker buildx build --push --platform linux/amd64,linux/arm64 \
-  -t ghcr.io/livebook-dev/utils:elixir-$elixir-erlang-$otp-cuda11.8 \
-  --build-arg ELIXIR_VERSION=$elixir \
-  --build-arg ERLANG_VERSION=$otp \
-  --build-arg UBUNTU_VERSION=$ubuntu \
-  --build-arg CUDA_VERSION=11.8.0 \
-  -f docker/base/elixir-cuda.dockerfile \
-  docker/base
+livebook_version="$(cat mix.exs | grep '@version "' | grep -v '\-dev' | grep -oE '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}' || true)"
 
-docker buildx build --push --platform linux/amd64,linux/arm64 \
-  -t ghcr.io/livebook-dev/utils:elixir-$elixir-erlang-$otp-cuda12.1 \
-  --build-arg ELIXIR_VERSION=$elixir \
-  --build-arg ERLANG_VERSION=$otp \
-  --build-arg UBUNTU_VERSION=$ubuntu \
-  --build-arg CUDA_VERSION=12.1.0 \
-  -f docker/base/elixir-cuda.dockerfile \
-  docker/base
+if [ -z "$livebook_version" ]; then
+  echo "No stable Livebook version detected"
+  exit 1
+fi
+
+cuda_tag_list=("cuda11.8" "cuda12.1")
+cuda_version_list=("11.8.0" "12.1.0")
+
+for idx in "${!cuda_tag_list[@]}"; do
+  cuda_tag="${cuda_tag_list[idx]}"
+  cuda_version="${cuda_version_list[idx]}"
+
+  base_image="ghcr.io/livebook-dev/utils:elixir-$elixir-erlang-$otp-$cuda_tag"
+
+  if docker manifest inspect $base_image > /dev/null; then
+    echo "Using base image: $base_image"
+  else
+    echo "Building base image: $base_image"
+
+    docker buildx build --push --platform linux/amd64,linux/arm64 \
+      -t $base_image \
+      --build-arg ELIXIR_VERSION=$elixir \
+      --build-arg ERLANG_VERSION=$otp \
+      --build-arg UBUNTU_VERSION=$ubuntu \
+      --build-arg CUDA_VERSION=$cuda_version \
+      -f docker/base/elixir-cuda.dockerfile \
+      docker/base
+  fi
+
+  image="ghcr.io/livebook-dev/livebook:$livebook_version-$cuda_tag"
+
+  if docker manifest inspect $image > /dev/null; then
+    echo "Skipping image, since it already exists: $image"
+  else
+    echo "Building image: $image"
+
+    docker buildx build --push --platform linux/amd64,linux/arm64 \
+      --build-arg BASE_IMAGE="$base_image" \
+      -t $image \
+      -t ghcr.io/livebook-dev/livebook:latest-$cuda_tag \
+      .
+  fi
+done


### PR DESCRIPTION
Building on CI runs out of disk space, so I updated the script to build all relevant images and this way we can run it anywhere. I used it to build the latest CUDA 12 image on an AWS instance.