### PR TITLE
Change copy about the relationship of a notebook and secrets

### DIFF
--- a/lib/livebook_web/live/hub/edit/personal_component.ex
+++ b/lib/livebook_web/live/hub/edit/personal_component.ex
@@ -89,9 +89,8 @@ defmodule LivebookWeb.Hub.Edit.PersonalComponent do
             </h2>
 
             <p class="text-gray-700">
-              Secrets are a safe way to share credentials and tokens with notebooks.
-              They are often used by Smart cells and can be read as
-              environment variables using the <code>LB_</code> prefix.
+              Secrets are a safe way to allow notebooks to have access to
+              credentials and tokens.
             </p>
 
             <.live_component

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -162,10 +162,8 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
               </h2>
 
               <p class="text-gray-700">
-                Secrets are a safe way to share credentials and tokens with notebooks
-                across your whole team.
-                They are often used by Smart cells and can be read as
-                environment variables using the <code>LB_</code> prefix.
+                Secrets are a safe way to allow notebooks to have access to
+                credentials and tokens.
               </p>
 
               <.live_component

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -187,7 +187,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
       <div class="mx-auto">
         <div class="rounded-lg bg-blue-600 py-1 px-4 shadow-sm">
           <div class="flex flex-wrap items-center justify-between">
-            <div class="flex w-0 flex-1 items-center">
+            <div class="flex w-0 flex-1 items-center pr-1">
               <.remix_icon
                 icon="error-warning-fill"
                 class="align-middle text-2xl flex text-gray-100 rounded-lg py-2"
@@ -195,7 +195,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
               <span class="ml-2 text-sm font-normal text-gray-100">
                 There is a secret named
                 <span class="font-semibold text-white"><%= @secret.name %></span>
-                in <%= hub_label(@hub) %>. Allow this session to access it?
+                in the <%= hub_label(@hub) %> workspace. Allow this notebook to access it?
               </span>
             </div>
             <.button

--- a/lib/livebook_web/live/session_live/secrets_list_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_list_component.ex
@@ -47,7 +47,7 @@ defmodule LivebookWeb.SessionLive.SecretsListComponent do
             <%= if @hub_secrets == [] do %>
               No secrets stored in this hub so far
             <% else %>
-              Toggle to share with this session
+              Toggle to allow access to a secret
             <% end %>
           </span>
         </div>
@@ -195,10 +195,10 @@ defmodule LivebookWeb.SessionLive.SecretsListComponent do
       class="tooltip bottom-left"
       data-tooltip={
         ~S'''
-        Secrets are a safe way to share credentials
-        and tokens with notebooks. They are often
-        shared with Smart cells and can be read as
-        environment variables using the LB_ prefix.
+        Secrets are a safe way to allow notebooks
+        to have access to credentials and tokens.
+        Your notebook can read them as environment
+        variables using the LB_ prefix.
         '''
       }
     >


### PR DESCRIPTION
This PR is about changing how we communicate in the UI (and think) about the relationship (the verb part) of a secret and a notebook.

Instead of "sharing" a secret with a notebook, we "allow" a notebook to access a secret.

I thought about changing this because when I think of "share" in the context of software apps, I usually think of:

- sharing a google doc
- sharing a photo
- share a "resource" with someone else

And those "sharing" ideas don't  apply so well to the secrets <-> notebook relationship.

So, I started to think of a new name.

When I looked at the UI we have to "share" a secret with a notebook:

![CleanShot 2024-04-18 at 15 23 05](https://github.com/livebook-dev/livebook/assets/2719/6ea9e4ca-01bb-452d-b347-892a912a34d1)

It reminded me of the UI there in iOS to allow an installed app to access resources in your phone:

![CleanShot 2024-04-18 at 15 25 25](https://github.com/livebook-dev/livebook/assets/2719/b6a8536e-c6a6-4185-82cc-39ee6d9157d1)

So, I think we can use a similar metaphor from iOS.

A workspace contains secrets. We can allow a notebook to access those secrets instead of sharing secrets with a notebook.

In fact, we're already using that wording here:

![CleanShot 2024-04-18 at 15 26 49](https://github.com/livebook-dev/livebook/assets/2719/0dc345fa-0118-4845-a7fd-41d8c8bf2c31)

## UI after the proposed change

![CleanShot 2024-04-18 at 15 31 04](https://github.com/livebook-dev/livebook/assets/2719/2e0e1850-5f28-4193-b19d-a3ea5307f644)

![CleanShot 2024-04-18 at 15 32 08](https://github.com/livebook-dev/livebook/assets/2719/df5c558c-75c7-4417-83d7-77c9eab74483)

![CleanShot 2024-04-18 at 15 31 14](https://github.com/livebook-dev/livebook/assets/2719/d8eb2c4b-47e0-44e7-98d0-10523fc4dc8a)

![CleanShot 2024-04-18 at 15 36 07](https://github.com/livebook-dev/livebook/assets/2719/0d4f2a36-19c8-45d7-8122-9fb75ec9eecc)

