### PR TITLE
Expand lazy creation of editor and JS Views to the proximity of the viewport

### DIFF
--- a/assets/js/hooks/cell_editor.js
+++ b/assets/js/hooks/cell_editor.js
@@ -65,7 +65,10 @@ const CellEditor = {
           })
         );
 
-        this.visibility = waitUntilInViewport(this.el);
+        this.visibility = waitUntilInViewport(this.el, {
+          root: document.querySelector("[data-el-notebook]"),
+          proximity: 2000,
+        });
 
         // We mount the editor lazily once it enters the viewport
         this.visibility.promise.then(() => {

--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -1,7 +1,6 @@
 import { parseHookProps } from "../lib/attribute";
 import {
   isElementHidden,
-  isElementVisibleInViewport,
   randomId,
   randomToken,
   waitUntilInViewport,
@@ -258,7 +257,10 @@ const JSView = {
     // We detect when the placeholder enters viewport and becomes visible,
     // based on that we can load the iframe contents lazily
 
-    const visibility = waitUntilInViewport(this.iframePlaceholder);
+    const visibility = waitUntilInViewport(this.iframePlaceholder, {
+      root: notebookEl,
+      proximity: 2000,
+    });
 
     // Reflect focus based on whether there is a focused parent, this
     // is later synced on "element_focused" events


### PR DESCRIPTION
Currently we load iframes and editors when they enter the viewport (at least 1px), which may be noticed by the user. This PR expands loading to also happen for elements within proximity of the viewport (arbitrary 2000px), which still has the lazy benefits for large pages, but is more unobtrusive.