### PR TITLE
Use pre-wrap for doctest results

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -208,7 +208,7 @@ Also some spacing adjustments.
 
 .doctest-details-widget {
   @apply font-editor;
-  white-space: pre;
+  white-space: pre-wrap;
   background-color: rgba(0, 0, 0, 0.05);
   padding-top: 6px;
   padding-bottom: 6px;


### PR DESCRIPTION
Before:

<img width="1125" alt="Screenshot 2023-11-15 at 16 58 11" src="https://github.com/livebook-dev/livebook/assets/9582/5f0993c2-0df2-455b-82ee-a13f36b3af7c">

After:

<img width="1123" alt="Screenshot 2023-11-15 at 17 15 03" src="https://github.com/livebook-dev/livebook/assets/9582/8bea41f1-da92-4d30-ac0f-2bc8ba0e37d0">
