### PR TITLE
Add handling of URL fields in deployment groups

### DIFF
--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -375,7 +375,8 @@ defmodule Livebook.Hubs.TeamClient do
       agent_keys: agent_keys,
       clustering: nullify(deployment_group.clustering),
       zta_provider: atomize(deployment_group.zta_provider),
-      zta_key: nullify(deployment_group.zta_key)
+      zta_key: nullify(deployment_group.zta_key),
+      url: nullify(deployment_group.url)
     }
   end
 
@@ -391,7 +392,8 @@ defmodule Livebook.Hubs.TeamClient do
       agent_keys: agent_keys,
       clustering: nullify(deployment_group_created.clustering),
       zta_provider: atomize(deployment_group_created.zta_provider),
-      zta_key: nullify(deployment_group_created.zta_key)
+      zta_key: nullify(deployment_group_created.zta_key),
+      url: nullify(deployment_group_created.url)
     }
   end
 
@@ -407,7 +409,8 @@ defmodule Livebook.Hubs.TeamClient do
         agent_keys: agent_keys,
         clustering: atomize(deployment_group_updated.clustering),
         zta_provider: atomize(deployment_group_updated.zta_provider),
-        zta_key: nullify(deployment_group_updated.zta_key)
+        zta_key: nullify(deployment_group_updated.zta_key),
+        url: nullify(deployment_group_updated.url)
     }
   end
 

--- a/lib/livebook/teams/deployment_group.ex
+++ b/lib/livebook/teams/deployment_group.ex
@@ -15,6 +15,7 @@ defmodule Livebook.Teams.DeploymentGroup do
     field :clustering, Ecto.Enum, values: [:fly_io, :dns]
     field :zta_provider, Ecto.Enum, values: @zta_providers
     field :zta_key, :string
+    field :url, :string
 
     has_many :secrets, Secret
     has_many :agent_keys, AgentKey
@@ -23,7 +24,7 @@ defmodule Livebook.Teams.DeploymentGroup do
   def changeset(deployment_group, attrs \\ %{}) do
     changeset =
       deployment_group
-      |> cast(attrs, [:id, :name, :mode, :hub_id, :clustering, :zta_provider, :zta_key])
+      |> cast(attrs, [:id, :name, :mode, :hub_id, :clustering, :zta_provider, :zta_key, :url])
       |> validate_required([:name, :mode])
 
     if get_field(changeset, :zta_provider) do

--- a/lib/livebook/teams/deployment_group.ex
+++ b/lib/livebook/teams/deployment_group.ex
@@ -26,6 +26,17 @@ defmodule Livebook.Teams.DeploymentGroup do
       deployment_group
       |> cast(attrs, [:id, :name, :mode, :hub_id, :clustering, :zta_provider, :zta_key, :url])
       |> validate_required([:name, :mode])
+      |> update_change(:url, fn url ->
+        if url do
+          url
+          |> String.trim_leading("http://")
+          |> String.trim_leading("https://")
+          |> String.trim_trailing("/")
+        end
+      end)
+      |> validate_format(:url, ~r/(^[^\/\.\s]+(\.[^\/\.\s]+)+)(\/[^\s]+)?$/,
+        message: "must be a well-formed URL"
+      )
 
     if get_field(changeset, :zta_provider) do
       validate_required(changeset, [:zta_key])

--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -174,7 +174,8 @@ defmodule Livebook.Teams.Requests do
       mode: deployment_group.mode,
       clustering: deployment_group.clustering,
       zta_provider: deployment_group.zta_provider,
-      zta_key: deployment_group.zta_key
+      zta_key: deployment_group.zta_key,
+      url: deployment_group.url
     }
 
     post("/api/v1/org/deployment-groups", params, team)

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -93,7 +93,7 @@ defmodule LivebookWeb.AppComponents do
     ~H"""
     <div>
       <div class="flex flex-col">
-        <.text_field label="URL" field={@form[:url]} />
+        <.text_field label="URL" type="base_url" field={@form[:url]} />
         <.select_field
           label="Clustering"
           help={

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -93,7 +93,7 @@ defmodule LivebookWeb.AppComponents do
     ~H"""
     <div>
       <div class="flex flex-col gap-4">
