### PR TITLE
Do not redeploy apps from dir on every node

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -333,7 +333,8 @@ defmodule Livebook.Application do
 
       Livebook.Apps.deploy_apps_in_dir(apps_path,
         password: Livebook.Config.apps_path_password(),
-        warmup: warmup
+        warmup: warmup,
+        start_only: true
       )
     end
   end


### PR DESCRIPTION
In distributed deployment, if the cluster is formed quickly enough, then multiple nodes may try to deploy to the same app. This is unnecessary work and also causes issues when the notebook has attachments files, since we don't access them across nodes.