### PR TITLE
Use shorter ids for cells and sections

### DIFF
--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -119,7 +119,7 @@ defmodule Livebook do
         config :livebook, authentication_mode: :password, password: password
 
       Livebook.Config.boolean!("LIVEBOOK_TOKEN_ENABLED", true) ->
-        config :livebook, token: Livebook.Utils.random_id()
+        config :livebook, token: Livebook.Utils.random_long_id()
 
       true ->
         config :livebook, authentication_mode: :disabled

--- a/lib/livebook/file_system/local.ex
+++ b/lib/livebook/file_system/local.ex
@@ -207,7 +207,7 @@ defimpl Livebook.FileSystem, for: Livebook.FileSystem.Local do
     FileSystem.Utils.assert_regular_path!(path)
 
     downloads_dir = Path.join(Livebook.Config.tmp_path(), "downloads")
-    download_path = Path.join(downloads_dir, Livebook.Utils.random_id())
+    download_path = Path.join(downloads_dir, Livebook.Utils.random_long_id())
 
     with :ok <- File.mkdir_p(downloads_dir),
          {:ok, device} <- File.open(download_path, [:write]) do

--- a/lib/livebook/runtime/erl_dist/node_manager.ex
+++ b/lib/livebook/runtime/erl_dist/node_manager.ex
@@ -223,7 +223,7 @@ defmodule Livebook.Runtime.ErlDist.NodeManager do
   end
 
   defp make_tmp_dir() do
-    path = Path.join([System.tmp_dir!(), "livebook_runtime", random_id()])
+    path = Path.join([System.tmp_dir!(), "livebook_runtime", random_long_id()])
 
     if File.mkdir_p(path) == :ok do
       path
@@ -234,9 +234,9 @@ defmodule Livebook.Runtime.ErlDist.NodeManager do
   defp ebin_path(tmp_dir), do: Path.join(tmp_dir, "ebin")
 
   defp child_tmp_dir(nil), do: nil
-  defp child_tmp_dir(tmp_dir), do: Path.join(tmp_dir, random_id())
+  defp child_tmp_dir(tmp_dir), do: Path.join(tmp_dir, random_long_id())
 
-  defp random_id() do
+  defp random_long_id() do
     :crypto.strong_rand_bytes(20) |> Base.encode32(case: :lower)
   end
 end

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -339,7 +339,7 @@ defmodule Livebook.Runtime.Evaluator do
   defp initial_context() do
     env = Code.env_for_eval([])
     env = Macro.Env.prepend_tracer(env, Evaluator.Tracer)
-    %{id: random_id(), binding: [], env: env, pdict: %{}}
+    %{id: random_long_id(), binding: [], env: env, pdict: %{}}
   end
 
   defp handle_cast({:evaluate_code, language, code, ref, parent_refs, opts}, state) do
@@ -432,7 +432,7 @@ defmodule Livebook.Runtime.Evaluator do
     {new_context, result, identifiers_used, identifiers_defined} =
       case eval_result do
         {:ok, value, binding, env} ->
