### PR TITLE
Fix file system type migration

### DIFF
--- a/lib/livebook/migration.ex
+++ b/lib/livebook/migration.ex
@@ -166,7 +166,7 @@ defmodule Livebook.Migration do
       Map.get_lazy(file, :file_system_type, fn ->
         case file.file_system_id do
           "local" -> "local"
-          "s3-" <> _ -> "s3"
+          _ -> "s3"
         end
       end)
 


### PR DESCRIPTION
Closes #2267.

I tested it from past main and new main, but in v0.10 the S3 ids were random, not prefixed.