### PR TITLE
Resolve user info requests coming from the runtime

### DIFF
--- a/lib/livebook/notebook/app_settings.ex
+++ b/lib/livebook/notebook/app_settings.ex
@@ -42,7 +42,7 @@ defmodule Livebook.Notebook.AppSettings do
       slug: nil,
       multi_session: false,
       zero_downtime: false,
-      show_existing_sessions: true,
+      show_existing_sessions: false,
       auto_shutdown_ms: nil,
       access_type: :protected,
       password: generate_password(),

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -1093,7 +1093,7 @@ defprotocol Livebook.Runtime do
   @doc """
   Notifies the runtime about connected clients.
   """
-  @spec register_clients(t(), list({client_id(), user_info()})) :: :ok
+  @spec register_clients(t(), list(client_id())) :: :ok
   def register_clients(runtime, clients)
 
   @doc """

--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -377,6 +377,11 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
     {{:ok, client_ids}, state}
   end
 
+  defp io_request({:livebook_get_user_info, client_id}, state) do
+    result = request_user_info(client_id, state)
+    {result, state}
+  end
+
   defp io_request(_, state) do
     {{:error, :request}, state}
   end
@@ -440,6 +445,13 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
   defp request_app_info(state) do
     request = {:runtime_app_info_request, self()}
     reply_tag = :runtime_app_info_reply
+
+    with {:ok, reply} <- runtime_request(state, request, reply_tag), do: reply
+  end
+
+  defp request_user_info(client_id, state) do
+    request = {:runtime_user_info_request, self(), client_id}
+    reply_tag = :runtime_user_info_reply
 
     with {:ok, reply} <- runtime_request(state, request, reply_tag), do: reply
   end

--- a/lib/livebook/runtime/evaluator/io_proxy.ex
+++ b/lib/livebook/runtime/evaluator/io_proxy.ex
@@ -373,8 +373,8 @@ defmodule Livebook.Runtime.Evaluator.IOProxy do
   end
 
   defp io_request({:livebook_monitor_clients, pid}, state) do
-    Evaluator.ClientTracker.monitor_clients(state.client_tracker, pid)
-    {:ok, state}
+    client_ids = Evaluator.ClientTracker.monitor_clients(state.client_tracker, pid)
+    {{:ok, client_ids}, state}
   end
 
   defp io_request(_, state) do

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -2085,13 +2085,8 @@ defmodule Livebook.Session do
       Runtime.restore_transient_state(runtime, state.data.runtime_transient_state)
     end
 
-    clients =
-      for {client_id, user_id} <- state.data.clients_map do
-        user = Map.fetch!(state.data.users_map, user_id)
-        {client_id, user_info(user)}
-      end
-
-    Runtime.register_clients(runtime, clients)
+    client_ids = Map.keys(state.data.clients_map)
+    Runtime.register_clients(runtime, client_ids)
 
     %{state | runtime_monitor_ref: runtime_monitor_ref}
   end
@@ -2207,7 +2202,7 @@ defmodule Livebook.Session do
     state = put_in(state.client_id_with_assets[client_id], %{})
 
     if Runtime.connected?(state.data.runtime) do
-      Runtime.register_clients(state.data.runtime, [{client_id, user_info(user)}])
+      Runtime.register_clients(state.data.runtime, [client_id])
     end
 
     app_report_client_count_change(state)

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -1645,6 +1645,24 @@ defmodule Livebook.Session do
     {:noreply, state}
   end
 
+  def handle_info({:runtime_user_info_request, reply_to, client_id}, state) do
+    reply =
+      cond do
+        not state.data.notebook.teams_enabled ->
+          {:error, :not_available}
+
+        user_id = state.data.clients_map[client_id] ->
+          user = Map.fetch!(state.data.users_map, user_id)
+          {:ok, user_info(user)}
+
+        true ->
+          {:error, :not_found}
+      end
+
+    send(reply_to, {:runtime_user_info_reply, reply})
+    {:noreply, state}
+  end
+
   def handle_info({:runtime_container_down, container_ref, message}, state) do
     broadcast_error(state.session_id, "evaluation process terminated - #{message}")
 

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1274,7 +1274,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
             | slug: "app",
               multi_session: true,
               zero_downtime: false,
-              show_existing_sessions: false,
+              show_existing_sessions: true,
               auto_shutdown_ms: 5_000,
               access_type: :public,
               show_source: true,
@@ -1283,7 +1283,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
       }
 
       expected_document = """
-      <!-- livebook:{"app_settings":{"access_type":"public","auto_shutdown_ms":5000,"multi_session":true,"output_type":"rich","show_existing_sessions":false,"show_source":true,"slug":"app"}} -->
+      <!-- livebook:{"app_settings":{"access_type":"public","auto_shutdown_ms":5000,"multi_session":true,"output_type":"rich","show_existing_sessions":true,"show_source":true,"slug":"app"}} -->
 
       # My Notebook
       """

--- a/test/livebook/runtime/erl_dist/runtime_server_test.exs
+++ b/test/livebook/runtime/erl_dist/runtime_server_test.exs
@@ -357,14 +357,12 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
       end
       """
 
-    clients = [{"c1", %{id: "u1", name: "Jake Peralta", email: nil, source: :session}}]
-    RuntimeServer.register_clients(pid, clients)
+    RuntimeServer.register_clients(pid, ["c1"])
 
     RuntimeServer.evaluate_code(pid, :elixir, code, {:c1, :e1}, [])
     assert_receive {:runtime_evaluation_response, :e1, _, %{evaluation_time_ms: _time_ms}}
 
