### PR TITLE
Fix links in the public apps list

### DIFF
--- a/lib/livebook_web/live/auth_app_list_live.ex
+++ b/lib/livebook_web/live/auth_app_list_live.ex
@@ -18,7 +18,7 @@ defmodule LivebookWeb.AuthAppListLive do
     <div class="w-full flex flex-col space-y-4">
       <.link
         :for={app <- visible_apps(@apps)}
-        navigate={~p"/apps/#{app.slug}"}
+        href={~p"/apps/#{app.slug}"}
         class="px-4 py-3 border border-gray-200 rounded-xl text-gray-800 pointer hover:bg-gray-50 flex justify-between"
       >
         <span class="font-semibold"><%= app.notebook_name %></span>


### PR DESCRIPTION
The apps list is a LV, but we render it inside a dead view, in which case we need to use regular links, rather than live navigation.

This may be handled transparently in the future, see https://github.com/phoenixframework/phoenix_live_view/issues/2832.