### PR TITLE
Send the apps manager report to Teams through WebSocket

### DIFF
--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -12,6 +12,7 @@ defmodule Livebook.Hubs.TeamClient do
   @supervisor Livebook.HubsSupervisor
 
   defstruct [
+    :pid,
     :hub,
     :connection_status,
     :derived_key,
@@ -169,8 +170,8 @@ defmodule Livebook.Hubs.TeamClient do
         ]
       end
 
-    {:ok, _pid} = Teams.Connection.start_link(self(), headers)
-    {:ok, %__MODULE__{hub: team, derived_key: derived_key}}
+    {:ok, pid} = Teams.Connection.start_link(self(), headers)
+    {:ok, %__MODULE__{pid: pid, hub: team, derived_key: derived_key}}
   end
 
   def init(%Hubs.Team{} = team) do

--- a/proto/lib/livebook_proto/app_deployment_status_type.pb.ex
+++ b/proto/lib/livebook_proto/app_deployment_status_type.pb.ex
@@ -1,8 +1,6 @@
 defmodule LivebookProto.AppDeploymentStatusType do
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :connecting, 0
-  field :preparing, 1
-  field :available, 2
-  field :deactivated, 4
+  field :preparing, 0
+  field :available, 1
 end

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -167,10 +167,8 @@ message Agent {
  * Otherwise, it shouldn't be used.
  */
 enum AppDeploymentStatusType {
-  connecting = 0;
-  preparing = 1;
-  available = 2;
-  deactivated = 4;
+  preparing = 0;
+  available = 1;
 }
 
 message AppDeploymentStatus {

--- a/test/livebook_teams/hubs_test.exs
+++ b/test/livebook_teams/hubs_test.exs
@@ -250,14 +250,6 @@ defmodule Livebook.HubsTest do
              Hubs.Provider.verify_notebook_stamp(team, notebook_source <> "change\n", stamp)
   end
 
-  defp connect_to_teams(user, node) do
-    %{id: id} = team = create_team_hub(user, node)
-    assert_receive {:hub_connected, ^id}
-    assert_receive {:client_connected, ^id}
-
-    team
-  end
-
   defp secret_name(%{id: id}) do
     id
     |> String.replace("-", "_")

--- a/test/livebook_teams/teams_test.exs
+++ b/test/livebook_teams/teams_test.exs
@@ -258,12 +258,4 @@ defmodule Livebook.TeamsTest do
       assert_receive {:app_deployment_stopped, ^app_deployment2}
     end
   end
-
-  defp connect_to_teams(user, node) do
-    %{id: id} = team = create_team_hub(user, node)
-    assert_receive {:hub_connected, ^id}, 3_000
-    assert_receive {:client_connected, ^id}, 3_000
-
-    team
-  end
 end

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -281,6 +281,24 @@ defmodule Livebook.HubHelpers do
     assert_receive {:agent_joined, ^agent}
   end
 
+  @doc """
+  Creates a new Team hub from given user and node, and await the WebSocket to be connected.
+
+      test "my test", %{user: user, node: node} do
+        team = connect_to_teams(user, node)
+        assert "team-" <> _ = team.id
+      end
+
+  """
+  @spec connect_to_teams(struct(), node()) :: Livebook.Hubs.Team.t()
+  def connect_to_teams(user, node) do
+    %{id: id} = team = create_team_hub(user, node)
+    assert_receive {:hub_connected, ^id}, 3_000
+    assert_receive {:client_connected, ^id}, 3_000
+
+    team
+  end
+
   defp hub_pid(hub) do
     if pid = GenServer.whereis({:via, Registry, {Livebook.HubsRegistry, hub.id}}) do
       {:ok, pid}


### PR DESCRIPTION
TODO

- [ ] Improve tests, using `receive do` blocks to wait the data being processed in the Teams side