### PR TITLE
Bump Elixir and Erlang versions

### DIFF
--- a/versions
+++ b/versions
@@ -1,5 +1,5 @@
-elixir="1.15.6"
-otp="26.1.1"
+elixir="1.15.7"
+otp="26.1.2"
 openssl="1.1.1s"
 rebar3="3.22.0"
 debian="bullseye-20230612-slim"


### PR DESCRIPTION
See https://github.com/livebook-dev/kino/issues/355#issuecomment-1757032341. This will improve the Remote execution cell to require the same OTP version, but not Elixir (provided v1.15.7+).