### PR TITLE
Use sponsors logo correct versions for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,11 @@ collaborates on models, datasets, and applications.
 <br />
 
 <a href="https://www.tigrisdata.com/">
-  <img height="50" src="https://www.tigrisdata.com/docs/logo/light.png" alt="Tigris">
+  <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://www.tigrisdata.com/docs/logo/dark.png">
+   <source media="(prefers-color-scheme: light)" srcset="https://www.tigrisdata.com/docs/logo/light.png">
+   <img height="50" src="https://www.tigrisdata.com/docs/logo/light.png" alt="Tigris">
+  </picture>
 </a>
 
 Tigris is a globally distributed S3-compatible object storage<br />

--- a/README.md
+++ b/README.md
@@ -350,7 +350,11 @@ For Windows, run:
 ## Platinum sponsors
 
 <a href="https://fly.io">
-  <img height="130" src="https://fly.io/public/images/brand/logo.svg" alt="Fly.io">
+ <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://fly.io/public/images/brand/logo-inverted.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://fly.io/public/images/brand/logo.svg">
+    <img height="130" src="https://fly.io/public/images/brand/logo.svg" alt="Fly.io">
+  </picture>
 </a>
 
 Fly is a platform for running full stack apps and databases close to your users.
@@ -368,9 +372,9 @@ collaborates on models, datasets, and applications.
 
 <a href="https://www.tigrisdata.com/">
   <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://www.tigrisdata.com/docs/logo/dark.png">
-   <source media="(prefers-color-scheme: light)" srcset="https://www.tigrisdata.com/docs/logo/light.png">
-   <img height="50" src="https://www.tigrisdata.com/docs/logo/light.png" alt="Tigris">
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.tigrisdata.com/docs/logo/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://www.tigrisdata.com/docs/logo/light.png">
+    <img height="50" src="https://www.tigrisdata.com/docs/logo/light.png" alt="Tigris">
   </picture>
 </a>
 


### PR DESCRIPTION
This PR changes the logos from Tigris and Fly for dark mode.

I'll open another PR when [HF answers if they have a logo for dark mode](https://huggingface.co/datasets/huggingface/brand-assets/discussions/3).