### PR TITLE
Make frame and text stream updates implicit

### DIFF
--- a/lib/livebook_web/live/app_session_live.ex
+++ b/lib/livebook_web/live/app_session_live.ex
@@ -410,11 +410,11 @@ defmodule LivebookWeb.AppSessionLive do
         changed_input_ids = Session.Data.changed_input_ids(data)
 
         for {{idx, frame}, cell} <- Notebook.find_frame_outputs(data.notebook, ref) do
+          input_views = input_views_for_cell(cell, data, changed_input_ids)
+
           send_update(LivebookWeb.Output.FrameComponent,
             id: "outputs-#{idx}-output",
-            outputs: frame.outputs,
-            update_type: update_type,
-            input_views: input_views_for_cell(cell, data, changed_input_ids)
+            event: {:update, update_type, frame.outputs, input_views}
           )
         end
 
@@ -432,7 +432,7 @@ defmodule LivebookWeb.AppSessionLive do
                 :markdown -> LivebookWeb.Output.MarkdownComponent
               end
 
-            send_update(module, id: "outputs-#{idx}-output", text: output.text)
+            send_update(module, id: "outputs-#{idx}-output", event: {:append, output.text})
             data_view
 
           _ ->

--- a/lib/livebook_web/live/output/frame_component.ex
+++ b/lib/livebook_web/live/output/frame_component.ex
@@ -7,19 +7,11 @@ defmodule LivebookWeb.Output.FrameComponent do
   end
 
   @impl true
-  def update(assigns, socket) do
-    {update_type, assigns} = Map.pop(assigns, :update_type, nil)
-    {outputs, assigns} = Map.pop!(assigns, :outputs)
-
-    socket = assign(socket, assigns)
-
-    socket = assign_new(socket, :num_outputs, fn -> length(outputs) end)
+  def update(%{event: {:update, update_type, outputs, input_views}}, socket) do
+    socket = assign(socket, input_views: input_views)
 
     socket =
       case update_type do
-        nil ->
-          stream(socket, :outputs, stream_items(outputs))
-
         :replace ->
           socket
           |> assign(num_outputs: length(outputs))
@@ -30,6 +22,17 @@ defmodule LivebookWeb.Output.FrameComponent do
           |> update(:num_outputs, &(length(outputs) + &1))
           |> stream(:outputs, stream_items(outputs))
       end
+
+    {:ok, socket}
+  end
+
+  def update(assigns, socket) do
+    {outputs, assigns} = Map.pop!(assigns, :outputs)
+
+    socket = assign(socket, assigns)
+
+    socket = assign_new(socket, :num_outputs, fn -> length(outputs) end)
+    socket = stream(socket, :outputs, stream_items(outputs))
 
     {:ok, socket}
   end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -2923,14 +2923,14 @@ defmodule LivebookWeb.SessionLive do
         changed_input_ids = Session.Data.changed_input_ids(data)
 
         for {{idx, frame}, cell} <- Notebook.find_frame_outputs(data.notebook, ref) do
+          # Note that we are not updating data_view to avoid re-render,
+          # but any change that causes frame to re-render will update
+          # data_view first
+          input_views = input_views_for_cell(cell, data, changed_input_ids)
+
           send_update(LivebookWeb.Output.FrameComponent,
             id: "outputs-#{idx}-output",
-            outputs: frame.outputs,
-            update_type: update_type,
-            # Note that we are not updating data_view to avoid re-render,
-            # but any change that causes frame to re-render will update
-            # data_view first
-            input_views: input_views_for_cell(cell, data, changed_input_ids)
+            event: {:update, update_type, frame.outputs, input_views}
           )
         end
 
@@ -2948,7 +2948,7 @@ defmodule LivebookWeb.SessionLive do
                 :markdown -> LivebookWeb.Output.MarkdownComponent
               end
 
-            send_update(module, id: "outputs-#{idx}-output", text: output.text)
+            send_update(module, id: "outputs-#{idx}-output", event: {:append, output.text})
             data_view
 
           _ ->


### PR DESCRIPTION
For frame and text output updates we make an explicit `send_update`. Currently everything is handled by a single clause with conditional logic, so I moved update to a separate event handler to make the flow more clear.