### PR TITLE
Fix generating html id with special characters

### DIFF
--- a/lib/livebook_web/helpers/html_helpers.ex
+++ b/lib/livebook_web/helpers/html_helpers.ex
@@ -36,7 +36,12 @@ defmodule LivebookWeb.HTMLHelpers do
     name
     |> String.trim()
     |> String.downcase()
+    |> String.replace(~r/[\p{P}\p{S}]/, "")
     |> String.replace(~r/\s+/u, "-")
+    |> case do
+      "" -> Base.url_encode64(name, padding: false)
+      id -> id
+    end
   end
 
   @doc """

--- a/lib/livebook_web/helpers/html_helpers.ex
+++ b/lib/livebook_web/helpers/html_helpers.ex
@@ -36,7 +36,7 @@ defmodule LivebookWeb.HTMLHelpers do
     name
     |> String.trim()
     |> String.downcase()
-    |> String.replace(~r/[\p{P}\p{S}]/, "")
+    |> String.replace(~r/[^\s\w]/u, "")
     |> String.replace(~r/\s+/u, "-")
     |> case do
       "" -> Base.url_encode64(name, padding: false)

--- a/lib/livebook_web/helpers/html_helpers.ex
+++ b/lib/livebook_web/helpers/html_helpers.ex
@@ -34,11 +34,8 @@ defmodule LivebookWeb.HTMLHelpers do
 
   defp name_to_html_id(name) do
     name
-    |> String.trim()
     |> String.downcase()
     |> String.replace(~r/[^\s\w]/u, "")
-    # We need to trim again after removing special characters
-    # in case of the last one was removed from the above regex
     |> String.trim()
     |> String.replace(~r/\s+/u, "-")
     |> case do

--- a/lib/livebook_web/helpers/html_helpers.ex
+++ b/lib/livebook_web/helpers/html_helpers.ex
@@ -37,6 +37,9 @@ defmodule LivebookWeb.HTMLHelpers do
     |> String.trim()
     |> String.downcase()
     |> String.replace(~r/[^\s\w]/u, "")
+    # We need to trim again after removing special characters
+    # in case of the last one was removed from the above regex
+    |> String.trim()
     |> String.replace(~r/\s+/u, "-")
     |> case do
       "" -> Base.url_encode64(name, padding: false)

--- a/test/livebook_web/helpers/html_helpers_test.exs
+++ b/test/livebook_web/helpers/html_helpers_test.exs
@@ -18,11 +18,11 @@ defmodule LivebookWeb.HTMLHelpersTest do
     end
 
     test "emoji at end" do
-      assert HTMLHelpers.names_to_html_ids(["Test 🦦 "]) == ["test-🦦"]
+      assert HTMLHelpers.names_to_html_ids(["Test 🦦 "]) == ["test"]
     end
 
     test "emoji in middle" do
-      assert HTMLHelpers.names_to_html_ids(["One 🥮 Two"]) == ["one-🥮-two"]
+      assert HTMLHelpers.names_to_html_ids(["One 🥮 Two"]) == ["one-two"]
     end
 
     test "returns empty list for an empty list" do


### PR DESCRIPTION
- Closes #2494 

If the section name has only special characters, we will use a hash:

![image](https://github.com/livebook-dev/livebook/assets/6402997/b800546e-c90d-4052-9a65-1cbdf668baa1)


If the section name has special characters and alphanumeric characters, we will replace special with empty string and space with `-`:

![image](https://github.com/livebook-dev/livebook/assets/6402997/81b34e26-d173-43aa-a223-ac30e2c3274f)
