### PR TITLE
Do not set XLA_TARGET when using Livebook CUDA-based images

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -65,11 +65,7 @@ defmodule Livebook.Config do
 
     [
       %{tag: version, name: "Livebook", env: []},
-      %{
-        tag: "#{version}-cuda12",
-        name: "Livebook + CUDA 12",
-        env: [{"XLA_TARGET", "cuda120"}]
-      }
+      %{tag: "#{version}-cuda12", name: "Livebook + CUDA 12", env: []}
     ]
   end
 

--- a/test/livebook/hubs/dockerfile_test.exs
+++ b/test/livebook/hubs/dockerfile_test.exs
@@ -174,8 +174,6 @@ defmodule Livebook.Hubs.DockerfileTest do
 
       assert dockerfile =~ """
              FROM ghcr.io/livebook-dev/livebook:#{@version}-cuda12
-
-             ENV XLA_TARGET "cuda120"
              """
     end
 
@@ -251,10 +249,9 @@ defmodule Livebook.Hubs.DockerfileTest do
       hub = team_hub()
       agent_key = Livebook.Factory.build(:agent_key)
 
-      %{image: image, env: env} = Dockerfile.online_docker_info(config, hub, agent_key)
+      %{image: image, env: _env} = Dockerfile.online_docker_info(config, hub, agent_key)
 
       assert image == "ghcr.io/livebook-dev/livebook:#{@version}-cuda12"
-      assert {"XLA_TARGET", "cuda120"} in env
     end
 
     test "deploying with auto cluster setup" do


### PR DESCRIPTION
EXLA now automatically sets `XLA_TARGET` when `nvcc` is detected, so we no longer need to put it in the Dockerfile.

One reason to still set it would be for older Nx versions, but the value we used to set (`cuda120`) is no longer valid anyway.