### PR TITLE
Replace dev assets watcher with cross-platform one

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "//": "If you change the watch script here, remember to update it in /config/dev.exs as well.",
   "scripts": {
     "deploy": "node build.js --deploy",
     "watch": "node build.js --watch",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "//": "If you change the watch script here, remember to update it in /config/dev.exs as well.",
   "scripts": {
     "deploy": "node build.js --deploy",
     "watch": "node build.js --watch",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -18,7 +18,7 @@ config :livebook, LivebookWeb.Endpoint,
   debug_errors: true,
   check_origin: false,
   watchers: [
-    # Keep up to date with /assets/package.json, see discussion 2544.
+    # We invoke node rather than an npm task, so that it works on Windows
     node: ["build.js", "--watch", cd: Path.expand("../assets", __DIR__)]
   ]
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -18,7 +18,8 @@ config :livebook, LivebookWeb.Endpoint,
   debug_errors: true,
   check_origin: false,
   watchers: [
-    npm: ["run", "watch", cd: Path.expand("../assets", __DIR__)]
+    # Keep up to date with /assets/package.json, see discussion 2544.
+    node: ["build.js", "--watch", cd: Path.expand("../assets", __DIR__)]
   ]
 
 config :livebook,


### PR DESCRIPTION
Also added comments to make sure the two are linked by documentation now that they are no longer linked by function.

As suggested in https://github.com/livebook-dev/livebook/discussions/2544#discussioncomment-9043775

Edit: For posterity, I used [Phoenix's documentation](https://hexdocs.pm/phoenix/1.7.11/Phoenix.Endpoint.html#module-runtime-configuration) (the `:watchers` section) as a reference.