### PR TITLE
Fix noscroll behaviour when dropdown menu is opened

### DIFF
--- a/lib/livebook_web/components/core_components.ex
+++ b/lib/livebook_web/components/core_components.ex
@@ -303,8 +303,6 @@ defmodule LivebookWeb.CoreComponents do
       >
         <%= render_slot(@toggle) %>
       </div>
-      <div id={"#{@id}-overlay"} class="fixed z-[90] inset-0 pointer-events-none hidden" phx-click-away={hide_menu(@id)}>
-      </div>
       <menu
         id={"#{@id}-content"}
         class={[
@@ -324,13 +322,11 @@ defmodule LivebookWeb.CoreComponents do
   end
 
   defp show_menu(id) do
-    JS.show(to: "##{id}-overlay")
-    |> JS.show(to: "##{id}-content", display: "flex")
+    JS.show(to: "##{id}-content", display: "flex")
   end
 
   defp hide_menu(id) do
-    JS.hide(to: "##{id}-overlay")
-    |> JS.hide(to: "##{id}-content")
+    JS.hide(to: "##{id}-content")
   end
 
   defp menu_position_class(:top_left), do: "top-0 left-0 transform -translate-y-full -mt-1"

--- a/lib/livebook_web/components/core_components.ex
+++ b/lib/livebook_web/components/core_components.ex
@@ -303,7 +303,7 @@ defmodule LivebookWeb.CoreComponents do
       >
         <%= render_slot(@toggle) %>
       </div>
-      <div id={"#{@id}-overlay"} class="fixed z-[90] inset-0 hidden" phx-click-away={hide_menu(@id)}>
+      <div id={"#{@id}-overlay"} class="fixed z-[90] inset-0 pointer-events-none hidden" phx-click-away={hide_menu(@id)}>
       </div>
       <menu
         id={"#{@id}-content"}


### PR DESCRIPTION
Currently an overlay is shown when a dropdown menu is opened.
The problem is, when trying to scroll down with the mouse outside the menu, nothing happens.
I think that is unexpected behaviour.
As discussed [here](https://github.com/phoenixframework/phoenix_live_view/issues/1826#issuecomment-1069526074) this was added to not trigger a mouseclick outside the menu when the menu is open.
But since some parts of the UI (e.g. the navigation bar on the left) have a higher z index than the overlay nontheless, I think removing the overlay to prevent the weird scroll behaviour is the best option?