### PR TITLE
Set evaluation file when autosaving to default location

### DIFF
--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -2438,7 +2438,7 @@ defmodule Livebook.Session do
 
   defp start_evaluation(state, cell, section) do
     path =
-      case state.data.file do
+      case state.data.file || default_notebook_file(state) do
         nil -> ""
         file -> file.path
       end


### PR DESCRIPTION
When no explicit file is selected then we don't set evaluation file and `__DIR__` resolves to `"."`. I believe it's a better behaviour to always set the file when we are saving, even if the location is not explicit. If someone relies on `__DIR__` to save files, it's not intuitive that in such case it's going to end up in CWD, and the user can always use `File.cwd!` if that's what they want.