### PR TITLE
Monitor clients presence in the runtime

### DIFF
--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -746,6 +746,23 @@ defprotocol Livebook.Runtime do
   """
   @type transient_state :: %{atom() => term()}
 
+  @typedoc """
+  An identifier representing a client process.
+
+  A client is a connected user that interacts with the runtime outputs.
+  """
+  @type client_id :: String.t()
+
+  @typedoc """
+  User information about a particular client.
+  """
+  @type user_info :: %{
+          id: String.t(),
+          name: String.t() | nil,
+          email: String.t() | nil,
+          source: atom()
+        }
+
   @doc """
   Returns relevant information about the runtime.
 
@@ -1072,4 +1089,16 @@ defprotocol Livebook.Runtime do
   """
   @spec restore_transient_state(t(), transient_state()) :: :ok
   def restore_transient_state(runtime, transient_state)
+
+  @doc """
+  Notifies the runtime about connected clients.
+  """
+  @spec register_clients(t(), list({client_id(), user_info()})) :: :ok
+  def register_clients(runtime, clients)
+
+  @doc """
+  Notifies the runtime about clients leaving.
+  """
+  @spec unregister_clients(t(), list(client_id())) :: :ok
+  def unregister_clients(runtime, client_ids)
 end

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -196,4 +196,12 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
   def restore_transient_state(runtime, transient_state) do
     RuntimeServer.restore_transient_state(runtime.server_pid, transient_state)
   end
+
+  def register_clients(runtime, clients) do
+    RuntimeServer.register_clients(runtime.server_pid, clients)
+  end
+
+  def unregister_clients(runtime, client_ids) do
+    RuntimeServer.unregister_clients(runtime.server_pid, client_ids)
+  end
 end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -194,4 +194,12 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
   def restore_transient_state(runtime, transient_state) do
     RuntimeServer.restore_transient_state(runtime.server_pid, transient_state)
   end
+
+  def register_clients(runtime, clients) do
+    RuntimeServer.register_clients(runtime.server_pid, clients)
+  end
+
+  def unregister_clients(runtime, client_ids) do
+    RuntimeServer.unregister_clients(runtime.server_pid, client_ids)
+  end
 end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -163,6 +163,14 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
     RuntimeServer.restore_transient_state(runtime.server_pid, transient_state)
   end
 
+  def register_clients(runtime, clients) do
+    RuntimeServer.register_clients(runtime.server_pid, clients)
+  end
+
+  def unregister_clients(runtime, client_ids) do
+    RuntimeServer.unregister_clients(runtime.server_pid, client_ids)
+  end
+
   defp config() do
     Application.get_env(:livebook, Livebook.Runtime.Embedded, [])
   end

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -27,6 +27,7 @@ defmodule Livebook.Runtime.ErlDist do
       Livebook.Runtime.Evaluator.IOProxy,
       Livebook.Runtime.Evaluator.Tracer,
       Livebook.Runtime.Evaluator.ObjectTracker,
+      Livebook.Runtime.Evaluator.ClientTracker,
       Livebook.Runtime.Evaluator.Formatter,
       Livebook.Runtime.Evaluator.Doctests,
       Livebook.Intellisense,

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -28,6 +28,7 @@ defmodule Livebook.Runtime.Evaluator do
           send_to: pid(),
           runtime_broadcast_to: pid(),
           object_tracker: pid(),
+          client_tracker: pid(),
           contexts: %{ref() => context()},
           initial_context: context(),
           initial_context_version: nil | (md5 :: binary()),
@@ -73,6 +74,9 @@ defmodule Livebook.Runtime.Evaluator do
     * `:send_to` - the process to send evaluation messages to. Required
 
     * `:object_tracker` - a pid of `Livebook.Runtime.Evaluator.ObjectTracker`.
+      Required
+
+    * `:client_tracker` - a pid of `Livebook.Runtime.Evaluator.ClientTracker`.
       Required
 
     * `:runtime_broadcast_to` - the process to send runtime broadcast
@@ -266,6 +270,7 @@ defmodule Livebook.Runtime.Evaluator do
     send_to = Keyword.fetch!(opts, :send_to)
     runtime_broadcast_to = Keyword.get(opts, :runtime_broadcast_to, send_to)
     object_tracker = Keyword.fetch!(opts, :object_tracker)
+    client_tracker = Keyword.fetch!(opts, :client_tracker)
     ebin_path = Keyword.get(opts, :ebin_path)
     tmp_dir = Keyword.get(opts, :tmp_dir)
     io_proxy_registry = Keyword.get(opts, :io_proxy_registry)
@@ -276,6 +281,7 @@ defmodule Livebook.Runtime.Evaluator do
         send_to,
         runtime_broadcast_to,
         object_tracker,
+        client_tracker,
         ebin_path,
         tmp_dir,
         io_proxy_registry
@@ -309,6 +315,7 @@ defmodule Livebook.Runtime.Evaluator do
       send_to: send_to,
       runtime_broadcast_to: runtime_broadcast_to,
       object_tracker: object_tracker,
+      client_tracker: client_tracker,
       contexts: %{},
       initial_context: context,
       initial_context_version: nil,

--- a/lib/livebook/runtime/evaluator/client_tracker.ex
+++ b/lib/livebook/runtime/evaluator/client_tracker.ex
@@ -61,10 +61,7 @@ defmodule Livebook.Runtime.Evaluator.ClientTracker do
       send(pid, {:client_leave, client_id})
     end
 
-    state =
-      update_in(state.clients, fn clients ->
-        Enum.reduce(client_ids, clients, &Map.delete(&2, &1))
-      end)
+    state = update_in(state.clients, &Map.drop(&1, client_ids))
 
     {:noreply, state}
   end

--- a/lib/livebook/runtime/evaluator/client_tracker.ex
+++ b/lib/livebook/runtime/evaluator/client_tracker.ex
@@ -1,0 +1,88 @@
+defmodule Livebook.Runtime.Evaluator.ClientTracker do
+  # Keeps track of connected clients as reported to the runtime by the
+  # owner.
+  #
+  # Sends events to processes monitoring clients presence.
+
+  use GenServer
+
+  alias Livebook.Runtime
+
+  @doc """
+  Starts a new client tracker.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, {})
+  end
+
+  @doc """
+  Registeres new connected clients.
+  """
+  @spec register_clients(pid(), list({Runtime.client_id(), Runtime.user_info()})) :: :ok
+  def register_clients(client_tracker, clients) do
+    GenServer.cast(client_tracker, {:register_clients, clients})
+  end
+
+  @doc """
+  Unregisteres connected clients.
+  """
+  @spec unregister_clients(pid(), list(Runtime.client_id())) :: :ok
+  def unregister_clients(client_tracker, client_ids) do
+    GenServer.cast(client_tracker, {:unregister_clients, client_ids})
+  end
+
+  @doc """
+  Subscribes the given process to client presence events.
+  """
+  @spec monitor_clients(pid(), pid) :: :ok
+  def monitor_clients(client_tracker, pid) do
+    GenServer.cast(client_tracker, {:monitor_clients, pid})
+  end
+
+  @impl true
+  def init({}) do
+    {:ok, %{clients: %{}, subscribers: MapSet.new()}}
+  end
+
+  @impl true
+  def handle_cast({:register_clients, clients}, state) do
+    for {client_id, _user_info} <- clients, pid <- state.subscribers do
+      send(pid, {:client_join, client_id})
+    end
+
+    state = update_in(state.clients, &Enum.into(clients, &1))
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:unregister_clients, client_ids}, state) do
+    for client_id <- client_ids, pid <- state.subscribers do
+      send(pid, {:client_leave, client_id})
+    end
+
+    state =
+      update_in(state.clients, fn clients ->
+        Enum.reduce(client_ids, clients, &Map.delete(&2, &1))
+      end)
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:monitor_clients, pid}, state) do
+    Process.monitor(pid)
+    state = update_in(state.subscribers, &MapSet.put(&1, pid))
+
+    for {client_id, _user_info} <- state.clients do
+      send(pid, {:client_join, client_id})
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    state = update_in(state.subscribers, &MapSet.delete(&1, pid))
+    {:noreply, state}
+  end
+end

