### PR TITLE
Updates Explorer guide

### DIFF
--- a/lib/livebook/notebook/learn/intro_to_explorer.livemd
+++ b/lib/livebook/notebook/learn/intro_to_explorer.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino_explorer, "~> 0.1.15"}
+  {:kino_explorer, "~> 0.1.18"}
 ])
 ```
 
@@ -10,11 +10,11 @@ Mix.install([
 
 To explore and transform data in Livebook we use two libraries:
 
-* The [`explorer`](https://github.com/elixir-nx/explorer)
+* The [`explorer`](https://hexdocs.pm/explorer/Explorer.html)
   package brings series (one-dimensional) and dataframes (two-dimensional)
   for fast data exploration to Elixir.
 
-* The [`kino_explorer`](https://github.com/livebook-dev/kino_explorer)
+* The [`kino_explorer`](https://hexdocs.pm/kino_explorer/components.html)
   package automatically renders an `Explorer.DataFrame` or `Explorer.Series`
   as a data table.
 


### PR DESCRIPTION
The guides are linking to GitHub, but I think that makes more sense to link to the docs. wdyt?