### PR TITLE
Security focused alternative image

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ The following environment variables can be used to configure Livebook on boot:
     cluster. Must be "name" (long names) or "sname" (short names). Note that this
     sets RELEASE_DISTRIBUTION if present when creating a release. Defaults to "sname".
 
+  * `LIVEBOOK_FIPS` - if set to "true" will try to enable the FIPS mode on startup.
+    See more details in [the documentation](https://hexdocs.pm/livebook/fips.html).
+
   * `LIVEBOOK_FORCE_SSL_HOST` - sets a host to redirect to if the request is not over HTTPS.
     Note it does not apply when accessing Livebook via localhost. Defaults to nil.
 
@@ -284,9 +287,6 @@ The following environment variables can be used to configure Livebook on boot:
   * `LIVEBOOK_WITHIN_IFRAME` - controls if the application is running inside an
     iframe. Set it to "true" to enable it. If you do enable it, then the application
     must run with HTTPS.
-
-  * `LIVEBOOK_FIPS` - if set to "true" will try to enable the FIPS mode on startup.
-    See more details in [the documentation](https://hexdocs.pm/livebook/fips.html).
 
 <!-- Environment variables -->
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ The following environment variables can be used to configure Livebook on boot:
     iframe. Set it to "true" to enable it. If you do enable it, then the application
     must run with HTTPS.
 
+  * `LIVEBOOK_FIPS` - if set to "true" will try to enable the FIPS mode on startup.
+    See more details in [the documentation](https://hexdocs.pm/livebook/fips.html).
+
 <!-- Environment variables -->
 
 If running Livebook via the command line, run `livebook server --help` to see

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -2,7 +2,7 @@
 
 For environments that require security hardening you might need to turn on FIPS mode. Being able to turn on FIPS in general is a complex procedure, this just enables you to be able to turn FIPS on.
 
-To be able to turn on fips mode you will need to have an erlang distribution that has been compiled with [fips enabled](https://www.erlang.org/doc/apps/crypto/fips).
+To be able to turn on FIPS mode you will need to have an Erlang installation that has been compiled with [FIPS enabled](https://www.erlang.org/doc/apps/crypto/fips).
 
 
 ### Docker example

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -5,23 +5,9 @@ For environments that require security hardening you might need to turn on FIPS 
 To be able to turn on fips mode you will need to have an erlang distribution that has been compiled with [fips enabled](https://www.erlang.org/doc/apps/crypto/fips).
 
 
-### Error on startup
-
-```bash
-export LIVEBOOK_FIPS=true
-_build/prod/rel/livebook/bin/livebook start_iex 
-
-ERROR! Config provider Config.Reader failed with:
-** (RuntimeError) Requested FIPS mode via LIVEBOOK_FIPS, but this Erlang installation was compiled without FIPS support
-    (livebook 0.13.0-dev) lib/livebook.ex:242: Livebook.config_runtime/0
-        ...
-
-```
-
-This means that your elixir/erlang environmet was NOT compiled with FIPS enabled.
-
 ### Docker example
-To do this in docker, you will need to build it a little bit differently. You can see a mini example below. This should be considered psuedo code, you will want to adapt it to your needs. You should consider having a base image for the erlang/elixir portion with FIPS turned on and then overlay with a [multi stage build](https://docs.docker.com/build/building/multi-stage/).
+
+To do this in Docker, you will need to build it a little bit differently. Below is an example Dockerfile with FIPS-enabled Erlang/Elixir base image. You can use it as a base image for building Livebook. See the Livebook Dockerfile for further reference.
 
 
 ```docker

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -1,0 +1,99 @@
+# FIPS mode
+
+For environments that require security hardening you might need to turn on FIPS mode. Being able to turn on FIPS in general is a complex procedure, this just enables you to be able to turn FIPS on.
+
+To be able to turn on fips mode you will need to have an erlang distribution that has been compiled with [fips enabled](https://www.erlang.org/doc/apps/crypto/fips).
+
+
+### Error on startup
+
+```bash
+export LIVEBOOK_FIPS=true
+_build/prod/rel/livebook/bin/livebook start_iex 
+
+ERROR! Config provider Config.Reader failed with:
+** (RuntimeError) Could not set FIPS mode but was asked to
+    (livebook 0.13.0-dev) lib/livebook.ex:242: Livebook.config_runtime/0
+        ...
+
+```
+
+This means that your elixir/erlang environmet was NOT compiled with FIPS enabled.
+
+### Docker example
+To do this in docker, you will need to build it a little bit differently. You can see a full example below. This should be considered psuedo code, you will want to adapt it to your needs. You should consider having a base image for the erlang/elixir portion with FIPS turned on and then overlay with a [multi stage build](https://docs.docker.com/build/building/multi-stage/).
+
+
+```docker
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
+# Set environment variables for path and language
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin 
+
+# Install system dependencies and clean cache in one layer
+RUN microdnf install -y unzip autoconf git ncurses-devel openssl-devel gcc gcc-c++ make automake perl clang wget tar cmake glibc-locale-source glibc-langpack-en && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /install
+
+# Download, configure, and install Erlang/OTP with FIPS enabled
+ARG ERLANG_VERSION
+RUN wget https://github.com/erlang/otp/archive/OTP-${ERLANG_VERSION}.tar.gz && \
+    tar -xzvf OTP-${ERLANG_VERSION}.tar.gz && \
+    cd otp-OTP-${ERLANG_VERSION} && \
+    ./otp_build autoconf && \
+    ./configure --enable-fips && \
+    make && make install
+
+# Clone, checkout, and install Elixir
+ARG ELIXIR_VERSION
+RUN git clone https://github.com/elixir-lang/elixir.git && \
+    cd elixir && \
+    git checkout v${ELIXIR_VERSION} && \
+    make compile && \
+    make install
+
+WORKDIR /build_app
+
+# Install hex and rebar globally
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# Prepare application build directory
+COPY mix.exs mix.lock ./
+COPY config config
+
+# Get and compile dependencies
+RUN mix do deps.get, deps.compile
+
+# Copy application source code and compile
+COPY rel rel
+COPY static static
+COPY iframe/priv/static/iframe iframe/priv/static/iframe
+COPY proto proto
+COPY lib lib
+COPY README.md README.md
+ENV MIX_ENV=prod
+RUN mix do compile, release livebook
+
+# Prepare app directory
+RUN cp -R /build_app/_build/prod/rel/livebook /app && \
+    mkdir -p /data && \
+    chmod 777 /data && \
+    mkdir -p /home/livebook && \
+    chmod 777 /home/livebook && \
+    chown -R nobody:root /app /home/livebook /data
+# Switch to a non-root user
+USER nobody
+WORKDIR /home/livebook
+ENV LANG='en_US.UTF-8' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='en_US.UTF-8' \
+    ERL_FLAGS="+JMsingle true" \
+    LIVEBOOK_IP=0.0.0.0 \
+    LIVEBOOK_FIPS=true \
+    LIVEBOOK_HOME=/data \
+    HOME=/home/livebook    
+# Set command to start the application
+CMD ["/app/bin/livebook", "start"]
+```

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -1,14 +1,12 @@
 # FIPS mode
 
-For environments that require security hardening you might need to turn on FIPS mode. Being able to turn on FIPS in general is a complex procedure, this just enables you to be able to turn FIPS on.
+For environments that require security hardening, you might need to turn on FIPS ([Federal Information Processing Standards](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)) mode. Turning FIPS is a complex procedure, this just enables you to do it.
 
-To be able to turn on FIPS mode you will need to have an Erlang installation that has been compiled with [FIPS enabled](https://www.erlang.org/doc/apps/crypto/fips).
+You will need to have an Erlang installation that has been compiled with [FIPS enabled](https://www.erlang.org/doc/apps/crypto/fips).
 
+## Docker example
 
-### Docker example
-
-To do this in Docker, you will need to build it a little bit differently. Below is an example Dockerfile with FIPS-enabled Erlang/Elixir base image. You can use it as a base image for building Livebook. See the Livebook Dockerfile for further reference.
-
+To do this in Docker, you will need to build it differently. Below is an example Dockerfile with FIPS-enabled Erlang/Elixir base image. You can use it as a base image for building Livebook. See the Livebook Dockerfile for further reference.
 
 ```docker
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
@@ -38,5 +36,4 @@ RUN git clone https://github.com/elixir-lang/elixir.git && \
     git checkout v${ELIXIR_VERSION} && \
     make compile && \
     make install
-
 ```

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -238,7 +238,9 @@ defmodule Livebook do
       if :crypto.enable_fips_mode(true) do
         IO.puts("[Livebook] FIPS mode enabled")
       else
-        raise "Could not set FIPS mode but was asked to"
+        Livebook.Config.abort!(
+          "Requested FIPS mode via LIVEBOOK_FIPS, but this Erlang installation was compiled without FIPS support"
+        )
       end
     end
   end

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -233,6 +233,14 @@ defmodule Livebook do
     if agent_name = Livebook.Config.agent_name!("LIVEBOOK_AGENT_NAME") do
       config :livebook, :agent_name, agent_name
     end
+
+    if Livebook.Config.boolean!("LIVEBOOK_FIPS", false) do
+      if :crypto.enable_fips_mode(true) do
+        IO.puts("[Livebook] FIPS mode enabled")
+      else
+        raise "Could not set FIPS mode but was asked to"
+      end
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -220,6 +220,7 @@ defmodule Livebook.MixProject do
       "docs/use_cases.md",
       "docs/authentication.md",
       "docs/deployment/docker.md",
+      "docs/deployment/fips.md",
       "docs/deployment/basic_auth.md",
       "docs/deployment/cloudflare.md",
       "docs/deployment/google_iap.md",


### PR DESCRIPTION
[I finally had time to come back around to getting a hardened version.](https://github.com/livebook-dev/livebook/discussions/1879)

Let me know if we would like a different pattern, I tried to follow the conventions in place as best as possible. 

This enables a ubi8 image which [currently has 0 vulnerabilities](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&image=65cad19b3e4fe61cff409362&container-tabs=security)


![image](https://github.com/livebook-dev/livebook/assets/121582843/580e0a2d-e3e9-4a42-8bef-8f9190bb7de2)


* ubi8
* FIPS 
* User change


## ubi8

Use ubi8 instead of 9 since it is [still pending for FIPS](https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2)

Redhat universal base image allows for a maintained upstrean docker image with security in mind


## Fips mode

This does NOT mean that everything that is run here is "FIPS compliant" you still have to configure hackney/req/ssl/ etc to run in these modes, but I figured that was out of scope for this. These changes to the runtime are what is required to be able to enable the others.

### Startup fips mode

This introduces a `LIVEBOOK_FIPS` flag that will show a log and raise an error if there is an issue setting the mode.


## User Change

nobody as the user for the execution environment, by default allow for this.

## Possible improvements

Possible improvements I see:
* I do not see any pre built fips compliant images to build the binaries so I put it into the docker itself. 
* Maybe some more documentation around:
  * giving example on how to extend this alternative image for adding system packages
  * using a fips compliant live books
  * how to create dedicated livebook pre built images