--- a/test/livebook/runtime/evaluator/client_tracker_test.exs
+++ b/test/livebook/runtime/evaluator/client_tracker_test.exs
@@ -1,0 +1,52 @@
+defmodule Livebook.Runtime.Evaluator.ClientTrackerTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Runtime.Evaluator.ClientTracker
+
+  setup do
+    {:ok, client_tracker} = start_supervised(ClientTracker)
+    %{client_tracker: client_tracker}
+  end
+
+  test "sends client joins to monitoring processes", %{client_tracker: client_tracker} do
+    ClientTracker.monitor_clients(client_tracker, self())
+
+    clients = [{"c1", user_info()}, {"c2", user_info()}]
+    ClientTracker.register_clients(client_tracker, clients)
+
+    assert_receive {:client_join, "c1"}
+    assert_receive {:client_join, "c2"}
+  end
+
+  test "sends client leaves to monitoring processes", %{client_tracker: client_tracker} do
+    ClientTracker.monitor_clients(client_tracker, self())
+
+    clients = [{"c1", user_info()}, {"c2", user_info()}]
+    ClientTracker.register_clients(client_tracker, clients)
+
+    ClientTracker.unregister_clients(client_tracker, ["c1"])
+    assert_receive {:client_leave, "c1"}
+
+    ClientTracker.unregister_clients(client_tracker, ["c2"])
+    assert_receive {:client_leave, "c2"}
+  end
+
+  test "sends existing client joins when monitoring starts", %{client_tracker: client_tracker} do
+    clients = [{"c1", user_info()}, {"c2", user_info()}]
+    ClientTracker.register_clients(client_tracker, clients)
+
+    ClientTracker.monitor_clients(client_tracker, self())
+
+    assert_receive {:client_join, "c1"}
+    assert_receive {:client_join, "c2"}
+  end
+
+  defp user_info() do
+    %{
+      id: "u1",
+      name: "Jake Peralta",
+      email: nil,
+      source: :session
+    }
+  end
+end

