### PR TITLE
Fix auth redirect with specific base url path

### DIFF
--- a/lib/livebook_web/controllers/auth_controller.ex
+++ b/lib/livebook_web/controllers/auth_controller.ex
@@ -65,7 +65,7 @@ defmodule LivebookWeb.AuthController do
         |> delete_session(:redirect_to)
         |> redirect(to: redirect_to)
       else
-        redirect(conn, to: "/")
+        redirect(conn, to: ~p"/")
       end
     end)
     |> halt()

--- a/lib/livebook_web/live/hub/edit_live.ex
+++ b/lib/livebook_web/live/hub/edit_live.ex
@@ -88,7 +88,7 @@ defmodule LivebookWeb.Hub.EditLive do
 
       socket
       |> put_flash(:success, "Hub deleted successfully")
-      |> push_navigate(to: "/")
+      |> push_navigate(to: ~p"/")
     end
 
     {:noreply,


### PR DESCRIPTION
Using a sub path on the url behind the reverse proxy (see old discussion on it #1540).
Some regression occured and the authentication success redirection did not take into account the sub path (always redirect to "/").
This PR fixes the issue.
Thanks!