### PR TITLE
Fix the S3 form to allow the user to enter a custom region

### DIFF
--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -33,10 +33,10 @@ defmodule Livebook.FileSystem.S3 do
   Infers region from the given bucket URL.
   """
   @spec region_from_uri(String.t()) :: String.t()
-  # TODO: make it private again on Livebook v0.12
   def region_from_uri(uri) do
     # For many services the API host is of the form *.[region].[rootdomain].com
-    %{host: host} = URI.parse(uri)
+    host = URI.parse(uri).host || ""
+
     splitted_host = host |> String.split(".") |> Enum.reverse()
 
     case Enum.at(splitted_host, 2, "auto") do
@@ -64,18 +64,10 @@ defmodule Livebook.FileSystem.S3 do
       :secret_access_key,
       :hub_id
     ])
-    |> put_region_from_uri()
     |> validate_required([:bucket_url, :region, :hub_id])
     |> Livebook.Utils.validate_url(:bucket_url)
     |> validate_credentials()
     |> put_id()
-  end
-
-  defp put_region_from_uri(changeset) do
-    case get_field(changeset, :bucket_url) do
-      nil -> changeset
-      bucket_url -> put_change(changeset, :region, region_from_uri(bucket_url))
-    end
   end
 
   defp validate_credentials(changeset) do

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -30,23 +30,6 @@ defmodule Livebook.FileSystem.S3 do
   end
 
   @doc """
-  Infers region from the given bucket URL.
-  """
-  @spec region_from_uri(String.t()) :: String.t()
-  def region_from_uri(uri) do
-    # For many services the API host is of the form *.[region].[rootdomain].com
-    host = URI.parse(uri).host || ""
-
-    splitted_host = host |> String.split(".") |> Enum.reverse()
-
-    case Enum.at(splitted_host, 2, "auto") do
-      "s3" -> "us-east-1"
-      "r2" -> "auto"
-      region -> region
-    end
-  end
-
-  @doc """
   Returns an `%Ecto.Changeset{}` for tracking file system changes.
   """
   @spec change_file_system(t(), map()) :: Ecto.Changeset.t()
@@ -64,7 +47,7 @@ defmodule Livebook.FileSystem.S3 do
       :secret_access_key,
       :hub_id
     ])
-    |> validate_required([:bucket_url, :region, :hub_id])
+    |> validate_required([:bucket_url, :hub_id])
     |> Livebook.Utils.validate_url(:bucket_url)
     |> validate_credentials()
     |> put_id()
@@ -148,6 +131,38 @@ defmodule Livebook.FileSystem.S3 do
       :aws_credentials.get_credentials()
     else
       :undefined
+    end
+  end
+
+  @doc """
+  Infers region from the given bucket URL.
+  """
+  @spec region_from_url(String.t()) :: String.t()
+  def region_from_url(url) do
+    # For many services the API host is of the form *.[region].[rootdomain].com
+    host = URI.parse(url).host || ""
+
+    splitted_host = host |> String.split(".") |> Enum.reverse()
+
+    case Enum.at(splitted_host, 2, "auto") do
+      "s3" -> "us-east-1"
+      "r2" -> "auto"
+      region -> region
+    end
+  end
+
+  @doc """
+  Sets region field on `changeset` based on bucket URL, unless already
+  specified.
+  """
+  @spec maybe_put_region_from_url(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def maybe_put_region_from_url(changeset) do
+    case {get_field(changeset, :region), get_field(changeset, :bucket_url)} do
+      {nil, bucket_url} when bucket_url != nil ->
+        put_change(changeset, :region, region_from_url(bucket_url))
+
+      _ ->
+        changeset
     end
   end
 end

--- a/lib/livebook/migration.ex
+++ b/lib/livebook/migration.ex
@@ -113,7 +113,7 @@ defmodule Livebook.Migration do
             new_fields = %{
               hub_id: Livebook.Hubs.Personal.id(),
               external_id: nil,
-              region: Livebook.FileSystem.S3.region_from_uri(config.bucket_url)
+              region: Livebook.FileSystem.S3.region_from_url(config.bucket_url)
             }
 
             config = Map.merge(new_fields, config)
@@ -142,7 +142,7 @@ defmodule Livebook.Migration do
       new_attrs = %{
         hub_id: Livebook.Hubs.Personal.id(),
         external_id: nil,
-        region: Livebook.FileSystem.S3.region_from_uri(attrs.bucket_url)
+        region: Livebook.FileSystem.S3.region_from_url(attrs.bucket_url)
       }
 
       attrs = Map.merge(new_attrs, attrs)

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -532,6 +532,7 @@ defmodule LivebookWeb.FormComponents do
           data-show
           type="button"
           aria-label="show password"
+          tabindex="-1"
           phx-click={
             JS.remove_attribute("type", to: "##{@id} input")
             |> JS.set_attribute({"type", "text"}, to: "##{@id} input")
@@ -546,6 +547,7 @@ defmodule LivebookWeb.FormComponents do
           data-hide
           type="button"
           aria-label="hide password"
+          tabindex="-1"
           phx-click={
             JS.remove_attribute("type", to: "##{@id} input")
             |> JS.set_attribute({"type", "password"}, to: "##{@id} input")

--- a/lib/livebook_web/live/hub/file_system_form_component.ex
+++ b/lib/livebook_web/live/hub/file_system_form_component.ex
@@ -58,7 +58,13 @@ defmodule LivebookWeb.Hub.FileSystemFormComponent do
             label="Bucket URL"
             placeholder="https://s3.[region].amazonaws.com/[bucket]"
           />
-          <.text_field field={f[:region]} label="Region (optional)" />
+          <.text_field
+            field={f[:region]}
+            label="Region"
+            placeholder={
+              FileSystem.S3.region_from_uri(Ecto.Changeset.get_field(@changeset, :bucket_url) || "")
+            }
+          />
           <%= if Livebook.Config.aws_credentials?() do %>
             <.password_field field={f[:access_key_id]} label="Access Key ID (optional)" />
             <.password_field field={f[:secret_access_key]} label="Secret Access Key (optional)" />


### PR DESCRIPTION
Closes #2379.

Currently we say "Region (optional)", but it's actually required. The validation never fails, because we always compute the region. However, we *always* override the region from URL, which is too intrusive, I think showing a placeholder is a sane approach.

https://github.com/livebook-dev/livebook/assets/17034772/a39596e3-2adb-4c05-9259-b6312f2bf114