### PR TITLE
Make checkboxes work with keyboard only

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -13,12 +13,11 @@
       "Segoe UI Emoji";
   }
 
-  /* Please don't do this. This is bad for accessibility. */
   /* Remove the default outline on focused elements */
-  /* :focus, */
-  /* button:focus { */
-    /* outline: none; */
-  /* } */
+  :focus,
+  button:focus {
+    outline: none;
+  }
 
   menu {
     margin: 0;

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -13,11 +13,12 @@
       "Segoe UI Emoji";
   }
 
+  /* Please don't do this. This is bad for accessibility. */
   /* Remove the default outline on focused elements */
-  :focus,
-  button:focus {
-    outline: none;
-  }
+  /* :focus, */
+  /* button:focus { */
+    /* outline: none; */
+  /* } */
 
   menu {
     margin: 0;

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -312,7 +312,6 @@ defmodule LivebookWeb.FormComponents do
         <button
           class="w-5 h-5 flex items-center justify-center border border-gray-300 peer-checked:border-transparent bg-white peer-checked:bg-blue-600 rounded"
           type="button"
-          autofocus
           phx-click={JS.dispatch("click", to: "##{@checkbox_input_id}")}
         >
           <svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg">

--- a/lib/livebook_web/components/form_components.ex
+++ b/lib/livebook_web/components/form_components.ex
@@ -291,7 +291,10 @@ defmodule LivebookWeb.FormComponents do
   attr :rest, :global
 
   def checkbox_field(assigns) do
-    assigns = assigns_from_field(assigns)
+    assigns =
+      assigns
+      |> assigns_from_field()
+      |> then(&assign(&1, :checkbox_input_id, &1[:id] || &1[:name]))
 
     ~H"""
     <div>
@@ -302,15 +305,20 @@ defmodule LivebookWeb.FormComponents do
           class="peer hidden"
           value={@checked_value}
           name={@name}
-          id={@id || @name}
+          id={@checkbox_input_id}
           checked={to_string(@value) == @checked_value}
           {@rest}
         />
-        <div class="w-5 h-5 flex items-center justify-center border border-gray-300 peer-checked:border-transparent bg-white peer-checked:bg-blue-600 rounded">
+        <button
+          class="w-5 h-5 flex items-center justify-center border border-gray-300 peer-checked:border-transparent bg-white peer-checked:bg-blue-600 rounded"
+          type="button"
+          autofocus
+          phx-click={JS.dispatch("click", to: "##{@checkbox_input_id}")}
+        >
           <svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg">
             <path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z" />
           </svg>
-        </div>
+        </button>
         <span :if={@label} class={["text-gray-700 flex gap-1 items-center", @small && "text-sm"]}>
           <%= @label %>
           <.help :if={@help} text={@help} />


### PR DESCRIPTION
I was learning the keyboard shortcuts for livebook.
I wanted to delete a cell.
When I typed `dd`, a modal appeared but I was unable to access the checkbox using just my keyboard.
This makes checkboxes work with keyboard only.