### PR TITLE
Add setting to enable font ligatures in the code editor

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -277,7 +277,9 @@ export default class LiveEditor {
     });
 
     const ligaturesTheme = EditorView.theme({
-      "&": { fontVariantLigatures: `${settings.editor_ligatures}` },
+      "&": {
+        fontVariantLigatures: `${settings.editor_ligatures ? "normal" : "none"}`,
+      },
     });
 
     const lineWrappingEnabled =

--- a/assets/js/hooks/cell_editor/live_editor.js
+++ b/assets/js/hooks/cell_editor/live_editor.js
@@ -276,6 +276,10 @@ export default class LiveEditor {
       "&": { fontSize: `${settings.editor_font_size}px` },
     });
 
+    const ligaturesTheme = EditorView.theme({
+      "&": { fontVariantLigatures: `${settings.editor_ligatures}` },
+    });
+
     const lineWrappingEnabled =
       this.language === "markdown" && settings.editor_markdown_word_wrap;
 
@@ -319,6 +323,7 @@ export default class LiveEditor {
         EditorView.contentAttributes.of({ tabIndex: -1 }),
         fontSizeTheme,
         settings.editor_theme === "light" ? lightTheme : theme,
+        ligaturesTheme,
         collab(this.collabClient),
         collabMarkers(this.collabClient),
         autocompletion({

--- a/assets/js/hooks/cell_editor/live_editor/codemirror/theme.js
+++ b/assets/js/hooks/cell_editor/live_editor/codemirror/theme.js
@@ -20,7 +20,6 @@ function buildEditorTheme(colors, { dark }) {
         backgroundColor: colors.background,
         fontSize: "14px",
         fontFamily: fonts.mono,
-        fontVariantLigatures: "none",
       },
 
       "&.cm-focused": {

--- a/assets/js/hooks/editor_settings.js
+++ b/assets/js/hooks/editor_settings.js
@@ -1,4 +1,9 @@
-import { settingsStore, EDITOR_FONT_SIZE, EDITOR_THEME } from "../lib/settings";
+import {
+  settingsStore,
+  EDITOR_FONT_SIZE,
+  EDITOR_THEME,
+  EDITOR_LIGATURES,
+} from "../lib/settings";
 
 /**
  * A hook for the editor settings.
@@ -20,6 +25,9 @@ const EditorSettings = {
     const editorFontSizeCheckbox = this.el.querySelector(
       `[name="editor_font_size"][value="true"]`,
     );
+    const editorLigaturesCheckbox = this.el.querySelector(
+      `[name="editor_ligatures"][value="true"]`,
+    );
     const editorLightThemeCheckbox = this.el.querySelector(
       `[name="editor_light_theme"][value="true"]`,
     );
@@ -32,6 +40,8 @@ const EditorSettings = {
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
     editorFontSizeCheckbox.checked =
       settings.editor_font_size === EDITOR_FONT_SIZE.large ? true : false;
+    editorLigaturesCheckbox.checked =
+      settings.editor_ligatures === EDITOR_LIGATURES.on ? true : false;
     editorLightThemeCheckbox.checked =
       settings.editor_theme === EDITOR_THEME.light ? true : false;
     editorMarkdownWordWrapCheckbox.checked = settings.editor_markdown_word_wrap;
@@ -50,6 +60,14 @@ const EditorSettings = {
         editor_font_size: event.target.checked
           ? EDITOR_FONT_SIZE.large
           : EDITOR_FONT_SIZE.normal,
+      });
+    });
+
+    editorLigaturesCheckbox.addEventListener("change", (event) => {
+      settingsStore.update({
+        editor_ligatures: event.target.checked
+          ? EDITOR_LIGATURES.on
+          : EDITOR_LIGATURES.off,
       });
     });
 

--- a/assets/js/hooks/editor_settings.js
+++ b/assets/js/hooks/editor_settings.js
@@ -1,9 +1,4 @@
-import {
-  settingsStore,
-  EDITOR_FONT_SIZE,
-  EDITOR_THEME,
-  EDITOR_LIGATURES,
-} from "../lib/settings";
+import { settingsStore, EDITOR_FONT_SIZE, EDITOR_THEME } from "../lib/settings";
 
 /**
  * A hook for the editor settings.
@@ -40,8 +35,7 @@ const EditorSettings = {
     editorAutoSignatureCheckbox.checked = settings.editor_auto_signature;
     editorFontSizeCheckbox.checked =
       settings.editor_font_size === EDITOR_FONT_SIZE.large ? true : false;
-    editorLigaturesCheckbox.checked =
-      settings.editor_ligatures === EDITOR_LIGATURES.on ? true : false;
+    editorLigaturesCheckbox.checked = settings.editor_ligatures;
     editorLightThemeCheckbox.checked =
       settings.editor_theme === EDITOR_THEME.light ? true : false;
     editorMarkdownWordWrapCheckbox.checked = settings.editor_markdown_word_wrap;
@@ -64,11 +58,7 @@ const EditorSettings = {
     });
 
     editorLigaturesCheckbox.addEventListener("change", (event) => {
-      settingsStore.update({
-        editor_ligatures: event.target.checked
-          ? EDITOR_LIGATURES.on
-          : EDITOR_LIGATURES.off,
-      });
+      settingsStore.update({ editor_ligatures: event.target.checked });
     });
 
     editorLightThemeCheckbox.addEventListener("change", (event) => {

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -19,11 +19,17 @@ export const EDITOR_THEME = {
   light: "light",
 };
 
+export const EDITOR_LIGATURES = {
+  off: "none",
+  on: "normal",
+};
+
 const DEFAULTSETTINGS = {
   editor_auto_completion: true,
   editor_auto_signature: true,
   editor_font_size: EDITOR_FONT_SIZE.normal,
   editor_theme: EDITOR_THEME.default,
+  editor_ligatures: EDITOR_LIGATURES.off,
   editor_markdown_word_wrap: true,
   editor_mode: EDITOR_MODE.default,
   custom_view_show_section: true,

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -19,17 +19,12 @@ export const EDITOR_THEME = {
   light: "light",
 };
 
-export const EDITOR_LIGATURES = {
-  off: "none",
-  on: "normal",
-};
-
 const DEFAULTSETTINGS = {
   editor_auto_completion: true,
   editor_auto_signature: true,
   editor_font_size: EDITOR_FONT_SIZE.normal,
   editor_theme: EDITOR_THEME.default,
-  editor_ligatures: EDITOR_LIGATURES.off,
+  editor_ligatures: false,
   editor_markdown_word_wrap: true,
   editor_mode: EDITOR_MODE.default,
   custom_view_show_section: true,

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -156,6 +156,7 @@ defmodule LivebookWeb.SettingsLive do
                 value={false}
               />
               <.switch_field name="editor_font_size" label="Increase font size" value={false} />
+              <.switch_field name="editor_ligatures" label="Render ligatures" value={false} />
               <.switch_field name="editor_light_theme" label="Use light theme" value={false} />
               <.switch_field
                 name="editor_markdown_word_wrap"


### PR DESCRIPTION
As jetbrains-mono is used as the default font in the codemirror editor and this font has support for ligatures a new setting is added to enable rendering with ligatjures. 
The default for this setting is off so that the current behavior  is maintained.
![image](https://github.com/livebook-dev/livebook/assets/1789532/c9845a4a-8611-4dcd-aea8-c24453104365)
![image](https://github.com/livebook-dev/livebook/assets/1789532/61196867-e16c-4472-8118-ea84a6a989e7)
