### PR TITLE
Do not check Elixir version in the Fly runtime

### DIFF
--- a/lib/livebook/runtime/fly.ex
+++ b/lib/livebook/runtime/fly.ex
@@ -296,19 +296,14 @@ defmodule Livebook.Runtime.Fly do
   defp fetch_runtime_info(child_node) do
     # Note: it is Livebook that starts the runtime node, so we know
     # that the node runs Livebook release of the exact same version
+    #
+    # Also, the remote node already has all the runtime modules in
+    # the code path, compiled for its Elixir version, so we don't
+    # need to check for matching Elixir version.
 
-    %{
-      pid: pid,
-      elixir_version: elixir_version
-    } = :erpc.call(child_node, :persistent_term, :get, [:livebook_runtime_info])
+    %{pid: pid} = :erpc.call(child_node, :persistent_term, :get, [:livebook_runtime_info])
 
-    if elixir_version != System.version() do
-      {:error,
-       "the local Elixir version (#{inspect(System.version())}) does not" <>
-         " match the one used by the runtime (#{elixir_version})"}
-    else
-      {:ok, pid}
-    end
+    {:ok, pid}
   end
 
   defp initialize_node(child_node) do

--- a/rel/server/overlays/bin/start_runtime.exs
+++ b/rel/server/overlays/bin/start_runtime.exs
@@ -13,8 +13,7 @@ node = :"#{node_base}@#{machine_id}.vm.#{app}.internal"
 
 # We persist the information before the node is reachable
 :persistent_term.put(:livebook_runtime_info, %{
-  pid: self(),
-  elixir_version: System.version()
+  pid: self()
 })
 
 Application.put_env(:kernel, :inet_dist_listen_min, dist_port)


### PR DESCRIPTION
In general we load modules into the runtime node, so it needs to have the same (or similar) Elixir version, and so for Attached runtime we assert on that. For the Fly runtime, the compiled runtime modules are already present in the Docker image and we add them to the path, so the local Elixir version doesn't matter.