-          context_id = random_id()
+          context_id = random_long_id()
 
           new_context = %{
             id: context_id,
@@ -585,7 +585,7 @@ defmodule Livebook.Runtime.Evaluator do
     binding = merge_binding(prev_context.binding, context.binding)
     env = merge_env(prev_context.env, context.env)
     pdict = context.pdict
-    %{id: random_id(), binding: binding, env: env, pdict: pdict}
+    %{id: random_long_id(), binding: binding, env: env, pdict: pdict}
   end
 
   defp merge_binding(prev_binding, binding) do
@@ -977,7 +977,7 @@ defmodule Livebook.Runtime.Evaluator do
     end
   end
 
-  defp random_id() do
+  defp random_long_id() do
     :crypto.strong_rand_bytes(20) |> Base.encode32(case: :lower)
   end
 

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -32,7 +32,7 @@ defmodule Livebook.Users.User do
   Generates a new user.
   """
   @spec new(String.t()) :: t()
-  def new(id \\ Utils.random_id()) do
+  def new(id \\ Utils.random_long_id()) do
     %__MODULE__{
       id: id,
       name: nil,

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -8,6 +8,14 @@ defmodule Livebook.Utils do
   """
   @spec random_id() :: id()
   def random_id() do
+    :crypto.strong_rand_bytes(10) |> Base.encode32(case: :lower)
+  end
+
+  @doc """
+  Generates a random long binary id.
+  """
+  @spec random_long_id() :: id()
+  def random_long_id() do
     :crypto.strong_rand_bytes(20) |> Base.encode32(case: :lower)
   end
 

--- a/lib/livebook_web/live/output/markdown_component.ex
+++ b/lib/livebook_web/live/output/markdown_component.ex
@@ -16,7 +16,7 @@ defmodule LivebookWeb.Output.MarkdownComponent do
     socket = assign(socket, assigns)
 
     if text do
-      chunk = %{id: Livebook.Utils.random_id(), text: text}
+      chunk = %{id: Livebook.Utils.random_long_id(), text: text}
       {:ok, stream_insert(socket, :chunks, chunk)}
     else
       {:ok, socket}

--- a/lib/livebook_web/live/output/plain_text_component.ex
+++ b/lib/livebook_web/live/output/plain_text_component.ex
@@ -13,7 +13,7 @@ defmodule LivebookWeb.Output.PlainTextComponent do
     socket = assign(socket, assigns)
 
     if text do
-      chunk = %{id: Livebook.Utils.random_id(), text: text}
+      chunk = %{id: Livebook.Utils.random_long_id(), text: text}
       {:ok, stream_insert(socket, :chunks, chunk)}
     else
       {:ok, socket}

--- a/lib/livebook_web/live/output/terminal_text_component.ex
+++ b/lib/livebook_web/live/output/terminal_text_component.ex
@@ -31,7 +31,7 @@ defmodule LivebookWeb.Output.TerminalTextComponent do
       {html_lines, [last_html_line]} = Enum.split(html_lines, -1)
 
       stream_items =
-        for html_line <- html_lines, do: %{id: Livebook.Utils.random_id(), html: html_line}
+        for html_line <- html_lines, do: %{id: Livebook.Utils.random_long_id(), html: html_line}
 
       socket = stream(socket, :html_lines, stream_items)
 

--- a/lib/livebook_web/session_identity.ex
+++ b/lib/livebook_web/session_identity.ex
@@ -7,7 +7,7 @@ defmodule LivebookWeb.SessionIdentity do
     if id = get_session(conn, :current_user_id) do
       {conn, %{id: id}}
     else
-      user_id = Livebook.Utils.random_id()
+      user_id = Livebook.Utils.random_long_id()
       {put_session(conn, :current_user_id, user_id), %{id: user_id}}
     end
   end

--- a/test/livebook_web/channels/js_view_channel_test.exs
+++ b/test/livebook_web/channels/js_view_channel_test.exs
@@ -8,7 +8,7 @@ defmodule LivebookWeb.JSViewChannelTest do
       LivebookWeb.Socket
       |> socket()
       |> subscribe_and_join(LivebookWeb.JSViewChannel, "js_view", %{
-        "session_token" => session_token(session_id, Livebook.Utils.random_id())
+        "session_token" => session_token(session_id, Livebook.Utils.random_long_id())
       })
 
     %{socket: socket}

--- a/test/livebook_web/live/app_auth_live_test.exs
+++ b/test/livebook_web/live/app_auth_live_test.exs
@@ -22,7 +22,7 @@ defmodule LivebookWeb.AppAuthLiveTest do
   end
 
   defp create_app(app_settings_attrs) do
-    slug = Livebook.Utils.random_id()
+    slug = Livebook.Utils.random_long_id()
 
     app_settings =
       Livebook.Notebook.AppSettings.new()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,7 +1,7 @@
 defmodule Livebook.Factory do
   def build(:user) do
     %Livebook.Users.User{
-      id: Livebook.Utils.random_id(),
+      id: Livebook.Utils.random_long_id(),
       name: "Jose Valim",
       hex_color: Livebook.EctoTypes.HexColor.random()
     }
@@ -21,7 +21,7 @@ defmodule Livebook.Factory do
       org_id: 1,
       user_id: 1,
       org_key_id: 1,
-      org_public_key: Livebook.Hubs.Team.public_key_prefix() <> Livebook.Utils.random_id(),
+      org_public_key: Livebook.Hubs.Team.public_key_prefix() <> Livebook.Utils.random_long_id(),
       teams_key: org.teams_key,
       session_token: Livebook.Utils.random_short_id(),
       offline: nil


### PR DESCRIPTION
Cell ids are visible in stacktrace and URLs and 10 bytes is definitely enough.