--- a/test/livebook/runtime/evaluator/io_proxy_test.exs
+++ b/test/livebook/runtime/evaluator/io_proxy_test.exs
@@ -8,9 +8,13 @@ defmodule Livebook.Runtime.Evaluator.IOProxyTest do
 
   setup do
     {:ok, object_tracker} = start_supervised(Evaluator.ObjectTracker)
+    {:ok, client_tracker} = start_supervised(Evaluator.ClientTracker)
 
     {:ok, _pid, evaluator} =
-      start_supervised({Evaluator, [send_to: self(), object_tracker: object_tracker]})
+      start_supervised(
+        {Evaluator,
+         [send_to: self(), object_tracker: object_tracker, client_tracker: client_tracker]}
+      )
 
     io = Process.info(evaluator.pid)[:group_leader]
     IOProxy.before_evaluation(io, :ref, "cell")

--- a/test/livebook/runtime/evaluator/object_tracker_test.exs
+++ b/test/livebook/runtime/evaluator/object_tracker_test.exs
@@ -1,4 +1,4 @@
-defmodule Livebook.Runtime.Evaluator.ObjecTrackerTest do
+defmodule Livebook.Runtime.Evaluator.ObjectTrackerTest do
   use ExUnit.Case, async: true
 
   alias Livebook.Runtime.Evaluator.ObjectTracker

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -17,13 +17,23 @@ defmodule Livebook.Runtime.EvaluatorTest do
       end
 
     {:ok, object_tracker} = start_supervised(Evaluator.ObjectTracker)
+    {:ok, client_tracker} = start_supervised(Evaluator.ClientTracker)
 
-    {:ok, _pid, evaluator} =
-      start_supervised(
-        {Evaluator, [send_to: self(), object_tracker: object_tracker, ebin_path: ebin_path]}
-      )
+    opts = [
+      send_to: self(),
+      object_tracker: object_tracker,
+      client_tracker: client_tracker,
+      ebin_path: ebin_path
+    ]
 
-    %{evaluator: evaluator, object_tracker: object_tracker, ebin_path: ebin_path}
+    {:ok, _pid, evaluator} = start_supervised({Evaluator, opts})
+
+    %{
+      evaluator: evaluator,
+      object_tracker: object_tracker,
+      client_tracker: client_tracker,
+      ebin_path: ebin_path
+    }
   end
 
   defmacrop metadata do
@@ -1188,11 +1198,9 @@ defmodule Livebook.Runtime.EvaluatorTest do
   end
 
   describe "initialize_from/3" do
-    setup %{object_tracker: object_tracker} do
-      {:ok, _pid, parent_evaluator} =
-        start_supervised({Evaluator, [send_to: self(), object_tracker: object_tracker]},
-          id: :parent_evaluator
-        )
+    setup %{object_tracker: object_tracker, client_tracker: client_tracker} do
+      opts = [send_to: self(), object_tracker: object_tracker, client_tracker: client_tracker]
+      {:ok, _pid, parent_evaluator} = start_supervised({Evaluator, opts}, id: :parent_evaluator)
 
       %{parent_evaluator: parent_evaluator}
     end

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -71,6 +71,9 @@ defmodule Livebook.Runtime.NoopRuntime do
       :ok
     end
 
+    def register_clients(_, _), do: :ok
+    def unregister_clients(_, _), do: :ok
+
     defp trace(runtime, fun, args) do
       if runtime.trace_to do
         send(runtime.trace_to, {:runtime_trace, fun, args})


### PR DESCRIPTION
Mirrors connected client from session to the runtime, and allows processes to monitor presence events. We plan to use this in Kino.