### PR TITLE
Change the scroll behavior when clicking notebook sections

### DIFF
--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -575,7 +575,7 @@ const Session = {
     if (sectionButton) {
       const sectionId = sectionButton.getAttribute("data-section-id");
       const section = this.getSectionById(sectionId);
-      section.scrollIntoView({ behavior: "smooth", block: "start" });
+      section.scrollIntoView({ behavior: "instant", block: "start" });
     }
   },
 


### PR DESCRIPTION
This PR changes the UI scrolling behavior when clicking a section in the section's sidebar.

This idea came up when I was watching a talk from Bruce Tate at an event. His whole talk was live coding using Livebook. After clicking the section items in the sidebar a few times, he said to the audience, "Are you feeling dizzy? I know I am."

While working on Livebook apps, I use the section navigation to help me navigate the codebase. I also noticed that the repeating smooth scrolling effect makes me feel a little bit dizzy.

This PR changes the scroll behavior from "smooth" to "instant."

## Before

Link to video: https://share.cleanshot.com/jFB0bqWr

## After

Link to video: https://share.cleanshot.com/gpFYvtdp