### PR TITLE
Use a bigger chunk size when transferring files across nodes

### DIFF
--- a/lib/livebook/runtime/erl_dist/runtime_server.ex
+++ b/lib/livebook/runtime/erl_dist/runtime_server.ex
@@ -177,7 +177,7 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
             {:transfer, target_path, target_pid} ->
               try do
                 path
-                |> File.stream!(2048, [])
+                |> File.stream!(64_000, [])
                 |> Enum.each(fn chunk -> IO.binwrite(target_pid, chunk) end)
 
                 target_path

--- a/lib/livebook_web/controllers/session_controller.ex
+++ b/lib/livebook_web/controllers/session_controller.ex
@@ -304,7 +304,7 @@ defmodule LivebookWeb.SessionController do
 
   defp transfer_file!(remote_node, remote_path, local_path) do
     File.mkdir_p!(Path.dirname(local_path))
-    remote_stream = :erpc.call(remote_node, File, :stream!, [remote_path, 2048, []])
+    remote_stream = :erpc.call(remote_node, File, :stream!, [remote_path, 64_000, []])
     local_stream = File.stream!(local_path)
     Enum.into(remote_stream, local_stream)
   end


### PR DESCRIPTION
We transparently copy files from Livebook to remote runtime (Fly), for example, when using `Kino.Input.image`. We noticed that it takes unusually long time to transfer the file. This increases file chunk size that we write across the nodes.

Just as an example, I tried ~1MB .jpeg image and this change dropped the transfer time roughly from 70s to 4s.