### PR TITLE
Rename: title -> name

### DIFF
--- a/lib/livebook_web/live/session_live/app_teams_live.ex
+++ b/lib/livebook_web/live/session_live/app_teams_live.ex
@@ -343,7 +343,7 @@ defmodule LivebookWeb.SessionLive.AppTeamsLive do
     with {:ok, app_deployment} <- pack_app(socket),
          :ok <- deploy_app(socket, app_deployment) do
       message =
-        "App deployment for #{app_deployment.slug} with name #{app_deployment.title} created successfully."
+        "App deployment created successfully."
 
       {:noreply,
        socket

--- a/lib/livebook_web/live/session_live/app_teams_live.ex
+++ b/lib/livebook_web/live/session_live/app_teams_live.ex
@@ -343,7 +343,7 @@ defmodule LivebookWeb.SessionLive.AppTeamsLive do
     with {:ok, app_deployment} <- pack_app(socket),
          :ok <- deploy_app(socket, app_deployment) do
       message =
-        "App deployment for #{app_deployment.slug} with title #{app_deployment.title} created successfully."
+        "App deployment for #{app_deployment.slug} with name #{app_deployment.title} created successfully."
 
       {:noreply,
        socket

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -545,7 +545,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       |> render_click()
 
       assert render(view) =~
-               "App deployment for #{slug} with title Untitled notebook created successfully"
+               "App deployment for #{slug} with name Untitled notebook created successfully"
     end
 
     test "deployment flow with existing deployment groups in the hub",
@@ -608,7 +608,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       |> render_click()
 
       assert render(view) =~
-               "App deployment for #{slug} with title Untitled notebook created successfully"
+               "App deployment for #{slug} with name Untitled notebook created successfully"
     end
 
     test "shows an error when the deployment size is higher than the maximum size of 20MB",

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -545,7 +545,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       |> render_click()
 
       assert render(view) =~
-               "App deployment for #{slug} with name Untitled notebook created successfully"
+               "App deployment created successfully"
     end
 
     test "deployment flow with existing deployment groups in the hub",
@@ -608,7 +608,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       |> render_click()
 
       assert render(view) =~
-               "App deployment for #{slug} with name Untitled notebook created successfully"
+               "App deployment created successfully"
     end
 
     test "shows an error when the deployment size is higher than the maximum size of 20MB",


### PR DESCRIPTION
A Livebook app has a "name," although a Livebook notebook has a title:

![CleanShot 2024-05-14 at 13 57 56](https://github.com/livebook-dev/livebook/assets/2719/f74e8a42-616c-4d8f-bb6e-2a5899f6d0a8)

This change is in the message that is shown when a app is deployed:

![CleanShot 2024-05-14 at 13 58 56](https://github.com/livebook-dev/livebook/assets/2719/f78351ec-2ed3-4390-a996-a98212b396c2)
