### PR TITLE
Rename Hubs to Workspaces

### DIFF
--- a/lib/livebook/file_system/file.ex
+++ b/lib/livebook/file_system/file.ex
@@ -387,7 +387,7 @@ defmodule Livebook.FileSystem.File do
     else
       {:error,
        "could not find file system (id: #{file_system_id}). This means that it has" <>
-         " been either detached or cannot be accessed from the Hub at the moment"}
+         " been either detached or cannot be accessed from the Workspace at the moment"}
     end
   end
 

--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -173,7 +173,7 @@ defmodule Livebook.Hubs do
           :ok
 
         {:error, reason} ->
-          Logger.error("Could not start Hub #{hub.id}: #{Exception.format_exit(reason)}")
+          Logger.error("Could not start Workspace #{hub.id}: #{Exception.format_exit(reason)}")
       end
     end
 

--- a/lib/livebook/hubs/dockerfile.ex
+++ b/lib/livebook/hubs/dockerfile.ex
@@ -367,7 +367,7 @@ defmodule Livebook.Hubs.Dockerfile do
       [
         if Livebook.Session.Data.session_secrets(secrets, hub.id) != [] do
           "The notebook uses session secrets, but those are not available to deployed apps." <>
-            " Convert them to Hub secrets instead."
+            " Convert them to Workspace secrets instead."
         end
       ] ++ config_warnings(config)
 
@@ -388,8 +388,8 @@ defmodule Livebook.Hubs.Dockerfile do
               %module{} = hd(used_hub_file_systems)
               name = LivebookWeb.FileSystemComponents.file_system_name(module)
 
-              "The #{name} file storage, defined in your personal hub, will not be available in the Docker image." <>
-                " You must either download all references as attachments or use Livebook Teams to automatically" <>
+              "The #{name} file storage, configured in your personal workspace, will not be available in the Docker image." <>
+                " You must either download all file references as file attachments or use Livebook Teams to automatically" <>
                 " encrypt and synchronize file storages across your team and deployments."
             end,
             if app_settings.access_type == :public do

--- a/lib/livebook/hubs/team.ex
+++ b/lib/livebook/hubs/team.ex
@@ -143,13 +143,13 @@ defimpl Livebook.Hubs.Provider, for: Livebook.Hubs.Team do
   def connection_status(team) do
     cond do
       team.offline ->
-        "You are running an offline Hub for deployment. You cannot modify its settings."
+        "You are running an offline Workspace for deployment. You cannot modify its settings."
 
       team.user_id == nil ->
-        "You are running a Livebook Agent instance with online Hub for deployment. You are in read-only mode."
+        "You are running a Livebook app server. This worksace is in read-only mode."
 
       reason = TeamClient.get_connection_status(team.id) ->
-        "Cannot connect to Hub: #{reason}.\nWill attempt to reconnect automatically..."
+        "Cannot connect to Teams: #{reason}.\nWill attempt to reconnect automatically..."
 
       true ->
         nil

--- a/lib/livebook/migration.ex
+++ b/lib/livebook/migration.ex
@@ -29,7 +29,7 @@ defmodule Livebook.Migration do
     unless Livebook.Hubs.hub_exists?(Livebook.Hubs.Personal.id()) do
       Livebook.Hubs.save_hub(%Livebook.Hubs.Personal{
         id: Livebook.Hubs.Personal.id(),
-        hub_name: "My Hub",
+        hub_name: "My Workspace",
         hub_emoji: "🏠",
         secret_key: Livebook.Hubs.Personal.generate_secret_key()
       })

--- a/lib/livebook_web/components/layout_components.ex
+++ b/lib/livebook_web/components/layout_components.ex
@@ -214,7 +214,7 @@ defmodule LivebookWeb.LayoutComponents do
     <div id="hubs" class="flex flex-col mt-12">
       <div class="space-y-3">
         <div class="grid grid-cols-1 md:grid-cols-2 relative leading-6 mb-2">
-          <small class="ml-5 font-medium text-gray-300 cursor-default">HUBS</small>
+          <small class="ml-5 font-medium text-gray-300 cursor-default">WORKSPACES</small>
         </div>
 
         <%= for hub <- @hubs do %>

