### PR TITLE
Fix editor rendering on socket reconnection

### DIFF
--- a/assets/js/hooks/cell_editor.js
+++ b/assets/js/hooks/cell_editor.js
@@ -87,6 +87,9 @@ const CellEditor = {
     // to clean up and mount a fresh hook, which we force by ensuring
     // the DOM id doesn't match
     this.el.removeAttribute("id");
+    // The container element has phx-update="ignore", so we want to
+    // make sure it is also replaced
+    this.el.querySelector(`[data-el-editor-container]`).removeAttribute("id");
   },
 
   destroyed() {


### PR DESCRIPTION
Recently I added id to the editor child element and moved `phx-update="ignore"` there ([diff](https://github.com/livebook-dev/livebook/commit/0142d4720bf41bfa4104d73c9f00d7981a0a4969#diff-e6eccbfd0e4a52177b76dca4787efb183bc7e090096522881f96c6c04ffc49adR615-R632)). On reconnect, even though we remove the parent id, the child still ignores the patch. This PR removes both ids, which makes sure we replace the DOM.