### PR TITLE
Disables deployment group mode editing

### DIFF
--- a/lib/livebook/teams/deployment_group.ex
+++ b/lib/livebook/teams/deployment_group.ex
@@ -36,6 +36,6 @@ defmodule Livebook.Teams.DeploymentGroup do
   def changeset(deployment_group, attrs \\ %{}) do
     deployment_group
     |> cast(attrs, [:id, :name, :mode, :hub_id, :clustering, :zta_provider, :zta_key])
-    |> validate_required([:name, :mode])
+    |> validate_required([:name])
   end
 end

--- a/lib/livebook/teams/deployment_group.ex
+++ b/lib/livebook/teams/deployment_group.ex
@@ -36,6 +36,6 @@ defmodule Livebook.Teams.DeploymentGroup do
   def changeset(deployment_group, attrs \\ %{}) do
     deployment_group
     |> cast(attrs, [:id, :name, :mode, :hub_id, :clustering, :zta_provider, :zta_key])
-    |> validate_required([:name])
+    |> validate_required([:name, :mode])
   end
 end

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -71,7 +71,6 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
                   {"Online", :online}
                 ]}
               />
-            <% end %>
             <LivebookWeb.AppComponents.deployment_group_form_content hub={@hub} form={f} />
             <div class="flex space-x-2">
               <button class="button-base button-blue" type="submit" disabled={not @changeset.valid?}>

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -57,8 +57,8 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
               autocomplete="off"
               phx-debounce
             />
-            <%= if @mode == :new do %>
               <.select_field
+                :if={@mode == :new}
                 label="Mode"
                 help={
                   ~S'''

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -57,6 +57,7 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
               autocomplete="off"
               phx-debounce
             />
+            <%= if @mode == :new do %>
             <.select_field
               label="Mode"
               help={
@@ -69,8 +70,8 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
                 {"Offline", :offline},
                 {"Online", :online}
               ]}
-              disabled={@mode != :new}
             />
+            <% end %>
             <LivebookWeb.AppComponents.deployment_group_form_content hub={@hub} form={f} />
             <div class="flex space-x-2">
               <button class="button-base button-blue" type="submit" disabled={not @changeset.valid?}>
@@ -143,8 +144,8 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
   defp subtitle(%DeploymentGroup{name: nil}, hub_name),
     do: "Add a new deployment group to #{hub_name}"
 
-  defp subtitle(%DeploymentGroup{name: deployment_group}, _),
-    do: "Manage the #{deployment_group} deployment group"
+  defp subtitle(%DeploymentGroup{name: deployment_group, mode: mode}, _),
+    do: "Manage the #{deployment_group} (#{mode}) deployment group"
 
   defp button(%DeploymentGroup{name: nil}), do: %{icon: "add-line", label: "Add"}
   defp button(_), do: %{icon: "save-line", label: "Save"}

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -57,20 +57,21 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
               autocomplete="off"
               phx-debounce
             />
-              <.select_field
-                :if={@mode == :new}
-                label="Mode"
-                help={
-                  ~S'''
-                  Deployment group mode.
-                  '''
-                }
-                field={f[:mode]}
-                options={[
-                  {"Offline", :offline},
-                  {"Online", :online}
-                ]}
-              />
+            <.select_field
+              :if={@mode == :new}
+              label="Mode"
+              help={
+                ~S'''
+                Deployment group mode.
+                '''
+              }
+              field={f[:mode]}
+              options={[
+                {"Offline", :offline},
+                {"Online", :online}
+              ]}
+            />
+            <.hidden_field :if={@mode != :new} field={f[:mode]} value={@deployment_group.mode} />
             <LivebookWeb.AppComponents.deployment_group_form_content hub={@hub} form={f} />
             <div class="flex space-x-2">
               <button class="button-base button-blue" type="submit" disabled={not @changeset.valid?}>

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -58,19 +58,19 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
               phx-debounce
             />
             <%= if @mode == :new do %>
-            <.select_field
-              label="Mode"
-              help={
-                ~S'''
-                Deployment group mode.
-                '''
-              }
-              field={f[:mode]}
-              options={[
-                {"Offline", :offline},
-                {"Online", :online}
-              ]}
-            />
+              <.select_field
+                label="Mode"
+                help={
+                  ~S'''
+                  Deployment group mode.
+                  '''
+                }
+                field={f[:mode]}
+                options={[
+                  {"Offline", :offline},
+                  {"Online", :online}
+                ]}
+              />
             <% end %>
             <LivebookWeb.AppComponents.deployment_group_form_content hub={@hub} form={f} />
             <div class="flex space-x-2">

--- a/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_form_component.ex
@@ -69,6 +69,7 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupFormComponent do
                 {"Offline", :offline},
                 {"Online", :online}
               ]}
+              disabled={@mode != :new}
             />
             <LivebookWeb.AppComponents.deployment_group_form_content hub={@hub} form={f} />
             <div class="flex space-x-2">

--- a/test/livebook_teams/web/hub/deployment_group_live_test.exs
+++ b/test/livebook_teams/web/hub/deployment_group_live_test.exs
@@ -92,7 +92,9 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupLiveTest do
       live(conn, ~p"/hub/#{hub.id}/deployment-groups/edit/#{deployment_group.id}")
 
     assert html =~ "Edit deployment group"
-    assert html =~ "Manage the #{deployment_group.name} deployment group"
+
+    assert html =~
+             "Manage the #{deployment_group.name} (#{deployment_group.mode}) deployment group"
 
     view
     |> element("#deployment-groups-form")

--- a/test/livebook_teams/web/hub/edit_live_test.exs
+++ b/test/livebook_teams/web/hub/edit_live_test.exs
@@ -387,7 +387,9 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
         live(conn, ~p"/hub/#{hub.id}/deployment-groups/edit/#{deployment_group.id}")
 
       assert html =~ "Edit deployment group"
-      assert html =~ "Manage the #{deployment_group.name} deployment group"
+
+      assert html =~
+               "Manage the #{deployment_group.name} (#{deployment_group.mode}) deployment group"
 
       view
       |> element("#deployment-groups-form")


### PR DESCRIPTION
I need help here @jonatanklosko . When I select `:offline` on creation, everything is fine! But when I select `:online` the select field is not disabled after the patch. I need to reload the page to disable it. The form mode is `:edit`in both cases!