--- a/lib/livebook_web/live/apps_dashboard_live.ex
+++ b/lib/livebook_web/live/apps_dashboard_live.ex
@@ -252,7 +252,7 @@ defmodule LivebookWeb.AppsDashboardLive do
       data-tooltip={
         ~S'''
         This is a permanent app started
-        from your Livebook Teams hub
+        deployed via Livebook Teams
         '''
       }
     >

--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -49,7 +49,7 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
           <LayoutComponents.title text={"#{@hub.hub_emoji} #{@hub.hub_name}"} />
 
           <p class="text-gray-700 text-sm">
-            Your personal hub. All data is stored on your machine and only you can access it.
+            Your personal workspace. All data is stored on your machine and only you can access it.
           </p>
         </div>
 

--- a/lib/livebook_web/live/hub/edit_live.ex
+++ b/lib/livebook_web/live/hub/edit_live.ex
@@ -19,7 +19,7 @@ defmodule LivebookWeb.Hub.EditLive do
        hub: nil,
        counter: 0,
        type: nil,
-       page_title: "Hub - Livebook",
+       page_title: "Workspace - Livebook",
        params: %{}
      )}
   end

--- a/lib/livebook_web/live/hub/new_live.ex
+++ b/lib/livebook_web/live/hub/new_live.ex
@@ -18,7 +18,7 @@ defmodule LivebookWeb.Hub.NewLive do
     socket =
       assign(socket,
         selected_option: "new-org",
-        page_title: "Hub - Livebook",
+        page_title: "Workspace - Livebook",
         requested_code: false,
         org: nil,
         verification_uri: nil,
@@ -285,7 +285,7 @@ defmodule LivebookWeb.Hub.NewLive do
 
         {:noreply,
          socket
-         |> put_flash(:success, "Hub added successfully")
+         |> put_flash(:success, "Workspace added successfully")
          |> push_navigate(to: ~p"/hub/#{hub.id}?show-key=confirm")}
 
       {:error, :expired} ->

--- a/lib/livebook_web/live/open_live/url_component.ex
+++ b/lib/livebook_web/live/open_live/url_component.ex
@@ -19,7 +19,7 @@ defmodule LivebookWeb.OpenLive.UrlComponent do
     |> Livebook.Utils.validate_url(:url)
     |> Livebook.Utils.validate_not_s3_url(
       :url,
-      ~s{invalid s3:// URL scheme, you must first connect to the Cloud Storage in your Hub page and then choose the relevant file in "From storage"}
+      ~s{invalid s3:// URL scheme, you must first connect to the Cloud Storage in your Workspace page and then choose the relevant file in "From storage"}
     )
   end
 

--- a/lib/livebook_web/live/session_live/add_file_entry_url_component.ex
+++ b/lib/livebook_web/live/session_live/add_file_entry_url_component.ex
@@ -18,7 +18,7 @@ defmodule LivebookWeb.SessionLive.AddFileEntryUrlComponent do
     |> Livebook.Utils.validate_url(:url)
     |> Livebook.Utils.validate_not_s3_url(
       :url,
-      ~s{invalid s3:// URL scheme, you must first connect to the Cloud Storage in your Hub page and then choose the relevant file in "From storage"}
+      ~s{invalid s3:// URL scheme, you must first connect to the Cloud Storage in your Workspace page and then choose the relevant file in "From storage"}
     )
   end
 

--- a/lib/livebook_web/live/session_live/app_docker_component.ex
+++ b/lib/livebook_web/live/session_live/app_docker_component.ex
@@ -122,7 +122,7 @@ defmodule LivebookWeb.SessionLive.AppDockerComponent do
 
       <div class="flex gap-12">
         <p class="text-gray-700">
-          <.label>Hub</.label>
+          <.label>Workspace</.label>
           <span>
             <span class="text-lg"><%= @hub.hub_emoji %></span>
             <span><%= @hub.hub_name %></span>

--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -31,7 +31,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
           <.message_box
             :if={@any_session_secrets?}
             kind={:warning}
-            message="The notebook uses session secrets, but those are not available to deployed apps. Convert them to Hub secrets instead."
+            message="The notebook uses session secrets, but those are not available to deployed apps. Convert them to Workspace secrets instead."
           />
 
           <div class="flex flex-col space-y-3">

--- a/lib/livebook_web/live/session_live/app_teams_component.ex
+++ b/lib/livebook_web/live/session_live/app_teams_component.ex
@@ -85,7 +85,7 @@ defmodule LivebookWeb.SessionLive.AppTeamsComponent do
 
       <div class="flex gap-12">
         <p class="text-gray-700">
-          <.label>Hub</.label>
+          <.label>Workspace</.label>
           <span>
             <span class="text-lg"><%= @hub.hub_emoji %></span>
             <span><%= @hub.hub_name %></span>

--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -1192,7 +1192,7 @@ defmodule LivebookWeb.SessionLive.Render do
                 class="inline-flex items-center cursor-pointer gap-1 mt-1 text-sm text-gray-600 hover:text-gray-800 focus:text-gray-800"
                 aria-label={@data_view.hub.hub_name}
               >
-                <span>in</span>
+                <span>workspace</span>
                 <span class="text-lg pl-1"><%= @data_view.hub.hub_emoji %></span>
                 <span><%= @data_view.hub.hub_name %></span>
                 <.remix_icon icon="arrow-down-s-line" />

--- a/test/livebook/hubs/dockerfile_test.exs
+++ b/test/livebook/hubs/dockerfile_test.exs
@@ -320,7 +320,7 @@ defmodule Livebook.Hubs.DockerfileTest do
                )
 
       assert warning =~
-               "The S3 file storage, defined in your personal hub, will not be available in the Docker image"
+               "The S3 file storage, configured in your personal workspace, will not be available in the Docker image"
     end
 
     test "warns when deploying a directory in personal hub and it has any file systems" do
@@ -335,7 +335,7 @@ defmodule Livebook.Hubs.DockerfileTest do
                Dockerfile.airgapped_warnings(config, hub, [], file_systems, app_settings, [], %{})
 
       assert warning =~
-               "The S3 file storage, defined in your personal hub, will not be available in the Docker image"
+               "The S3 file storage, configured in your personal workspace, will not be available in the Docker image"
     end
 
     test "warns when the app has no password in personal hub" do

--- a/test/livebook_teams/web/hub/new_live_test.exs
+++ b/test/livebook_teams/web/hub/new_live_test.exs
@@ -47,7 +47,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       # wait for the c:handle_info/2 cycle
       # check if the page redirected to edit hub page
       # and check the flash message
-      %{"success" => "Hub added successfully"} =
+      %{"success" => "Workspace added successfully"} =
         assert_redirect(
           view,
           "/hub/team-#{name}?show-key=confirm",
@@ -112,7 +112,7 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       # wait for the c:handle_info/2 cycle
       # check if the page redirected to edit hub page
       # and check the flash message
-      %{"success" => "Hub added successfully"} =
+      %{"success" => "Workspace added successfully"} =
         assert_redirect(
           view,
           "/hub/team-#{name}?show-key=confirm",

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -215,7 +215,7 @@ defmodule LivebookWeb.HomeLiveTest do
       team = Livebook.HubHelpers.offline_hub()
 
       {:ok, view, _} = live(conn, ~p"/")
-      assert render(view) =~ "HUBS"
+      assert render(view) =~ "WORKSPACES"
       assert render(view) =~ team.hub_name
       assert render(view) =~ "Add Organization"
     end

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -2239,7 +2239,7 @@ defmodule LivebookWeb.SessionLiveTest do
       {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}")
 
       assert render(view) =~
-               "The notebook uses session secrets, but those are not available to deployed apps. Convert them to Hub secrets instead."
+               "The notebook uses session secrets, but those are not available to deployed apps. Convert them to Workspace secrets instead."
     end
   end
 


### PR DESCRIPTION
I was talking to José, and I believe we should make a few nomenclature changes. This is probably the main one.

I talked to him, and he suggested only changing the text that is shown to the user instead of also changing the code. 