### PR TITLE
Don't copy outputs when converting smart cell to code

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1142,14 +1142,12 @@ defmodule Livebook.Session do
              Notebook.fetch_cell_and_section(state.data.notebook, cell_id) do
         index = Enum.find_index(section.cells, &(&1 == cell))
         chunks = cell.chunks || [{0, byte_size(cell.source)}]
-        chunk_count = length(chunks)
 
         state =
           for {{offset, size}, chunk_idx} <- Enum.with_index(chunks), reduce: state do
             state ->
-              outputs = if(chunk_idx == chunk_count - 1, do: cell.outputs, else: [])
               source = binary_part(cell.source, offset, size)
-              attrs = %{source: source, outputs: outputs}
+              attrs = %{source: source}
               cell_idx = index + chunk_idx
               cell_id = Utils.random_id()
 

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -178,8 +178,7 @@ defmodule Livebook.SessionTest do
       assert_receive {:operation, {:delete_cell, _client_id, ^cell_id}}
 
       assert_receive {:operation,
-                      {:insert_cell, _client_id, ^section_id, 0, :code, _id,
-                       %{source: "content", outputs: []}}}
+                      {:insert_cell, _client_id, ^section_id, 0, :code, _id, %{source: "content"}}}
     end
 
     test "inserts multiple cells when the smart cell has explicit chunks" do
@@ -206,40 +205,10 @@ defmodule Livebook.SessionTest do
       assert_receive {:operation, {:delete_cell, _client_id, ^cell_id}}
 
       assert_receive {:operation,
-                      {:insert_cell, _client_id, ^section_id, 0, :code, _id,
-                       %{source: "chunk 1", outputs: []}}}
+                      {:insert_cell, _client_id, ^section_id, 0, :code, _id, %{source: "chunk 1"}}}
 
       assert_receive {:operation,
-                      {:insert_cell, _client_id, ^section_id, 1, :code, _id,
-                       %{source: "chunk 2", outputs: [{1, terminal_text("Hello")}]}}}
-    end
-
-    test "doesn't garbage collect input values" do
-      input = %{
-        type: :input,
-        ref: "ref",
-        id: "input1",
-        destination: :noop,
-        attrs: %{type: :text, default: "hey", label: "Name", debounce: :blur}
-      }
-
-      smart_cell = %{
-        Notebook.Cell.new(:smart)
-        | kind: "text",
-          source: "content",
-          outputs: [{1, input}]
-      }
-
-      section = %{Notebook.Section.new() | cells: [smart_cell]}
-      notebook = %{Notebook.new() | sections: [section]}
-
-      session = start_session(notebook: notebook)
-
-      Session.subscribe(session.id)
-
-      Session.convert_smart_cell(session.pid, smart_cell.id)
-
-      assert %{input_infos: %{"input1" => %{value: "hey"}}} = Session.get_data(session.pid)
+                      {:insert_cell, _client_id, ^section_id, 1, :code, _id, %{source: "chunk 2"}}}
     end
   end
 


### PR DESCRIPTION
Currently we copy outputs, but since the original cell is deleted, any processes tied to its evaluation are garbage collected. This means that for Neural network cell, the form is no longer interactive, because the `Kino.listen/2` listener no longer exists. The newly inserted cell(s) is not evaluated anyway, so clearing outputs is more consistent.