### PR TITLE
Print auth token in URL; fix bad pattern match

### DIFF
--- a/lib/livebook_web/endpoint.ex
+++ b/lib/livebook_web/endpoint.ex
@@ -156,7 +156,7 @@ defmodule LivebookWeb.Endpoint do
     base = update_in(base.path, &(&1 || "/"))
 
     case Livebook.Config.authentication() do
-      %{mode: token, secret: token} ->
+      %{mode: :token, secret: token} ->
         %{base | query: "token=" <> token}
 
       _ ->


### PR DESCRIPTION
Thanks for making Livebook! It is very handy especially when used with Phoenix/live code reloading.

81f6744 introduced a regression that caused auth tokens to no longer be printed out on start; a faulty match pattern introduced a binding instead of matching on an atom. This PR fixes that.

Before:

```
$ livebook server
[Livebook] Application running at http://localhost:8080/
```

After:
```
[Livebook] Application running at http://localhost:8080/?token=ere...
```