### PR TITLE
Clear cell outputs when moving to bin

### DIFF
--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -1109,7 +1109,7 @@ defmodule Livebook.Session.Data do
       notebook: Notebook.delete_cell(data.notebook, cell.id),
       bin_entries: [
         %{
-          cell: cell,
+          cell: Map.replace(cell, :outputs, []),
           section_id: section.id,
           section_name: section.name,
           index: Enum.find_index(section.cells, &(&1 == cell)),

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -780,6 +780,21 @@ defmodule Livebook.Session.DataTest do
       refute Map.has_key?(cell_infos, "c1")
     end
 
+    test "does not include cell outputs in deleted cells" do
+      data =
+        data_after_operations!([
+          {:insert_section, @cid, 0, "s1"},
+          {:insert_cell, @cid, "s1", 0, :code, "c1", %{}},
+          {:set_runtime, @cid, connected_noop_runtime()},
+          evaluate_cells_operations(["setup", "c1"])
+        ])
+
+      operation = {:delete_cell, @cid, "c1"}
+
+      assert {:ok, %{bin_entries: [%{cell: %{id: "c1", outputs: []}}]}, _actions} =
+               Data.apply_operation(data, operation)
+    end
+
     test "unqueues the cell if it's queued for evaluation" do
       data =
         data_after_operations!([


### PR DESCRIPTION
Currently there's a crash when restoring cell with input, but thinking about it, we should just clear the outputs altogether, since we clear all the cell evaluation state.