### PR TITLE
Add smart cell definition for KinoFLAME with k8s backend

### DIFF
--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -61,7 +61,7 @@ defmodule Livebook.Runtime.Definitions do
   }
 
   flame_k8s_backend = %{
-    name: "kino_flame",
+    name: "flame_k8s_backend",
     dependency: %{dep: {:flame_k8s_backend, "~> 0.5"}, config: []}
   }
 

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -80,6 +80,11 @@ defmodule Livebook.Runtime.Definitions do
     dependency: %{dep: {:xlsx_reader, "~> 0.8.5"}, config: []}
   }
 
+  yaml_elixir = %{
+    name: "kino_flame",
+    dependency: %{dep: {:yaml_elixir, "~> 2.0"}, config: []}
+  }
+
   windows? = match?({:win32, _}, :os.type())
   nx_backend_package = if(windows?, do: torchx, else: exla)
 
@@ -223,7 +228,7 @@ defmodule Livebook.Runtime.Definitions do
         },
         %{
           name: "Kubernetes",
-          packages: [kino_flame, flame_k8s_backend]
+          packages: [kino_flame, flame_k8s_backend, yaml_elixir]
         }
       ]
     }

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -60,6 +60,16 @@ defmodule Livebook.Runtime.Definitions do
     dependency: %{dep: {:kino_flame, "~> 0.1.0"}, config: []}
   }
 
+  flame_k8s_backend = %{
+    name: "kino_flame",
+    dependency: %{dep: {:flame_k8s_backend, "~> 0.5.1"}, config: []}
+  }
+
+  yaml_elixir = %{
+    name: "kino_flame",
+    dependency: %{dep: {:yaml_elixir, "~> 2.11.0"}, config: []}
+  }
+
   jason = %{
     name: "jason",
     dependency: %{dep: {:jason, "~> 1.4"}, config: []}
@@ -213,8 +223,12 @@ defmodule Livebook.Runtime.Definitions do
       name: "FLAME runner cell",
       requirement_presets: [
         %{
-          name: "Default",
+          name: "Fly Backend",
           packages: [kino_flame]
+        },
+        %{
+          name: "Kubernetes Backend",
+          packages: [kino_flame, flame_k8s_backend, yaml_elixir]
         }
       ]
     }

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -62,12 +62,7 @@ defmodule Livebook.Runtime.Definitions do
 
   flame_k8s_backend = %{
     name: "kino_flame",
-    dependency: %{dep: {:flame_k8s_backend, "~> 0.5.1"}, config: []}
-  }
-
-  yaml_elixir = %{
-    name: "kino_flame",
-    dependency: %{dep: {:yaml_elixir, "~> 2.11.0"}, config: []}
+    dependency: %{dep: {:flame_k8s_backend, "~> 0.5"}, config: []}
   }
 
   jason = %{
@@ -228,7 +223,7 @@ defmodule Livebook.Runtime.Definitions do
         },
         %{
           name: "Kubernetes",
-          packages: [kino_flame, flame_k8s_backend, yaml_elixir]
+          packages: [kino_flame, flame_k8s_backend]
         }
       ]
     }

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -223,11 +223,11 @@ defmodule Livebook.Runtime.Definitions do
       name: "FLAME runner cell",
       requirement_presets: [
         %{
-          name: "Fly Backend",
+          name: "Fly",
           packages: [kino_flame]
         },
         %{
-          name: "Kubernetes Backend",
+          name: "Kubernetes",
           packages: [kino_flame, flame_k8s_backend, yaml_elixir]
         }
       ]

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -81,7 +81,7 @@ defmodule Livebook.Runtime.Definitions do
   }
 
   yaml_elixir = %{
-    name: "kino_flame",
+    name: "yaml_elixir",
     dependency: %{dep: {:yaml_elixir, "~> 2.0"}, config: []}
   }
 

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -57,7 +57,7 @@ defmodule Livebook.Runtime.Definitions do
 
   kino_flame = %{
     name: "kino_flame",
-    dependency: %{dep: {:kino_flame, "~> 0.1.0"}, config: []}
+    dependency: %{dep: {:kino_flame, "~> 0.1.3"}, config: []}
   }
 
   flame_k8s_backend = %{


### PR DESCRIPTION
Once https://github.com/livebook-dev/kino_flame/pull/3 is merged, let's add a definition for Kubernetes backend with the required packages. I guess there is no way to set the `"backend"` attribute to "k8s", right?