### PR TITLE
Make the go-to-definition link a client concern

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor/codemirror/theme.js
+++ b/assets/js/hooks/cell_editor/live_editor/codemirror/theme.js
@@ -265,10 +265,28 @@ function buildEditorTheme(colors, { dark }) {
         maxWidth: "800px",
         maxHeight: "300px",
         overflowY: "auto",
-        padding: "8px",
         display: "flex",
         flexDirection: "column",
-        gap: "64px",
+
+        "& .cm-hoverDocsDefinitionLink": {
+          padding: "4px 8px",
+          cursor: "pointer",
+          fontSize: "0.875em",
+          fontFamily: fonts.sans,
+          opacity: 0.8,
+          borderBottom: `1px solid ${colors.separator}`,
+
+          "& i": {
+            marginRight: "2px",
+          },
+        },
+
+        "& .cm-hoverDocsContents": {
+          padding: "8px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "64px",
+        },
       },
 
       // Signature

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -546,20 +546,6 @@ const Session = {
       this.setInsertMode(false);
     }
 
-    if (
-      event.target.matches("a") &&
-      event.target.hash.startsWith("#go-to-definition")
-    ) {
-      const search = event.target.hash.replace("#go-to-definition", "");
-      const params = new URLSearchParams(search);
-      const line = parseInt(params.get("line"), 10);
-      const file = params.get("file");
-
-      this.jumpToLine(file, line);
-
-      event.preventDefault();
-    }
-
     const evalButton = event.target.closest(
       `[data-el-queue-cell-evaluation-button]`,
     );

--- a/lib/livebook/intellisense.ex
+++ b/lib/livebook/intellisense.ex
@@ -53,10 +53,6 @@ defmodule Livebook.Intellisense do
     get_details(line, column, context, node)
   end
 
-  def handle_request({:definition, line, column}, context, node) do
-    get_definitions(line, column, context, node)
-  end
-
   def handle_request({:signature, hint}, context, node) do
     get_signature_items(hint, context, node)
   end
@@ -418,12 +414,12 @@ defmodule Livebook.Intellisense do
         nil
 
       matches ->
-        contents =
-          matches
-          |> Enum.sort_by(& &1[:arity], :asc)
-          |> Enum.map(&format_details_item(&1, context))
+        matches = Enum.sort_by(matches, & &1[:arity], :asc)
+        contents = Enum.map(matches, &format_details_item/1)
 
-        %{range: range, contents: contents}
+        definition = get_definition_location(hd(matches), context)
+
+        %{range: range, contents: contents, definition: definition}
     end
   end
 
@@ -431,13 +427,13 @@ defmodule Livebook.Intellisense do
   defp include_in_details?(%{kind: :bitstring_modifier}), do: false
   defp include_in_details?(_), do: true
 
-  defp format_details_item(%{kind: :variable, name: name}, _context), do: code(name)
+  defp format_details_item(%{kind: :variable, name: name}), do: code(name)
 
-  defp format_details_item(%{kind: :map_field, name: name}, _context), do: code(name)
+  defp format_details_item(%{kind: :map_field, name: name}), do: code(name)
 
-  defp format_details_item(%{kind: :in_map_field, name: name}, _context), do: code(name)
+  defp format_details_item(%{kind: :in_map_field, name: name}), do: code(name)
 