-        <.text_field label="URL" type="base_url" field={@form[:url]}/>
+        <.text_field label="URL" type="base_url" field={@form[:url]} />
 
         <.select_field
           label="Clustering"

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -92,8 +92,9 @@ defmodule LivebookWeb.AppComponents do
   def deployment_group_form_content(assigns) do
     ~H"""
     <div>
-      <div class="flex flex-col">
-        <.text_field label="URL" type="base_url" field={@form[:url]} />
+      <div class="flex flex-col gap-4">
+        <.text_field label="URL" type="base_url" field={@form[:url]}/>
+
         <.select_field
           label="Clustering"
           help={

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -93,6 +93,7 @@ defmodule LivebookWeb.AppComponents do
     ~H"""
     <div>
       <div class="flex flex-col">
+        <.text_field label="URL" field={@form[:url]} />
         <.select_field
           label="Clustering"
           help={

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -93,7 +93,20 @@ defmodule LivebookWeb.AppComponents do
     ~H"""
     <div>
       <div class="flex flex-col gap-4">
-        <.text_field label="URL" type="base_url" field={@form[:url]} />
+        <.text_field
+          label="URL"
+          type="base_url"
+          help={
+            ~S'''
+            If you provide the URL you
+            will host your instances at,
+            Livebook will use it to
+            generate direct links
+            throughout its interface
+            '''
+          }
+          field={@form[:url]}
+        />
 
         <.select_field
           label="Clustering"

--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -93,9 +93,8 @@ defmodule LivebookWeb.AppComponents do
     ~H"""
     <div>
       <div class="flex flex-col gap-4">
-        <.text_field
+        <.schemaless_url_field
           label="URL"
-          type="base_url"
           help={
             ~S'''
             If you provide the URL you

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -20,6 +20,25 @@ defmodule LivebookWeb.FormComponents do
 
   attr :rest, :global, include: ~w(autocomplete readonly disabled step min max)
 
+  def text_field(%{type: "base_url"} = assigns) do
+    assigns = assigns_from_field(assigns)
+
+    ~H"""
+    <.field_wrapper id={@id} name={@name} label={@label} errors={@errors} help={@help}>
+      <div class="flex flex-row">
+        <div class={[input_classes([]), "flex-1 rounded-e-none border-e-0"]}>http(s)://</div>
+        <input
+          type="text"
+          name={@name}
+          id={@id || @name}
+          value={Phoenix.HTML.Form.normalize_value("text", @value)}
+          class={[input_classes(@errors), "rounded-s-none", @class]}
+          {@rest}
+        />
+      </div>
+    </.field_wrapper>
+    """
+  end
   def text_field(assigns) do
     assigns = assigns_from_field(assigns)
 

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -39,6 +39,7 @@ defmodule LivebookWeb.FormComponents do
     </.field_wrapper>
     """
   end
+
   def text_field(assigns) do
     assigns = assigns_from_field(assigns)
 

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -6,7 +6,7 @@ defmodule LivebookWeb.FormComponents do
   alias Phoenix.LiveView.JS
 
   @doc """
-  Renders a text input with label and error messages.
+  Renders a text input with label and error messages, as well as a "http(s)://" prefix.
   """
   attr :id, :any, default: nil
   attr :name, :any
@@ -15,12 +15,11 @@ defmodule LivebookWeb.FormComponents do
   attr :errors, :list, default: []
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form"
   attr :help, :string, default: nil
-  attr :type, :string, default: "text"
   attr :class, :string, default: nil
 
   attr :rest, :global, include: ~w(autocomplete readonly disabled step min max)
 
-  def text_field(%{type: "base_url"} = assigns) do
+  def schemaless_url_field(assigns) do
     assigns = assigns_from_field(assigns)
 
     ~H"""
@@ -39,6 +38,21 @@ defmodule LivebookWeb.FormComponents do
     </.field_wrapper>
     """
   end
+
+  @doc """
+  Renders a text input with label and error messages.
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :errors, :list, default: []
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form"
+  attr :help, :string, default: nil
+  attr :type, :string, default: "text"
+  attr :class, :string, default: nil
+
+  attr :rest, :global, include: ~w(autocomplete readonly disabled step min max)
 
   def text_field(assigns) do
     assigns = assigns_from_field(assigns)

--- a/lib/livebook_web/live/hub/teams/deployment_group_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_component.ex
@@ -40,7 +40,14 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupComponent do
                 </div>
               <% end %>
             </div>
-            <div class="text-sm mt-1">internal-domain.example.com</div>
+            <.link
+              :if={@deployment_group.url}
+              href={"https://#{@deployment_group.url}"}
+              class="text-sm font-semibold text-blue-600 hover:text-blue-700 mt-1"
+              target="_blank"
+            >
+              <%= @deployment_group.url %>
+            </.link>
           </div>
           <.link
             href={Livebook.Config.teams_url() <> "/orgs/#{@hub.org_id}/deployments/groups/#{@deployment_group.id}"}

--- a/proto/lib/livebook_proto/deployment_group.pb.ex
+++ b/proto/lib/livebook_proto/deployment_group.pb.ex
@@ -9,4 +9,5 @@ defmodule LivebookProto.DeploymentGroup do
   field :zta_provider, 6, type: :string, json_name: "ztaProvider"
   field :zta_key, 7, type: :string, json_name: "ztaKey"
   field :agent_keys, 8, repeated: true, type: LivebookProto.AgentKey, json_name: "agentKeys"
+  field :url, 9, type: :string
 end

--- a/proto/lib/livebook_proto/deployment_group_created.pb.ex
+++ b/proto/lib/livebook_proto/deployment_group_created.pb.ex
@@ -8,4 +8,5 @@ defmodule LivebookProto.DeploymentGroupCreated do
   field :zta_provider, 6, type: :string, json_name: "ztaProvider"
   field :zta_key, 7, type: :string, json_name: "ztaKey"
   field :agent_keys, 8, repeated: true, type: LivebookProto.AgentKey, json_name: "agentKeys"
+  field :url, 9, type: :string
 end

--- a/proto/lib/livebook_proto/deployment_group_updated.pb.ex
+++ b/proto/lib/livebook_proto/deployment_group_updated.pb.ex
@@ -8,4 +8,5 @@ defmodule LivebookProto.DeploymentGroupUpdated do
   field :zta_provider, 5, type: :string, json_name: "ztaProvider"
   field :zta_key, 6, type: :string, json_name: "ztaKey"
   field :agent_keys, 7, repeated: true, type: LivebookProto.AgentKey, json_name: "agentKeys"
+  field :url, 8, type: :string
 end

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -63,6 +63,7 @@ message DeploymentGroup {
   string zta_provider = 6;
   string zta_key = 7;
   repeated AgentKey agent_keys = 8;
+  string url = 9;
 }
 
 message DeploymentGroupCreated {
@@ -73,6 +74,7 @@ message DeploymentGroupCreated {
   string zta_provider = 6;
   string zta_key = 7;
   repeated AgentKey agent_keys = 8;
+  string url = 9;
 }
 
 message DeploymentGroupUpdated {
@@ -83,6 +85,7 @@ message DeploymentGroupUpdated {
   string zta_provider = 5;
   string zta_key = 6;
   repeated AgentKey agent_keys = 7;
+  string url = 8;
 }
 
 message DeploymentGroupDeleted {


### PR DESCRIPTION
Includes changes to the protobuf definitions and handling of Teams events, as well as changes to the frontend to allow for creating the deployment group with the specified URL.