### PR TITLE
ZTA metadata - help field

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -31,7 +31,7 @@ defmodule Livebook.Config do
       name: "Teleport",
       value: "Teleport cluster address",
       module: Livebook.ZTA.Teleport,
-      help: "(https://[cluster-name]:3080)"
+      help: "Example: https://[cluster-name]:3080"
     }
   ]
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -29,8 +29,9 @@ defmodule Livebook.Config do
     %{
       type: :teleport,
       name: "Teleport",
-      value: "Teleport cluster address (https://[cluster-name]:3080)",
-      module: Livebook.ZTA.Teleport
+      value: "Teleport cluster address",
+      module: Livebook.ZTA.Teleport,
+      help: "(https://[cluster-name]:3080)"
     }
   ]
 

--- a/lib/livebook_web/live/app_helpers.ex
+++ b/lib/livebook_web/live/app_helpers.ex
@@ -144,6 +144,7 @@ defmodule LivebookWeb.AppHelpers do
               :if={zta_metadata = zta_metadata(@form[:zta_provider].value)}
               field={@form[:zta_key]}
               label={zta_metadata.value}
+              help={zta_help(zta_metadata)}
               phx-debounce
             />
           </div>
@@ -282,4 +283,7 @@ defmodule LivebookWeb.AppHelpers do
   def update_app_list(apps, {:app_closed, app}) do
     Enum.reject(apps, &(&1.slug == app.slug))
   end
+
+  defp zta_help(%{help: help}), do: "#{help}"
+  defp zta_help(_), do: nil
 end


### PR DESCRIPTION
Too long labels break the layout. I think this information works better in a tooltip helper. WDYT?


<img width="693" alt="Screenshot 2023-12-24 at 17 07 20" src="https://github.com/livebook-dev/livebook/assets/5660941/cea1ad6d-923b-445f-8195-dde02cd3a2c6">
<img width="710" alt="after" src="https://github.com/livebook-dev/livebook/assets/5660941/01f3a9b3-670e-4976-982c-b11694c70343">
