### PR TITLE
Fix broken MapLibre Evented URLs

### DIFF
--- a/lib/livebook/notebook/learn/intro_to_maplibre.livemd
+++ b/lib/livebook/notebook/learn/intro_to_maplibre.livemd
@@ -14,7 +14,7 @@ To work with maps in Livebook we need two libraries:
 * The [`maplibre`](https://hexdocs.pm/maplibre/MapLibre.html)
   package allows us to define our map style specifications
 
-* The [`kino_maplibre`](https://hexdocs.pm/kino_maplibre/) package instructs Livebook how to render our specifications and also provides some initial support for [MapLibre Evented API](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Evented/)
+* The [`kino_maplibre`](https://hexdocs.pm/kino_maplibre/) package instructs Livebook how to render our specifications and also provides some initial support for [MapLibre Evented API](https://maplibre.org/maplibre-gl-js/docs/API/classes/Evented/)
 
 We will make extensive use of MapLibre's functions, so it's handy to alias the module to something shorter.
 
@@ -362,7 +362,7 @@ Ml.new() |> Kino.MapLibre.add_geocode_control()
 
 ## Interactive maps
 
-As said before, the `MapLibre` package covers all the style specification, but for the interactivity of the [Evented API](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Evented/) we need `Kino.MapLibre`.
+As said before, the `MapLibre` package covers all the style specification, but for the interactivity of the [Evented API](https://maplibre.org/maplibre-gl-js/docs/API/classes/Evented/) we need `Kino.MapLibre`.
 
 `Kino.MapLibre` supports two types of maps: static and dynamic. Essentially, a dynamic map can be updated on the fly without having to be re-evaluated. To make a map dynamic you need to wrap it in `Kino.MapLibre.new/1`
 


### PR DESCRIPTION
I noticed these two broken links in [intro_to_maplibre.livemd](https://github.com/livebook-dev/livebook/blob/8146bfd3b99dd0b4c343492c5f6a1bbc55b8d379/lib/livebook/notebook/learn/intro_to_maplibre.livemd). I checked other maplibre.org links and they all seem fine.