### PR TITLE
Await previous machine to release volume when reconnecting fly runtime

### DIFF
--- a/lib/livebook/fly_api.ex
+++ b/lib/livebook/fly_api.ex
@@ -210,6 +210,24 @@ defmodule Livebook.FlyAPI do
     end
   end
 
+  @doc """
+  Waits for the machine to be destroyed.
+  """
+  @spec await_machine_destroyed(String.t(), String.t(), String.t(), pos_integer()) ::
+          :ok | {:error, error}
+  def await_machine_destroyed(token, app_name, machine_id, timeout_s) when timeout_s <= 60 do
+    # Contrarily to the above, if we expect the machine to be destroying,
+    # it should take a short time, so we don't retry requests and expect
+    # a rather short timeout
+    with {:ok, _data} <-
+           flaps_request(token, "/v1/apps/#{app_name}/machines/#{machine_id}/wait",
+             params: %{state: "destroyed", timeout: timeout_s},
+             retry: false
+           ) do
+      :ok
+    end
+  end
+
   defp flaps_request(token, path, opts \\ []) do
     opts =
       [base_url: @flaps_url, url: path, auth: {:bearer, token}]


### PR DESCRIPTION
Currently reconnecting Fly runtime with a volume may fail, because we attempt to create a new machine while the volume is attached to the stopping machine (this happens more or less consistently, depending on the user location).

I considered a few implementation options, but I went with what I think is the simplest one (that is, the simplest one that is also robust).