### PR TITLE
Make auth-dependent tests async

### DIFF
--- a/lib/livebook_web/controllers/auth_controller.ex
+++ b/lib/livebook_web/controllers/auth_controller.ex
@@ -22,7 +22,7 @@ defmodule LivebookWeb.AuthController do
   def index(conn, _params) do
     render(conn, "index.html",
       errors: [],
-      authentication_mode: Livebook.Config.authentication().mode
+      authentication_mode: LivebookWeb.AuthPlug.authentication(conn).mode
     )
   end
 

--- a/test/livebook_web/controllers/session_controller_test.exs
+++ b/test/livebook_web/controllers/session_controller_test.exs
@@ -250,6 +250,8 @@ defmodule LivebookWeb.SessionControllerTest do
   end
 
   describe "show_asset" do
+    @describetag authentication: %{mode: :password, secret: "grumpycat"}
+
     test "fetches assets and redirects to the session-less path", %{conn: conn} do
       %{notebook: notebook, hash: hash} = notebook_with_js_output()
 
@@ -297,6 +299,8 @@ defmodule LivebookWeb.SessionControllerTest do
   end
 
   describe "show_cached_asset" do
+    @describetag authentication: %{mode: :password, secret: "grumpycat"}
+
     test "returns not found when no matching assets are in the cache", %{conn: conn} do
       %{notebook: _notebook, hash: hash} = notebook_with_js_output()
 
@@ -345,7 +349,7 @@ defmodule LivebookWeb.SessionControllerTest do
 
       token = LivebookWeb.SessionHelpers.generate_input_token(view.pid, input_id)
 
-      conn = get(conn, ~p"/public/sessions/audio-input/#{token}")
+      conn = conn |> with_password_auth() |> get(~p"/public/sessions/audio-input/#{token}")
 
       assert conn.status == 200
       assert conn.resp_body == "wav content"
@@ -364,6 +368,7 @@ defmodule LivebookWeb.SessionControllerTest do
 
       conn =
         conn
+        |> with_password_auth()
         |> put_req_header("range", "bytes=4-")
         |> get(~p"/public/sessions/audio-input/#{token}")
 
@@ -382,7 +387,7 @@ defmodule LivebookWeb.SessionControllerTest do
 
       token = LivebookWeb.SessionHelpers.generate_input_token(view.pid, input_id)
 
-      conn = get(conn, ~p"/public/sessions/audio-input/#{token}")
+      conn = conn |> with_password_auth() |> get(~p"/public/sessions/audio-input/#{token}")
 
       assert conn.status == 200
       assert <<_header::44-binary, "pcm content">> = conn.resp_body
@@ -401,6 +406,7 @@ defmodule LivebookWeb.SessionControllerTest do
 
       conn =
         conn
+        |> with_password_auth()
         |> put_req_header("range", "bytes=48-")
         |> get(~p"/public/sessions/audio-input/#{token}")
 
@@ -421,7 +427,7 @@ defmodule LivebookWeb.SessionControllerTest do
 
       token = LivebookWeb.SessionHelpers.generate_input_token(view.pid, input_id)
 
-      conn = get(conn, ~p"/public/sessions/image-input/#{token}")
+      conn = conn |> with_password_auth() |> get(~p"/public/sessions/image-input/#{token}")
 
       assert conn.status == 200
       assert conn.resp_body == "rgb content"
@@ -441,6 +447,11 @@ defmodule LivebookWeb.SessionControllerTest do
     Session.close(session.pid)
 
     conn
+  end
+
+  defp with_password_auth(conn) do
+    authentication = %{mode: :password, secret: "grumpycat"}
+    with_authentication(conn, authentication)
   end
 
   defp notebook_with_js_output() do

--- a/test/livebook_web/live/app_auth_live_test.exs
+++ b/test/livebook_web/live/app_auth_live_test.exs
@@ -1,6 +1,5 @@
 defmodule LivebookWeb.AppAuthLiveTest do
-  # Not async, because we alter global config (auth mode)
-  use LivebookWeb.ConnCase, async: false
+  use LivebookWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
 
@@ -11,13 +10,7 @@ defmodule LivebookWeb.AppAuthLiveTest do
       Livebook.App.close(app_pid)
     end)
 
-    Application.put_env(:livebook, :authentication, {:password, ctx[:livebook_password]})
-
-    on_exit(fn ->
-      Application.put_env(:livebook, :authentication, :disabled)
-    end)
-
-    %{slug: slug}
+    [slug: slug]
   end
 
   defp create_app(app_settings_attrs) do
@@ -42,6 +35,8 @@ defmodule LivebookWeb.AppAuthLiveTest do
     {slug, app_pid}
   end
 
+  @moduletag authentication: %{mode: :password, secret: "long_livebook_password"}
+
   # Integration tests for the authentication scenarios
 
   describe "public app" do
@@ -58,7 +53,6 @@ defmodule LivebookWeb.AppAuthLiveTest do
   end
 
   describe "protected app" do
-    @describetag livebook_password: "long_livebook_password"
     @describetag app_settings: %{access_type: :protected, password: "long_app_password"}
 
     test "redirect to auth page when not authenticated", %{conn: conn, slug: slug} do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -16,7 +16,20 @@ defmodule LivebookWeb.ConnCase do
     end
   end
 
-  setup _tags do
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  setup tags do
+    conn = Phoenix.ConnTest.build_conn()
+
+    conn =
+      if authentication = tags[:authentication] do
+        with_authentication(conn, authentication)
+      else
+        conn
+      end
+
+    [conn: conn]
+  end
+
+  def with_authentication(conn, authentication) do
+    Plug.Test.init_test_session(conn, authentication_test_override: authentication)
   end
 end


### PR DESCRIPTION
Allows for overriding the authentication mode scoped to each `conn` in tests, this way tests no longer rely on application config and can run asynchronously.