-    clients = [{"c2", %{id: "u2", name: "Jake Peralta", email: nil, source: :session}}]
-    RuntimeServer.register_clients(pid, clients)
+    RuntimeServer.register_clients(pid, ["c2"])
     assert_receive {:client_join, "c2"}
 
     RuntimeServer.unregister_clients(pid, ["c1"])

--- a/test/livebook/runtime/erl_dist/runtime_server_test.exs
+++ b/test/livebook/runtime/erl_dist/runtime_server_test.exs
@@ -353,16 +353,19 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServerTest do
       send(Process.group_leader(), {:io_request, self(), ref, {:livebook_monitor_clients, pid}})
 
       receive do
-        {:io_reply, ^ref, :ok} -> :ok
+        {:io_reply, ^ref, {:ok, ["c1"]}} -> :ok
       end
       """
+
+    clients = [{"c1", %{id: "u1", name: "Jake Peralta", email: nil, source: :session}}]
+    RuntimeServer.register_clients(pid, clients)
 
     RuntimeServer.evaluate_code(pid, :elixir, code, {:c1, :e1}, [])
     assert_receive {:runtime_evaluation_response, :e1, _, %{evaluation_time_ms: _time_ms}}
 
-    clients = [{"c1", %{id: "u1", name: "Jake Peralta", email: nil, source: :session}}]
+    clients = [{"c2", %{id: "u2", name: "Jake Peralta", email: nil, source: :session}}]
     RuntimeServer.register_clients(pid, clients)
-    assert_receive {:client_join, "c1"}
+    assert_receive {:client_join, "c2"}
 
     RuntimeServer.unregister_clients(pid, ["c1"])
     assert_receive {:client_leave, "c1"}

--- a/test/livebook/runtime/evaluator/client_tracker_test.exs
+++ b/test/livebook/runtime/evaluator/client_tracker_test.exs
@@ -11,8 +11,7 @@ defmodule Livebook.Runtime.Evaluator.ClientTrackerTest do
   test "sends client joins to monitoring processes", %{client_tracker: client_tracker} do
     ClientTracker.monitor_clients(client_tracker, self())
 
-    clients = [{"c1", user_info()}, {"c2", user_info()}]
-    ClientTracker.register_clients(client_tracker, clients)
+    ClientTracker.register_clients(client_tracker, ["c1", "c2"])
 
     assert_receive {:client_join, "c1"}
     assert_receive {:client_join, "c2"}
@@ -21,8 +20,7 @@ defmodule Livebook.Runtime.Evaluator.ClientTrackerTest do
   test "sends client leaves to monitoring processes", %{client_tracker: client_tracker} do
     ClientTracker.monitor_clients(client_tracker, self())
 
-    clients = [{"c1", user_info()}, {"c2", user_info()}]
-    ClientTracker.register_clients(client_tracker, clients)
+    ClientTracker.register_clients(client_tracker, ["c1", "c2"])
 
     ClientTracker.unregister_clients(client_tracker, ["c1"])
     assert_receive {:client_leave, "c1"}
@@ -32,19 +30,9 @@ defmodule Livebook.Runtime.Evaluator.ClientTrackerTest do
   end
 
   test "returns existing client joins when monitoring starts", %{client_tracker: client_tracker} do
-    clients = [{"c1", user_info()}, {"c2", user_info()}]
-    ClientTracker.register_clients(client_tracker, clients)
+    ClientTracker.register_clients(client_tracker, ["c1", "c2"])
     ClientTracker.unregister_clients(client_tracker, ["c1"])
 
     assert ClientTracker.monitor_clients(client_tracker, self()) == ["c2"]
-  end
-
-  defp user_info() do
-    %{
-      id: "u1",
-      name: "Jake Peralta",
-      email: nil,
-      source: :session
-    }
   end
 end

--- a/test/livebook/runtime/evaluator/client_tracker_test.exs
+++ b/test/livebook/runtime/evaluator/client_tracker_test.exs
@@ -31,14 +31,12 @@ defmodule Livebook.Runtime.Evaluator.ClientTrackerTest do
     assert_receive {:client_leave, "c2"}
   end
 
-  test "sends existing client joins when monitoring starts", %{client_tracker: client_tracker} do
+  test "returns existing client joins when monitoring starts", %{client_tracker: client_tracker} do
     clients = [{"c1", user_info()}, {"c2", user_info()}]
     ClientTracker.register_clients(client_tracker, clients)
+    ClientTracker.unregister_clients(client_tracker, ["c1"])
 
-    ClientTracker.monitor_clients(client_tracker, self())
-
-    assert_receive {:client_join, "c1"}
-    assert_receive {:client_join, "c2"}
+    assert ClientTracker.monitor_clients(client_tracker, self()) == ["c2"]
   end
 
   defp user_info() do

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -28,7 +28,14 @@ defmodule LivebookWeb.AppLiveTest do
   describe "multi-session app" do
     test "renders a list of active app sessions", %{conn: conn} do
       slug = Utils.random_short_id()
-      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+
+      app_settings = %{
+        Notebook.AppSettings.new()
+        | slug: slug,
+          multi_session: true,
+          show_existing_sessions: true
+      }
+
       notebook = %{Notebook.new() | app_settings: app_settings}
 
       Apps.subscribe()


### PR DESCRIPTION
Adds support for getting user info from within the runtime (when requested by Kino), given a client id. The info is only available when using Livebook teams.

Also, changes default notebook app settings to not list multi-session app sessions.