### PR TITLE
Amplify Output button increases vertical size

### DIFF
--- a/assets/js/lib/utils.js
+++ b/assets/js/lib/utils.js
@@ -241,6 +241,18 @@ export function findChildOrThrow(element, selector) {
   return child;
 }
 
+export function findClosestOrThrow(element, selector) {
+  const closest = element.closest(selector);
+
+  if (!closest) {
+    throw new Error(
+      `expected closest matching ${selector}, but none was found`,
+    );
+  }
+
+  return closest;
+}
+
 export function cancelEvent(event) {
   // Cancel any default browser behavior.
   event.preventDefault();

--- a/lib/livebook_web/live/output/terminal_text_component.ex
+++ b/lib/livebook_web/live/output/terminal_text_component.ex
@@ -64,6 +64,7 @@ defmodule LivebookWeb.Output.TerminalTextComponent do
       class="relative group/root"
       phx-hook="VirtualizedLines"
       data-p-max-height={hook_prop(300)}
+      data-p-max-height-amplified={hook_prop(600)}
       data-p-follow={hook_prop(true)}
       data-p-max-lines={hook_prop(Livebook.Notebook.max_terminal_lines())}
       data-p-ignore-trailing-empty-line={hook_prop(true)}


### PR DESCRIPTION
The existing "Amplify output" button increases horizontal size, but when returning a large data structure and/or sending a larger amount of data to stdout, the small vertical size is frustrating. Especially so on larger screen where there is more real estate to work with.

- increase vertical size too when "Amplify output" is clicked.
- regular size unchanged at 300px
- "Amplified" size at 600px

This preserves existing logic by keeping the amplify setting client side only, and not relying on state managed via the liveview process. It could be done that way, but kept it consistent with current implementation.


https://github.com/livebook-dev/livebook/assets/27223/8279a63d-8ae5-4bf3-9dc5-32d44db9ae42