### PR TITLE
Set maximum number of ports

### DIFF
--- a/rel/server/vm.args.eex
+++ b/rel/server/vm.args.eex
@@ -1,2 +1,3 @@
 # Disable busy waiting so that we don't waste resources
-+sbwt none +sbwtdcpu none +sbwtdio none
+# Limit the maximal number of ports for the same reason
++sbwt none +sbwtdcpu none +sbwtdio none +Q 65536


### PR DESCRIPTION
Some modern Linux distributions have ridiculous default limits of file descriptors. For example, Rocky Linux has a default configuration of up to 134217727 file descriptors. Setting to 64k descriptors is unlimited in the traditional sense.

This setting prevents situations like #2640. Even Users can fix the problem themselves this sensible setting prevents future problems. 