### PR TITLE
Always show expand icon on hub select

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -343,13 +343,13 @@ defmodule LivebookWeb.SessionLive do
               <.menu position={:bottom_left} id="notebook-hub-menu">
                 <:toggle>
                   <div
-                    class="inline-flex items-center group cursor-pointer gap-1 mt-1 text-sm text-gray-600 hover:text-gray-800 focus:text-gray-800"
+                    class="inline-flex items-center cursor-pointer gap-1 mt-1 text-sm text-gray-600 hover:text-gray-800 focus:text-gray-800"
                     aria-label={@data_view.hub.hub_name}
                   >
                     <span>in</span>
                     <span class="text-lg pl-1"><%= @data_view.hub.hub_emoji %></span>
                     <span><%= @data_view.hub.hub_name %></span>
-                    <.remix_icon icon="arrow-down-s-line" class="invisible group-hover:visible" />
+                    <.remix_icon icon="arrow-down-s-line" />
                   </div>
                 </:toggle>
                 <.menu_item :for={hub <- @saved_hubs}>


### PR DESCRIPTION
🐈‍⬛