### PR TITLE
WIP: feat: [#2498] Allow drag-n-drop in a notebook to upload to a particular storage

### DIFF
--- a/lib/livebook/file_system.ex
+++ b/lib/livebook/file_system.ex
@@ -23,7 +23,7 @@ defprotocol Livebook.FileSystem do
   Path has most of the semantics of regular file paths, with the
   following exceptions:
 
-    * path must be be absolute for consistency
+    * path must be absolute for consistency
 
     * directory path must have a trailing slash, whereas regular file
       path must not have a trailing slash. Rationale: certain file

--- a/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
+++ b/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
@@ -142,7 +142,9 @@ defmodule LivebookWeb.SessionLive.AddFileEntryUploadComponent do
 
           {:noreply, socket}
         else
-          # TODO  
+          # -- TODO  
+          # Option 1: Livebook.FileSystem.write(%Livebook.FileSystem.S3{}, "", false)
+          # Option 2: Livebook.FileSystem.S3.write(%Livebook.FileSystem.S3{}, path, content)
           IO.puts("Imma be stored in a global storage")
         end
 

--- a/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
+++ b/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
@@ -1,11 +1,11 @@
 defmodule LivebookWeb.SessionLive.AddFileEntryUploadComponent do
+  # TODO REMOVE BEFORE FLIGHT!!!!!!
+  """
+  TODO:
+  - add uploaded file in a sidebar "Files/references"
+  - validate radio (when user forgot to choose one of options)
+  """
 
-# TODO REMOVE BEFORE FLIGHT!!!!!!
-"""
-TODO:
-- add uploaded file in a sidebar "Files/references"
-- validate radio (when user forgot to choose one of options)
-"""
   use LivebookWeb, :live_component
 
   import Ecto.Changeset
@@ -74,7 +74,6 @@ TODO:
             options={[
               {"true", "Store in the notebook files as an attachment"},
               {"false", "Upload to storage and store link"}
-
             ]}
           />
         </div>
@@ -140,6 +139,7 @@ TODO:
 
           {:noreply, socket}
         else
+          # TODO  
           IO.puts("Imma be stored in a global storage")
         end
 

--- a/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
+++ b/lib/livebook_web/live/session_live/add_file_entry_upload_component.ex
@@ -70,7 +70,7 @@ defmodule LivebookWeb.SessionLive.AddFileEntryUploadComponent do
             phx-debounce="200"
           />
           <.radio_field
-            field={f[:storage_place]}
+            field={f[:store_local?]}
             options={[
               {"true", "Store in the notebook files as an attachment"},
               {"false", "Upload to storage and store link"}
@@ -130,6 +130,9 @@ defmodule LivebookWeb.SessionLive.AddFileEntryUploadComponent do
       {:ok, data} ->
         [:ok] =
           consume_uploaded_entries(socket, :file, fn %{}, _entry -> {:ok, :ok} end)
+
+        dbg(data.store_local?)
+        IO.inspect(data.store_local? |> is_boolean(), label: "is bool?")
 
         if data.store_local? do
           file_entry = %{name: data.name, type: :attachment}


### PR DESCRIPTION
This PR is for #2498 

TODO:
- add uploaded file's link in a sidebar "Files/references"
- validate radio (when user forgot to choose one of options)
- tests, u know

DoD:
- user can upload a file via drag-n-drop as an attached file into current notebook
- user can upload a file in "global" storage and find their file in a current notebook's "References"
