### PR TITLE
Allow Web Bluetooth and Web Serial within iframes

### DIFF
--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -35,7 +35,7 @@ export function initializeIframeSource(iframe, iframePort, iframeUrl) {
     iframe.sandbox =
       "allow-scripts allow-same-origin allow-downloads allow-forms allow-modals allow-popups allow-top-navigation";
     iframe.allow =
-      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; fullscreen; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write";
+      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; fullscreen; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write; bluetooth; serial";
     iframe.src = url;
   });
 }


### PR DESCRIPTION
## What
Allow livebooks to use the Web Bluetooth and Web Serial APIs.
Previously discussed here: https://github.com/livebook-dev/livebook/discussions/1331

## How
Both Web Bluetooth and Web Serial are disallowed for cross origin iframes unless enabled in the iframe allow attribute. 

## Verification

Using the attached Livebook  before these changes and clicking the "Open Web Bluetooth Dialog" and "Open Web Serial Dialog" will result in `Permissions policy violation: bluetooth is not allowed in this document.` and `Permissions policy violation: serial is not allowed in this document` errors. 

After these changes the Web Bluetooth and Web Serial dialogs open as expected (in supported browsers). 

<img width="456" alt="image" src="https://github.com/livebook-dev/livebook/assets/620837/417b5734-4c04-4a6c-a70c-5264bf5dd612">

### Web BLE and Web Serial Livebook
# WebBluetooth & WebSerial

```elixir
Mix.install([
  {:kino, "~> 0.12.0"}
])
```

## Web Bluetooth

```elixir
defmodule WebBLE do
  use Kino.JS

  def web_ble() do
    Kino.JS.new(__MODULE__, "")
  end

  asset "main.js" do
    """
       export function init(ctx) {
        ctx.root.innerHTML = `
          <button id="bleButton">Open Web Bluetooth Dialog</button>
       `;

       var bleDialogButtonEl = document.getElementById("bleButton");
       
       bleDialogButtonEl.addEventListener("click", (_event) => {
         navigator.bluetooth.requestDevice({ acceptAllDevices: true});
       }); 
    }
    """
  end
end
```

```elixir
WebBLE.web_ble()
```

## Web Serial

```elixir
defmodule WebSerial do
  use Kino.JS

  def web_serial() do
    Kino.JS.new(__MODULE__, "")
  end

  asset "main.js" do
    """
       export function init(ctx) {
        ctx.root.innerHTML = `
          <button id="serialButton">Open Web Serial Dialog</button>
       `;

       var serialDialogButtonEl = document.getElementById("serialButton");
       
       serialDialogButtonEl.addEventListener("click", (_event) => {
         navigator.serial.requestPort({ acceptAllDevices: true});
       }); 
    }
    """
  end
end
```

```elixir
WebSerial.web_serial()
```




