### PR TITLE
Show connected nodes counter

### DIFF
--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -794,6 +794,9 @@ defmodule LivebookWeb.SessionLive.Render do
     <div class="mt-8 flex flex-col gap-2">
       <span class="text-sm text-gray-500 font-semibold uppercase">
         Connected nodes
+        <%= if @runtime_connected_nodes != [] do %>
+          (<%= length(@runtime_connected_nodes) %>)
+        <% end %>
       </span>
       <%= if @runtime_connected_nodes == [] do %>
         <div class="text-sm text-gray-800 flex flex-col">


### PR DESCRIPTION
Hard to know how many there are otherwise when you are running a cluster of 32 machines. The only question is if we show this information when we have zero nodes, but I chose not to. Here is how it would look like:

<img width="372" alt="Screenshot 2024-09-06 at 16 50 44" src="https://github.com/user-attachments/assets/7cf2e463-ceb1-49e7-a176-079fefc7334a">
