### PR TITLE
Only keep #cell: markers in stacktrace

### DIFF
--- a/lib/livebook/runtime/evaluator/doctests.ex
+++ b/lib/livebook/runtime/evaluator/doctests.ex
@@ -334,7 +334,7 @@ defmodule Livebook.Runtime.Evaluator.Doctests do
   end
 
   defp format_stacktrace_entry(entry, _test_case, _test) do
-    Exception.format_stacktrace_entry(entry)
+    Livebook.Runtime.Evaluator.Formatter.format_stacktrace_entry(entry)
   end
 
   defp format_label(label), do: colorize(:cyan, "#{label}:")

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -195,6 +195,17 @@ defmodule Livebook.Runtime.EvaluatorTest do
              """ <> _ = clean_message(message)
     end
 
+    test "only keeps #cell: markers in stacktrace", %{evaluator: evaluator} do
+      code = """
+      List.first(%{})
+      """
+
+      Evaluator.evaluate_code(evaluator, :elixir, code, :code_1, [], file: "file.ex#cell:abcDEF")
+
+      assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()}
+      assert message =~ "  #cell:abcDEF:1: (file)"
+    end
+
     test "returns additional metadata when there is a syntax error", %{evaluator: evaluator} do
       code = "1+"
 


### PR DESCRIPTION
<img width="1141" alt="Screenshot 2023-11-15 at 18 08 23" src="https://github.com/livebook-dev/livebook/assets/9582/7912366b-4703-4e18-9d30-05c9e45ea7e6">
<img width="1133" alt="Screenshot 2023-11-15 at 18 09 19" src="https://github.com/livebook-dev/livebook/assets/9582/56ad584c-0724-494b-bc27-4e89b645fb68">
