### PR TITLE
Make sure declared fields are set on AWS credentials map

### DIFF
--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -114,7 +114,9 @@ defmodule Livebook.FileSystem.S3 do
             %{access_key_id: nil, secret_access_key: nil, token: nil}
 
           credentials ->
-            Map.take(credentials, [:access_key_id, :secret_access_key, :token])
+            credentials
+            |> Map.take([:access_key_id, :secret_access_key, :token])
+            |> then(&Map.merge(%{token: nil, access_key_id: nil, secret_access_key: nil}, &1))
         end
 
       _ ->

--- a/lib/livebook/file_system/s3.ex
+++ b/lib/livebook/file_system/s3.ex
@@ -109,14 +109,15 @@ defmodule Livebook.FileSystem.S3 do
   def credentials(%__MODULE__{} = file_system) do
     case {file_system.access_key_id, file_system.secret_access_key} do
       {nil, nil} ->
+        defaults = %{token: nil, access_key_id: nil, secret_access_key: nil}
+
         case get_credentials() do
           :undefined ->
-            %{access_key_id: nil, secret_access_key: nil, token: nil}
+            defaults
 
           credentials ->
-            credentials
-            |> Map.take([:access_key_id, :secret_access_key, :token])
-            |> then(&Map.merge(%{token: nil, access_key_id: nil, secret_access_key: nil}, &1))
+            credentials = Map.take(credentials, [:access_key_id, :secret_access_key, :token])
+            Map.merge(defaults, credentials)
         end
 
       _ ->


### PR DESCRIPTION
Fixes #2471 

Not sure `then` is the right choice here. `|> Map.put_new(%{token: nil, access_key_id: nil, secret_access_key: nil})` would be nice! :)

I have tested this quickly. It does solve the problem.