### PR TITLE
Ignore channel events for unknown JS Views

### DIFF
--- a/test/livebook_web/channels/js_view_channel_test.exs
+++ b/test/livebook_web/channels/js_view_channel_test.exs
@@ -57,6 +57,14 @@ defmodule LivebookWeb.JSViewChannelTest do
     assert_push "event:1", %{"root" => [["ping"], [1, 2, 3]]}
   end
 
+  test "ignores client events when no connection is found", %{socket: socket} do
+    push(socket, "event", %{"root" => [["ping", "1"], [1, 2, 3]]})
+
+    # The channel should still be operational
+    push(socket, "connect", %{"connect_token" => connect_token(), "ref" => "1", "id" => "id1"})
+    assert_receive {:connect, _from, %{}}
+  end
+
   describe "binary payload" do
     test "initial data", %{socket: socket} do
       push(socket, "connect", %{"connect_token" => connect_token(), "ref" => "1", "id" => "id1"})


### PR DESCRIPTION
Closes #2362.

We are multiplexing JSView events through a single channel, so each JSView needs to send "connect" event to register. When the connection is lost the JSView information is discarded and it needs to register again, by remounting the client-side hook (when the LV channel is reconnected):

https://github.com/livebook-dev/livebook/blob/d345c9eeff54c541bf8e09a251a0dc22d4a124b0/assets/js/hooks/js_view.js#L165-L168

However, it is possible that when both channels reconnect we push (or flush accumulated) events, before the hook is destroyed and mounted again.

I was considering solving this on the client, but in this case I think it's actually simpler and more reliable to do it on the server.