### PR TITLE
Minimize lifespan of param-driven assigns

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -169,9 +169,11 @@ defmodule LivebookWeb.SessionLive do
     {socket, %{tab: tab, file_drop_metadata: file_drop_metadata}}
   end
 
-  defp handle_params(:secrets, _params, _url, socket) do
+  defp handle_params(:secrets, params, _url, socket) do
     {select_secret_metadata, socket} = pop_in(socket.assigns[:select_secret_metadata])
-    {socket, %{select_secret_metadata: select_secret_metadata}}
+
+    {socket,
+     %{select_secret_metadata: select_secret_metadata, prefill_secret_name: params["secret_name"]}}
   end
 
   defp handle_params(live_action, params, _url, socket)
@@ -687,12 +689,14 @@ defmodule LivebookWeb.SessionLive do
       assign(socket,
         select_secret_metadata: %{
           ref: select_secret_ref,
-          options: select_secret_options,
-          preselect_name: preselect_name
+          options: select_secret_options
         }
       )
 
-    {:noreply, push_patch(socket, to: ~p"/sessions/#{socket.assigns.session.id}/secrets")}
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/sessions/#{socket.assigns.session.id}/secrets?secret_name=#{preselect_name}"
+     )}
   end
 
   def handle_event("select_hub", %{"id" => id}, socket) do

--- a/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
+++ b/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
@@ -120,7 +120,7 @@ defmodule LivebookWeb.SessionLive.AddFileEntryUploadComponent do
         file_entry = %{name: data.name, type: :attachment}
         Livebook.Session.add_file_entries(socket.assigns.session.pid, [file_entry])
         send(self(), {:file_entry_uploaded, file_entry})
-        {:noreply, push_patch(socket, to: ~p"/sessions/#{socket.assigns.session.id}")}
+        {:noreply, socket}
 
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}

--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -72,7 +72,7 @@ defmodule LivebookWeb.SessionLive.Render do
         session={@session}
         file={@data_view.file}
         hub={@data_view.hub}
-        context={@route_params["context"]}
+        context={@action_assigns.context}
         persist_outputs={@data_view.persist_outputs}
         autosave_interval_s={@data_view.autosave_interval_s}
       />
@@ -90,7 +90,7 @@ defmodule LivebookWeb.SessionLive.Render do
         id="app-settings"
         session={@session}
         settings={@data_view.app_settings}
-        context={@route_params["context"]}
+        context={@action_assigns.context}
         deployed_app_slug={@data_view.deployed_app_slug}
       />
     </.modal>
@@ -127,7 +127,7 @@ defmodule LivebookWeb.SessionLive.Render do
         session={@session}
         hub={@data_view.hub}
         file_entries={@data_view.file_entries}
-        tab={@tab}
+        tab={@action_assigns.tab}
       />
     </.modal>
 
@@ -168,11 +168,11 @@ defmodule LivebookWeb.SessionLive.Render do
       patch={@self_path}
     >
       <.live_component
-        module={settings_component_for(@cell)}
+        module={settings_component_for(@action_assigns.cell)}
         id="cell-settings"
         session={@session}
         return_to={@self_path}
-        cell={@cell}
+        cell={@action_assigns.cell}
       />
     </.modal>
 
@@ -188,7 +188,7 @@ defmodule LivebookWeb.SessionLive.Render do
         id="insert-image"
         session={@session}
         return_to={@self_path}
-        insert_image_metadata={@insert_image_metadata}
+        insert_image_metadata={@action_assigns.insert_image_metadata}
       />
     </.modal>
 
@@ -204,7 +204,7 @@ defmodule LivebookWeb.SessionLive.Render do
         id="insert-file"
         session={@session}
         return_to={@self_path}
-        insert_file_metadata={@insert_file_metadata}
+        insert_file_metadata={@action_assigns.insert_file_metadata}
       />
     </.modal>
 
@@ -223,8 +223,8 @@ defmodule LivebookWeb.SessionLive.Render do
         module={LivebookWeb.SessionLive.ExportComponent}
         id="export"
         session={@session}
-        tab={@tab}
-        any_stale_cell?={@any_stale_cell?}
+        tab={@action_assigns.tab}
+        any_stale_cell?={@action_assigns.any_stale_cell?}
       />
     </.modal>
 
@@ -248,7 +248,7 @@ defmodule LivebookWeb.SessionLive.Render do
       :if={@live_action == :secrets}
       id="secrets-modal"
       show
-      width={if(@select_secret_ref, do: :large, else: :medium)}
+      width={if(@action_assigns.select_secret_metadata, do: :large, else: :medium)}
       patch={@self_path}
     >
       <.live_component
@@ -258,9 +258,7 @@ defmodule LivebookWeb.SessionLive.Render do
         secrets={@data_view.secrets}
         hub_secrets={@data_view.hub_secrets}
         hub={@data_view.hub}
-        prefill_secret_name={@prefill_secret_name}
-        select_secret_ref={@select_secret_ref}
-        select_secret_options={@select_secret_options}
+        select_secret_metadata={@action_assigns.select_secret_metadata}
         return_to={@self_path}
       />
     </.modal>

--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -142,7 +142,7 @@ defmodule LivebookWeb.SessionLive.Render do
         module={LivebookWeb.SessionLive.RenameFileEntryComponent}
         id="rename-file-entry"
         session={@session}
-        file_entry={@renaming_file_entry}
+        file_entry={@action_assigns.renaming_file_entry}
       />
     </.modal>
 
