### PR TITLE
Wait for Fly machine to start before attempting to connect

### DIFF
--- a/lib/livebook/fly_api.ex
+++ b/lib/livebook/fly_api.ex
@@ -188,6 +188,21 @@ defmodule Livebook.FlyAPI do
     %{id: machine["id"], private_ip: machine["private_ip"]}
   end
 
+  @doc """
+  Waits for the machine to start.
+  """
+  @spec await_machine_started(String.t(), String.t(), String.t()) :: :ok | {:error, error}
+  def await_machine_started(token, app_name, machine_id) do
+    with {:ok, _data} <-
+           flaps_request(token, "/v1/apps/#{app_name}/machines/#{machine_id}/wait",
+             params: %{state: "started", timeout: 60},
+             receive_timeout: 90_000,
+             retry: false
+           ) do
+      :ok
+    end
+  end
+
   defp flaps_request(token, path, opts \\ []) do
     opts =
       [base_url: @flaps_url, url: path, auth: {:bearer, token}]

--- a/test/livebook/runtime/fly_test.exs
+++ b/test/livebook/runtime/fly_test.exs
@@ -26,6 +26,7 @@ defmodule Livebook.Runtime.FlyTest do
 
     assert_receive {:runtime_connect_info, ^pid, "create machine"}, @assert_receive_timeout
     assert_receive {:runtime_connect_info, ^pid, "start proxy"}, @assert_receive_timeout
+    assert_receive {:runtime_connect_info, ^pid, "machine starting"}, @assert_receive_timeout
     assert_receive {:runtime_connect_info, ^pid, "connect to node"}, @assert_receive_timeout
     assert_receive {:runtime_connect_info, ^pid, "initialize node"}, @assert_receive_timeout
     assert_receive {:runtime_connect_done, ^pid, {:ok, runtime}}, @assert_receive_timeout


### PR DESCRIPTION
Starting a machine may take a while, for example if it is the first boot with a volume and it needs to be initialized, or if a large Docker image needs to be pulled and is not in cache. The Fly API has a convenient endpoint to wait for the machine to reach a certain status. With this PR we show a more relevant information to the user while the machine is still starting, and also show a better error when it fails.