### PR TITLE
Close runtime modal once connecting succeeds

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -1053,6 +1053,10 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, put_flash(socket, kind, message)}
   end
 
+  def handle_info({:push_patch, to}, socket) do
+    {:noreply, push_patch(socket, to: to)}
+  end
+
   def handle_info({:starred_notebooks_updated, starred_notebooks}, socket) do
     {:noreply, assign(socket, starred_files: starred_files(starred_notebooks))}
   end

--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -60,6 +60,7 @@ defmodule LivebookWeb.SessionLive.Render do
         module={LivebookWeb.SessionLive.RuntimeComponent}
         id="runtime-settings"
         session={@session}
+        return_to={@self_path}
         runtime={@data_view.runtime}
         runtime_status={@data_view.runtime_status}
         runtime_connect_info={@data_view.runtime_connect_info}

--- a/lib/livebook_web/live/session_live/runtime_component.ex
+++ b/lib/livebook_web/live/session_live/runtime_component.ex
@@ -14,6 +14,12 @@ defmodule LivebookWeb.SessionLive.RuntimeComponent do
   end
 
   def update(assigns, socket) do
+    with %{runtime_status: :connecting} <- socket.assigns,
+         %{runtime_status: :connected} <- assigns,
+         true <- socket.assigns.type == runtime_type(assigns.runtime) do
+      send(self(), {:push_patch, socket.assigns.return_to})
+    end
+
     socket =
       socket
       |> assign(assigns)

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -913,8 +913,12 @@ defmodule LivebookWeb.SessionLiveTest do
       assert_receive {:operation, {:set_runtime, _pid, %Runtime.Standalone{}}}
       assert_receive {:operation, {:runtime_connected, _pid, %Runtime.Standalone{} = runtime}}
 
+      assert_patch(view, "/sessions/#{session.id}")
+      assert render(view) =~ Atom.to_string(runtime.node)
+
+      {:ok, view, _} = live(conn, ~p"/sessions/#{session.id}/settings/runtime")
+
       page = render(view)
-      assert page =~ Atom.to_string(runtime.node)
       assert page =~ "Reconnect"
       assert page =~ "Disconnect"
     end


### PR DESCRIPTION
Currently connecting a runtime simply changes the button to "Reconnect", so the success is not obvious. We could show a message, but actually there is no reason to keep the modal open; if the connection succeeded, the user can go back to the notebook.