### PR TITLE
Don't create online team hubs in off-hub tests

### DIFF
--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -104,13 +104,9 @@ defmodule Livebook.Hubs do
     :ok
   end
 
-  @spec unset_default_hub(String.t()) :: :ok
-  def unset_default_hub(id) do
-    with {:ok, _hub} <- fetch_hub(id) do
-      :ok = Storage.delete(:default_hub, "default_hub")
-    end
-
-    :ok
+  @spec unset_default_hub() :: :ok
+  def unset_default_hub() do
+    :ok = Storage.delete(:default_hub, "default_hub")
   end
 
   @spec get_default_hub() :: Provider.t()
@@ -124,7 +120,7 @@ defmodule Livebook.Hubs do
   end
 
   defp maybe_unset_default_hub(hub_id) do
-    if get_default_hub().id == hub_id, do: unset_default_hub(hub_id), else: :ok
+    if get_default_hub().id == hub_id, do: unset_default_hub(), else: :ok
   end
 
   defp disconnect_hub(hub) do

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -433,7 +433,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
   end
 
   def handle_event("remove_as_default", _, socket) do
-    Hubs.unset_default_hub(socket.assigns.hub.id)
+    Hubs.unset_default_hub()
     {:noreply, push_navigate(socket, to: ~p"/hub/#{socket.assigns.hub.id}")}
   end
 

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -749,7 +749,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
   end
 
   test "imports notebook hub id when exists" do
-    %{id: hub_id} = Livebook.Factory.insert_hub(:team)
+    %{id: hub_id} = Livebook.HubHelpers.offline_hub()
 
     markdown = """
     <!-- livebook:{"hub_id":"#{hub_id}"} -->
@@ -1216,7 +1216,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
     end
 
     test "sets :teams_enabled to true when the teams hub exist regardless the stamp" do
-      %{id: hub_id} = Livebook.Factory.insert_hub(:team)
+      %{id: hub_id} = Livebook.HubHelpers.offline_hub()
 
       markdown = """
       <!-- livebook:{"hub_id":"#{hub_id}"} -->

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -1918,26 +1918,30 @@ defmodule Livebook.SessionTest do
         notebook = Livebook.Session.default_notebook()
 
         assert notebook.hub_id == hub.id
-        Livebook.Hubs.delete_hub(hub.id)
+
+        Livebook.Hubs.unset_default_hub()
       end
 
       test "fallback to personal-hub when there's no default" do
         hub = Livebook.HubHelpers.offline_hub()
-        Livebook.Hubs.unset_default_hub(hub.id)
+        Livebook.Hubs.set_default_hub(hub.id)
+        Livebook.Hubs.unset_default_hub()
         notebook = Livebook.Session.default_notebook()
 
         assert notebook.hub_id == "personal-hub"
-        Livebook.Hubs.delete_hub(hub.id)
       end
 
       test "fallback to personal-hub when the default doesn't exist" do
-        hub = Livebook.HubHelpers.offline_hub()
+        hub = Livebook.Factory.build(:team)
+        Livebook.Hubs.save_hub(hub)
         Livebook.Hubs.set_default_hub(hub.id)
         Livebook.Hubs.delete_hub(hub.id)
         notebook = Livebook.Session.default_notebook()
 
         refute Livebook.Hubs.hub_exists?(hub.id)
         assert notebook.hub_id == "personal-hub"
+
+        Livebook.Hubs.unset_default_hub()
       end
     end
   end

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -1913,7 +1913,7 @@ defmodule Livebook.SessionTest do
 
     describe "default hub for new notebooks" do
       test "use the default hub as default for new notebooks" do
-        hub = Livebook.Factory.insert_hub(:team)
+        hub = Livebook.HubHelpers.offline_hub()
         Livebook.Hubs.set_default_hub(hub.id)
         notebook = Livebook.Session.default_notebook()
 
@@ -1922,7 +1922,7 @@ defmodule Livebook.SessionTest do
       end
 
       test "fallback to personal-hub when there's no default" do
-        hub = Livebook.Factory.insert_hub(:team)
+        hub = Livebook.HubHelpers.offline_hub()
         Livebook.Hubs.unset_default_hub(hub.id)
         notebook = Livebook.Session.default_notebook()
 
@@ -1931,7 +1931,7 @@ defmodule Livebook.SessionTest do
       end
 
       test "fallback to personal-hub when the default doesn't exist" do
-        hub = Livebook.Factory.insert_hub(:team)
+        hub = Livebook.HubHelpers.offline_hub()
         Livebook.Hubs.set_default_hub(hub.id)
         Livebook.Hubs.delete_hub(hub.id)
         notebook = Livebook.Session.default_notebook()

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -205,20 +205,13 @@ defmodule LivebookWeb.HomeLiveTest do
   end
 
   describe "hubs" do
-    test "renders sidebar section", %{conn: conn} do
-      {:ok, view, _} = live(conn, ~p"/")
-      assert render(view) =~ "HUBS"
-      assert render(view) =~ "Add Organization"
-    end
-
-    test "renders sidebar persisted hubs", %{conn: conn} do
-      team = insert_hub(:team, id: "team-foo-bar-id")
+    test "renders persisted hubs in the sidebar", %{conn: conn} do
+      team = Livebook.HubHelpers.offline_hub()
 
       {:ok, view, _} = live(conn, ~p"/")
       assert render(view) =~ "HUBS"
       assert render(view) =~ team.hub_name
-
-      Livebook.Hubs.delete_hub("team-foo-bar-id")
+      assert render(view) =~ "Add Organization"
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -89,12 +89,6 @@ defmodule Livebook.Factory do
     factory_name |> build() |> struct!(attrs) |> Map.from_struct()
   end
 
-  def insert_hub(factory_name, attrs \\ %{}) do
-    factory_name
-    |> build(attrs)
-    |> Livebook.Hubs.save_hub()
-  end
-
   def insert_secret(attrs \\ %{}) do
     secret = build(:secret, attrs)
     hub = Livebook.Hubs.fetch_hub!(secret.hub_id)


### PR DESCRIPTION
Some tests have `Livebook.Factory.insert_hub(:team)`, which create online team hubs, but only in Livebook. As soon as we create the hub it tries to connect and since that fails it automatically removes itself, which causes some intermittent test failures. Since we use it only in a couple places, I replaced those to use offline hub, if actual hub is needed it should most likely be a part of the integration suit.