### PR TITLE
Add configuration for update check to target a different repository

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,7 @@ config :livebook,
   shutdown_callback: nil,
   teams_auth?: false,
   teams_url: "https://teams.livebook.dev",
+  github_release_repo: "livebook-dev/livebook",
   update_instructions_url: nil,
   within_iframe: false
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -426,7 +426,7 @@ defmodule Livebook.Config do
   def app_version(), do: @app_version
 
   @doc """
-  This is the URL of the application repo that will be checked to see whetehr
+  This is the URL of the application repo that will be checked to see whether
   some new version is available. Note: Currently this must be a github repo.
   """
   def app_repo_url() do

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -426,6 +426,14 @@ defmodule Livebook.Config do
   def app_version(), do: @app_version
 
   @doc """
+  This is the URL of the application repo that will be checked to see whetehr
+  some new version is available. Note: Currently this must be a github repo.
+  """
+  def app_repo_url() do
+    Application.get_env(:livebook, :app_repo_url, "https://api.github.com/repos/livebook-dev/livebook/releases/latest")
+  end
+
+  @doc """
   Aborts booting due to a configuration error.
   """
   @spec abort!(String.t()) :: no_return()

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -426,11 +426,10 @@ defmodule Livebook.Config do
   def app_version(), do: @app_version
 
   @doc """
-  This is the URL of the application repo that will be checked to see whether
-  some new version is available. Note: Currently this must be a github repo.
+  Returns the GitHub org/repo where the releases are created.
   """
-  def app_repo_url() do
-    Application.get_env(:livebook, :app_repo_url, "https://api.github.com/repos/livebook-dev/livebook/releases/latest")
+  def github_release_repo() do
+    Application.get_env(:livebook, :github_release_repo)
   end
 
   @doc """

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -128,7 +128,7 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp fetch_latest_version() do
-    url = "https://api.github.com/repos/livebook-dev/livebook/releases/latest"
+    url = Livebook.Config.app_repo_url()
     headers = [{"accept", "application/vnd.github.v3+json"}]
 
     case Livebook.Utils.HTTP.request(:get, url, headers: headers) do

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -128,7 +128,7 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp fetch_latest_version() do
-    url = Livebook.Config.app_repo_url()
+    url = "https://api.github.com/repos/#{Livebook.Config.github_release_repo()}/releases/latest"
     headers = [{"accept", "application/vnd.github.v3+json"}]
 
     case Livebook.Utils.HTTP.request(:get, url, headers: headers) do


### PR DESCRIPTION
This is a proposal for [this idea](https://github.com/livebook-dev/livebook/discussions/2742) to solve the issue of nerves_livebook not displaying the correct version or a banner that isn't valid, because more effort is required to get the latest version of livebook into nerves.