### PR TITLE
Do not close package search modal after adding the package

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -627,8 +627,7 @@ defmodule LivebookWeb.SessionLive do
         id: "package-search",
         session: %{
           "session_pid" => @session.pid,
-          "runtime" => @data_view.runtime,
-          "return_to" => @self_path
+          "runtime" => @data_view.runtime
         }
       ) %>
     </.modal>

--- a/lib/livebook_web/live/session_live/package_search_live.ex
+++ b/lib/livebook_web/live/session_live/package_search_live.ex
@@ -145,5 +145,6 @@ defmodule LivebookWeb.SessionLive.PackageSearchLive do
 
   defp add_dependency(socket, dependency) do
     Livebook.Session.add_dependencies(socket.assigns.session.pid, [dependency])
+    assign(socket, search: "", search_ref: nil, packages: [])
   end
 end

--- a/lib/livebook_web/live/session_live/package_search_live.ex
+++ b/lib/livebook_web/live/session_live/package_search_live.ex
@@ -2,16 +2,11 @@ defmodule LivebookWeb.SessionLive.PackageSearchLive do
   use LivebookWeb, :live_view
 
   @impl true
-  def mount(
-        _params,
-        %{"session_pid" => session_pid, "runtime" => runtime, "return_to" => return_to},
-        socket
-      ) do
+  def mount(_params, %{"session_pid" => session_pid, "runtime" => runtime}, socket) do
     socket =
       assign(socket,
         session: Livebook.Session.get_by_pid(session_pid),
         runtime: runtime,
-        return_to: return_to,
         search: "",
         search_ref: nil,
         packages: [],

--- a/lib/livebook_web/live/session_live/package_search_live.ex
+++ b/lib/livebook_web/live/session_live/package_search_live.ex
@@ -145,6 +145,5 @@ defmodule LivebookWeb.SessionLive.PackageSearchLive do
 
   defp add_dependency(socket, dependency) do
     Livebook.Session.add_dependencies(socket.assigns.session.pid, [dependency])
-    push_patch(socket, to: socket.assigns.return_to)
   end
 end


### PR DESCRIPTION
The UX for adding multiple packages improve, if we keep the modal open after adding a package.