-  defp format_details_item(%{kind: :in_struct_field, name: name, default: default}, _context) do
+  defp format_details_item(%{kind: :in_struct_field, name: name, default: default}) do
     join_with_divider([
       code(name),
       """
@@ -450,35 +446,27 @@ defmodule Livebook.Intellisense do
     ])
   end
 
-  defp format_details_item(
-         %{kind: :module, module: module, documentation: documentation},
-         context
-       ) do
+  defp format_details_item(%{kind: :module, module: module, documentation: documentation}) do
     join_with_divider([
       code(inspect(module)),
-      format_definition_link(module, context, {:module, module}),
       format_docs_link(module),
       format_documentation(documentation, :all)
     ])
   end
 
-  defp format_details_item(
-         %{
-           kind: :function,
-           module: module,
-           name: name,
-           arity: arity,
-           documentation: documentation,
-           signatures: signatures,
-           specs: specs,
-           meta: meta
-         },
-         context
-       ) do
+  defp format_details_item(%{
+         kind: :function,
+         module: module,
+         name: name,
+         arity: arity,
+         documentation: documentation,
+         signatures: signatures,
+         specs: specs,
+         meta: meta
+       }) do
     join_with_divider([
       format_signatures(signatures, module) |> code(),
       join_with_middle_dot([
-        format_definition_link(module, context, {:function, name, arity}),
         format_docs_link(module, {:function, name, arity}),
         format_meta(:since, meta)
       ]),
@@ -488,34 +476,58 @@ defmodule Livebook.Intellisense do
     ])
   end
 
-  defp format_details_item(
-         %{
-           kind: :type,
-           module: module,
-           name: name,
-           arity: arity,
-           documentation: documentation,
-           type_spec: type_spec
-         },
-         context
-       ) do
+  defp format_details_item(%{
+         kind: :type,
+         module: module,
+         name: name,
+         arity: arity,
+         documentation: documentation,
+         type_spec: type_spec
+       }) do
     join_with_divider([
       format_type_signature(type_spec, module) |> code(),
-      format_definition_link(module, context, {:type, name, arity}),
       format_docs_link(module, {:type, name, arity}),
       format_type_spec(type_spec, @extended_line_length) |> code(),
       format_documentation(documentation, :all)
     ])
   end
 
-  defp format_details_item(
-         %{kind: :module_attribute, name: name, documentation: documentation},
-         _context
-       ) do
+  defp format_details_item(%{kind: :module_attribute, name: name, documentation: documentation}) do
     join_with_divider([
       code("@#{name}"),
       format_documentation(documentation, :all)
     ])
+  end
+
+  defp get_definition_location(%{kind: :module, module: module}, context) do
+    get_definition_location(module, context, {:module, module})
+  end
+
+  defp get_definition_location(
+         %{kind: :function, module: module, name: name, arity: arity},
+         context
+       ) do
+    get_definition_location(module, context, {:function, name, arity})
+  end
+
+  defp get_definition_location(%{kind: :type, module: module, name: name, arity: arity}, context) do
+    get_definition_location(module, context, {:type, name, arity})
+  end
+
+  defp get_definition_location(_idenfitier, _context), do: nil
+
+  defp get_definition_location(module, context, identifier) do
+    if context.ebin_path do
+      path = Path.join(context.ebin_path, "#{module}.beam")
+
+      with true <- File.exists?(path),
+           {:ok, line} <- Docs.locate_definition(path, identifier) do
+        file = module.module_info(:compile)[:source]
+        %{file: to_string(file), line: line}
+      else
+        _otherwise -> nil
+      end
+    end
   end
 
   # Formatting helpers
@@ -541,12 +553,6 @@ defmodule Livebook.Intellisense do
     #{code}
     ```\
     """
-  end
-
-  defp format_definition_link(module, context, identifier) do
-    if query = get_definition_location(module, context, identifier) do
-      "[Go to definition](#go-to-definition?#{URI.encode_query(query)})"
-    end
   end
 
   defp format_docs_link(module, function_or_type \\ nil) do
@@ -698,56 +704,6 @@ defmodule Livebook.Intellisense do
 
   defp format_documentation({format, _content}, _variant) do
     raise "unknown documentation format #{inspect(format)}"
-  end
-
-  @doc """
-  Returns the identifier definition located in `column` in `line`.
-  """
-  @spec get_definitions(String.t(), pos_integer(), context(), node()) ::
-          Runtime.definition_response() | nil
-  def get_definitions(line, column, context, node) do
-    case IdentifierMatcher.locate_identifier(line, column, context, node) do
-      %{matches: []} ->
-        nil
-
-      %{matches: matches, range: range} ->
-        matches
-        |> Enum.sort_by(& &1[:arity], :asc)
-        |> Enum.flat_map(&List.wrap(get_definition_location(&1, context)))
-        |> case do
-          [%{file: file, line: line} | _] -> %{range: range, file: file, line: line}
-          _ -> nil
-        end
-    end
-  end
-
-  defp get_definition_location(%{kind: :module, module: module}, context) do
-    get_definition_location(module, context, {:module, module})
-  end
-
-  defp get_definition_location(
-         %{kind: :function, module: module, name: name, arity: arity},
-         context
-       ) do
-    get_definition_location(module, context, {:function, name, arity})
-  end
-
-  defp get_definition_location(%{kind: :type, module: module, name: name, arity: arity}, context) do
-    get_definition_location(module, context, {:type, name, arity})
-  end
-
-  defp get_definition_location(module, context, identifier) do
-    if context.ebin_path do
-      path = Path.join(context.ebin_path, "#{module}.beam")
-
-      with true <- File.exists?(path),
-           {:ok, line} <- Docs.locate_definition(path, identifier) do
-        file = module.module_info(:compile)[:source]
-        %{file: to_string(file), line: line}
-      else
-        _otherwise -> nil
-      end
-    end
   end
 
   # Erlang HTML AST

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -503,7 +503,6 @@ defprotocol Livebook.Runtime do
   @type intellisense_request ::
           completion_request()
           | details_request()
-          | definition_request()
           | signature_request()
           | format_request()
 
@@ -517,7 +516,6 @@ defprotocol Livebook.Runtime do
           nil
           | completion_response()
           | details_response()
-          | definition_response()
           | signature_response()
           | format_response()
 
@@ -552,22 +550,8 @@ defprotocol Livebook.Runtime do
             from: non_neg_integer(),
             to: non_neg_integer()
           },
-          contents: list(String.t())
-        }
-
-  @typedoc """
-  Looks up more the definition about an identifier found in `column` in
-  `line`.
-  """
-  @type definition_request :: {:definition, line :: String.t(), column :: pos_integer()}
-
-  @type definition_response :: %{
-          range: %{
-            from: non_neg_integer(),
-            to: non_neg_integer()
-          },
-          line: pos_integer(),
-          file: String.t()
+          contents: list(String.t()),
+          definition: %{file: String.t(), line: pos_integer()} | nil
         }
 
   @typedoc """

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -616,10 +616,6 @@ defmodule LivebookWeb.SessionLive do
           column = Text.JS.js_column_to_elixir(column, line)
           {:details, line, column}
 
-        %{"type" => "definition", "line" => line, "column" => column} ->
-          column = Text.JS.js_column_to_elixir(column, line)
-          {:definition, line, column}
-
         %{"type" => "signature", "hint" => hint} ->
           {:signature, hint}
 


### PR DESCRIPTION
This changes the hover details, so that instead of including a magic link in the docs (`#go-to-definition?#{...}`), we include the location in the intellisense response and create a link on the client, that looks like this:

<img width="310" alt="image" src="https://github.com/user-attachments/assets/d7b29a72-508d-419c-9241-661258817aac">

Since the "details" request now returns the location, we can reuse it for on-click go-to-definition as well :)

Initially I was thinking of moving "View on HexDocs" there as well, but I think it's fine as is, those are distinct things.