### PR TITLE
add `gg` and `G` vim motions to keyboard shortcuts

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -409,6 +409,10 @@ const Session = {
         this.moveFocusedCell(1);
       } else if (keyBuffer.tryMatch(["K"])) {
         this.moveFocusedCell(-1);
+      } else if (keyBuffer.tryMatch(["g", "g"])) {
+        this.moveFocusToTop();
+      } else if (keyBuffer.tryMatch(["G"])) {
+        this.moveFocusToBottom();
       } else if (keyBuffer.tryMatch(["n"])) {
         this.insertCellBelowFocused("code");
       } else if (keyBuffer.tryMatch(["N"])) {
@@ -959,6 +963,20 @@ const Session = {
   moveFocus(offset) {
     const focusableId = this.nearbyFocusableId(this.focusedId, offset);
     this.setFocusedEl(focusableId);
+  },
+
+  moveFocusToTop() {
+    const focusableIds = this.getFocusableIds();
+    if (focusableIds.length > 0) {
+      this.setFocusedEl(focusableIds[0]);
+    }
+  },
+
+  moveFocusToBottom() {
+    const focusableIds = this.getFocusableIds();
+    if (focusableIds.length > 0) {
+      this.setFocusedEl(focusableIds[focusableIds.length - 1]);
+    }
   },
 
   moveFocusedCell(offset) {

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -93,6 +93,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["M"], desc: "Insert Markdown cell above"},
       %{seq: ["c"], desc: "Expand/collapse section"},
       %{seq: ["C"], desc: "Expand/collapse all sections"},
+      %{seq: ["G"], desc: "Focus bottom cell"},
+      %{seq: ["g", "g"], desc: "Focus top cell"},
       %{seq: ["v", "z"], desc: "Toggle code zen view"},
       %{seq: ["v", "p"], desc: "Toggle presentation view"},
       %{seq: ["v", "c"], desc: "Toggle custom view"},


### PR DESCRIPTION
I added two basic vim motions to the keyboard shortcuts:

`g` `g`: move focus to top
`G`: move focus to bottom

A few thoughts:

1. I was unsure whether to add these to the help page. I did, though I placed them with the other multi-key commands as if I placed them next to the existing Focus commands the `g` `g` multi-key looked ugly in an otherwise single-key column.

*visually aligned*
<img width="341" alt="Visually aligned" src="https://github.com/livebook-dev/livebook/assets/11857814/e540c825-57c4-4883-b7a3-917672c8957e">

*topically placed, but visually poor?*
<img width="365" alt="Out of place?" src="https://github.com/livebook-dev/livebook/assets/11857814/931b12a0-ab4c-4cb9-8686-5fe197c1d8c4">

2. I debated whether to make `moveFocusToTop` shift focus to the title cell (idx 0), the setup cell (idx 1), or the first custom cell. I chose idx 0 as that seemed the plainest meaning of "shift focus to top".

3. I'm new to Livebook, so I don't know how practical or possible a motion like `5` `G` ("go to 5th cell") would be. I did not add anything in this regard, but would be happy to look into it if it would be a common motion.