@@ -259,6 +259,7 @@ defmodule LivebookWeb.SessionLive.Render do
         hub_secrets={@data_view.hub_secrets}
         hub={@data_view.hub}
         select_secret_metadata={@action_assigns.select_secret_metadata}
+        prefill_secret_name={@action_assigns.prefill_secret_name}
         return_to={@self_path}
       />
     </.modal>

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -15,7 +15,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
   def update(assigns, socket) do
     socket = assign(socket, assigns)
 
-    secret_name = socket.assigns.select_secret_metadata[:preselect_name]
+    secret_name = socket.assigns.prefill_secret_name
 
     socket =
       socket
@@ -62,7 +62,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
                 secret_name={secret.name}
                 hub?={false}
                 stored="Session"
-                active={secret.name == @select_secret_metadata.preselect_name}
+                active={secret.name == @prefill_secret_name}
                 target={@myself}
               />
               <.secret_with_badge
@@ -71,7 +71,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
                 hub?={true}
                 stored={hub_label(@hub)}
                 active={
-                  secret.name == @select_secret_metadata.preselect_name and
+                  secret.name == @prefill_secret_name and
                     Session.Data.secret_toggled?(secret, @secrets)
                 }
                 target={@myself}
@@ -104,7 +104,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
             <.text_field
               field={f[:name]}
               label="Name (alphanumeric and underscore)"
-              autofocus={@select_secret_metadata[:preselect_name] == nil}
+              autofocus={@prefill_secret_name == nil}
               spellcheck="false"
               autocomplete="off"
               phx-debounce
@@ -113,7 +113,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
             <.password_field
               field={f[:value]}
               label="Value"
-              autofocus={@select_secret_metadata[:preselect_name] != nil}
+              autofocus={@prefill_secret_name != nil}
               spellcheck="false"
               autocomplete="off"
               phx-debounce

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -15,7 +15,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
   def update(assigns, socket) do
     socket = assign(socket, assigns)
 
-    secret_name = socket.assigns[:prefill_secret_name]
+    secret_name = socket.assigns.select_secret_metadata[:preselect_name]
 
     socket =
       socket
@@ -48,7 +48,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
         hub={@hub}
       />
       <div class="flex flex-columns gap-4">
-        <div :if={@select_secret_ref} class="basis-1/2 grow-0 pr-4 border-r">
+        <div :if={@select_secret_metadata} class="basis-1/2 grow-0 pr-4 border-r">
           <div class="flex flex-col space-y-4">
             <p class="text-gray-800">
               Choose a secret
@@ -62,7 +62,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
                 secret_name={secret.name}
                 hub?={false}
                 stored="Session"
-                active={secret.name == @prefill_secret_name}
+                active={secret.name == @select_secret_metadata.preselect_name}
                 target={@myself}
               />
               <.secret_with_badge
@@ -71,7 +71,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
                 hub?={true}
                 stored={hub_label(@hub)}
                 active={
-                  secret.name == @prefill_secret_name and
+                  secret.name == @select_secret_metadata.preselect_name and
                     Session.Data.secret_toggled?(secret, @secrets)
                 }
                 target={@myself}
@@ -98,13 +98,13 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
           class="basis-1/2 grow"
         >
           <div class="flex flex-col space-y-4">
-            <p :if={@select_secret_ref} class="text-gray-700">
+            <p :if={@select_secret_metadata} class="text-gray-700">
               Add new secret
             </p>
             <.text_field
               field={f[:name]}
               label="Name (alphanumeric and underscore)"
-              autofocus={@prefill_secret_name == nil}
+              autofocus={@select_secret_metadata[:preselect_name] == nil}
               spellcheck="false"
               autocomplete="off"
               phx-debounce
@@ -113,7 +113,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
             <.password_field
               field={f[:value]}
               label="Value"
-              autofocus={@prefill_secret_name != nil}
+              autofocus={@select_secret_metadata[:preselect_name] != nil}
               spellcheck="false"
               autocomplete="off"
               phx-debounce
@@ -258,14 +258,17 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
      |> push_secret_selected(secret_name)}
   end
 
-  defp push_secret_selected(%{assigns: %{select_secret_ref: nil}} = socket, _), do: socket
+  defp push_secret_selected(%{assigns: %{select_secret_metadata: nil}} = socket, _), do: socket
 
-  defp push_secret_selected(%{assigns: %{select_secret_ref: ref}} = socket, secret_name) do
+  defp push_secret_selected(
+         %{assigns: %{select_secret_metadata: %{ref: ref}}} = socket,
+         secret_name
+       ) do
     push_event(socket, "secret_selected", %{select_secret_ref: ref, secret_name: secret_name})
   end
 
-  defp title(%{assigns: %{select_secret_ref: nil}}), do: "Add secret"
-  defp title(%{assigns: %{select_secret_options: %{"title" => title}}}), do: title
+  defp title(%{assigns: %{select_secret_metadata: nil}}), do: "Add secret"
+  defp title(%{assigns: %{select_secret_metadata: %{options: %{"title" => title}}}}), do: title
   defp title(_), do: "Select secret"
 
   defp set_secret(socket, %Secret{hub_id: nil} = secret) do


### PR DESCRIPTION
Whenever we need to assign something in `handle_params` we now put it in `action_assigns` and it is automatically cleared/overridden on a subsequent navigation. This means we don't keep unnecessary assigns around. This also simplifies some logic where we had to make sure old assigns are ignored if nor relevant.