### PR TITLE
Fix invalid cookie naming - cookie names can't contain `:`

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -143,9 +143,9 @@ if (hasCookiesAccess()) {
 }
 
 function hasCookiesAccess() {
-  document.cookie = `lb:probe_cookie=;path=/${cookieOptions()}`;
+  document.cookie = `lb_probe_cookie=;path=/${cookieOptions()}`;
 
   return document.cookie
     .split("; ")
-    .some((cookie) => cookie.startsWith(`lb:probe_cookie=`));
+    .some((cookie) => cookie.startsWith(`lb_probe_cookie=`));
 }

--- a/assets/js/lib/user.js
+++ b/assets/js/lib/user.js
@@ -1,9 +1,9 @@
 import { cookieOptions, decodeBase64, encodeBase64 } from "./utils";
 
-const USER_DATA_COOKIE = "lb:user_data";
+const USER_DATA_COOKIE = "lb_user_data";
 
 /**
- * Stores user data in the `"lb:user_data"` cookie.
+ * Stores user data in the `"lb_user_data"` cookie.
  */
 export function storeUserData(userData) {
   const json = JSON.stringify(userData);
@@ -12,7 +12,7 @@ export function storeUserData(userData) {
 }
 
 /**
- * Loads user data from the `"lb:user_data"` cookie.
+ * Loads user data from the `"lb_user_data"` cookie.
  */
 export function loadUserData() {
   const encoded = getCookieValue(USER_DATA_COOKIE);

--- a/lib/livebook_web/endpoint.ex
+++ b/lib/livebook_web/endpoint.ex
@@ -6,7 +6,7 @@ defmodule LivebookWeb.Endpoint do
   # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
     store: :cookie,
-    key: "lb:session",
+    key: "lb_session",
     signing_salt: "deadbook"
   ]
 
@@ -126,7 +126,7 @@ defmodule LivebookWeb.Endpoint do
 
     if cookie_size > 24576 do
       conn.cookies
-      |> Enum.reject(fn {key, _value} -> String.starts_with?(key, "lb:") end)
+      |> Enum.reject(fn {key, _value} -> String.starts_with?(key, "lb_") end)
       |> Enum.take(10)
       |> Enum.reduce(conn, fn {key, _value}, conn ->
         Plug.Conn.delete_resp_cookie(conn, key)

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -48,7 +48,7 @@ defmodule LivebookWeb.UserPlug do
   defp ensure_user_data(conn) when conn.halted, do: conn
 
   defp ensure_user_data(conn) do
-    if Map.has_key?(conn.req_cookies, "lb:user_data") do
+    if Map.has_key?(conn.req_cookies, "lb_user_data") do
       conn
     else
       identity_data = get_session(conn, :identity_data)
@@ -58,7 +58,7 @@ defmodule LivebookWeb.UserPlug do
       # We disable HttpOnly, so that it can be accessed on the client
       # and set expiration to 5 years
       opts = [http_only: false, max_age: 157_680_000] ++ LivebookWeb.Endpoint.cookie_options()
-      put_resp_cookie(conn, "lb:user_data", encoded, opts)
+      put_resp_cookie(conn, "lb_user_data", encoded, opts)
     end
   end
 
@@ -74,7 +74,7 @@ defmodule LivebookWeb.UserPlug do
   defp mirror_user_data_in_session(conn) when conn.halted, do: conn
 
   defp mirror_user_data_in_session(conn) do
-    user_data = conn.cookies["lb:user_data"] |> Base.decode64!() |> Jason.decode!()
+    user_data = conn.cookies["lb_user_data"] |> Base.decode64!() |> Jason.decode!()
     put_session(conn, :user_data, user_data)
   end
 end

--- a/test/livebook_web/controllers/endpoint_test.exs
+++ b/test/livebook_web/controllers/endpoint_test.exs
@@ -4,7 +4,7 @@ defmodule LivebookWeb.EndpointTest do
   test "delete cookies once they go over a certain limit", %{conn: conn} do
     cookies =
       Enum.map(1..5, &"c#{&1}=#{String.duplicate("a", 4096)}") ++
-        Enum.map(1..5, &"lb:#{&1}=#{String.duplicate("a", 4096)}")
+        Enum.map(1..5, &"lb_#{&1}=#{String.duplicate("a", 4096)}")
 
     assert [
              "c1=;" <> _,
@@ -12,8 +12,8 @@ defmodule LivebookWeb.EndpointTest do
              "c3=;" <> _,
              "c4=;" <> _,
              "c5=;" <> _,
-             "lb:session" <> _,
-             "lb:user_data" <> _
+             "lb_session" <> _,
+             "lb_user_data" <> _
            ] =
              conn
              |> put_req_header("cookie", Enum.join(cookies, "; "))

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -38,7 +38,7 @@ defmodule LivebookWeb.UserPlugTest do
              "hex_color" => <<_::binary>>,
              "id" => <<_::binary>>,
              "name" => nil
-           } = conn.cookies["lb:user_data"] |> Base.decode64!() |> Jason.decode!()
+           } = conn.cookies["lb_user_data"] |> Base.decode64!() |> Jason.decode!()
   end
 
   test "keeps user_data cookie if present" do
@@ -48,10 +48,10 @@ defmodule LivebookWeb.UserPlugTest do
     conn =
       conn(:get, "/")
       |> init_test_session(%{})
-      |> put_req_cookie("lb:user_data", cookie_value)
+      |> put_req_cookie("lb_user_data", cookie_value)
       |> fetch_cookies()
       |> call()
 
-    assert conn.cookies["lb:user_data"] == cookie_value
+    assert conn.cookies["lb_user_data"] == cookie_value
   end
 end


### PR DESCRIPTION
Closes #2537

RFCs:
* http://tools.ietf.org/html/rfc6265#section-4.1.1
* http://tools.ietf.org/html/rfc2616#section-2.2
