### PR TITLE
Respect LIVEBOOK_BASE_URL_PATH when checking /public assets availability

### DIFF
--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -507,8 +507,9 @@ const JSView = {
  * once and the response is cached.
  */
 function cachedPublicEndpointCheck() {
-    let healthUrl = window.LIVEBOOK_BASE_URL_PATH + "/public/health";
-    cachedPublicEndpointCheck.promise =
+  const healthUrl = window.LIVEBOOK_BASE_URL_PATH + "/public/health";
+
+  cachedPublicEndpointCheck.promise =
     cachedPublicEndpointCheck.promise ||
     fetch(healthUrl)
       .then((response) => response.status === 200)

--- a/assets/js/hooks/js_view.js
+++ b/assets/js/hooks/js_view.js
@@ -507,9 +507,10 @@ const JSView = {
  * once and the response is cached.
  */
 function cachedPublicEndpointCheck() {
-  cachedPublicEndpointCheck.promise =
+    let healthUrl = window.LIVEBOOK_BASE_URL_PATH + "/public/health";
+    cachedPublicEndpointCheck.promise =
     cachedPublicEndpointCheck.promise ||
-    fetch("/public/health")
+    fetch(healthUrl)
       .then((response) => response.status === 200)
       .catch((error) => false);
 


### PR DESCRIPTION
This prevents the check from failing when running on a non-root path, which would otherwise make Livebook try to load the assets directly from hex.pm, which fails CORS checks.