### PR TITLE
Add wget to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE} AS build
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
-        build-essential git && \
+        wget build-essential git && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When trying to build the docker image using a CUDA base container (e.g. ghcr.io/livebook-dev/livebook:latest-cuda12.1), I got this error here:

```
#0 38.82 could not compile dependency :exla, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile exla --force", update it with "mix deps.update exla" or clean it with "mix deps.clean exla"
#0 38.82 ** (RuntimeError) expected either curl or wget to be available in your system, but neither was found
#0 38.82     (xla 0.5.1) lib/xla.ex:221: XLA.assert_network_tool!/0
#0 38.82     (xla 0.5.1) lib/xla.ex:180: XLA.download_matching!/1
#0 38.82     (xla 0.5.1) lib/xla.ex:33: XLA.archive_path!/0
#0 38.82     /app/deps/exla/mix.exs:112: EXLA.MixProject.extract_xla/1
#0 38.82     (mix 1.15.7) lib/mix/task.ex:527: Mix.Task.run_alias/6
#0 38.82     (mix 1.15.7) lib/mix/tasks/compile.all.ex:124: Mix.Tasks.Compile.All.run_compiler/2
#0 38.82     (mix 1.15.7) lib/mix/tasks/compile.all.ex:104: Mix.Tasks.Compile.All.compile/4
#0 38.82     (mix 1.15.7) lib/mix/tasks/compile.all.ex:93: Mix.Tasks.Compile.All.with_logger_app/2
```

Adding wget to the build container fixes it. We could also add it to [elixir-cuda.dockerfile](https://github.com/livebook-dev/livebook/blob/main/docker/base/elixir-cuda.dockerfile#L16) but then historic base images would still not work.

It's also possible that I've somehow done something else wrong and this actually isn't needed. I'm actually a little confused how any official cuda livebook images have been built without wget or curl in the build container