### PR TITLE
Allow disconnecting Fly runtime during initialization

### DIFF
--- a/lib/livebook/fly_api.ex
+++ b/lib/livebook/fly_api.ex
@@ -189,6 +189,22 @@ defmodule Livebook.FlyAPI do
   end
 
   @doc """
+  Deletes the given machine.
+  """
+  @spec delete_machine(String.t(), String.t(), String.t()) :: :ok | {:error, error}
+  def delete_machine(token, app_name, machine_id) do
+    params = %{force: true}
+
+    with {:ok, _data} <-
+           flaps_request(token, "/v1/apps/#{app_name}/machines/#{machine_id}",
+             method: :delete,
+             params: params
+           ) do
+      :ok
+    end
+  end
+
+  @doc """
   Waits for the machine to start.
   """
   @spec await_machine_started(String.t(), String.t(), String.t()) :: :ok | {:error, error}

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -806,13 +806,20 @@ defprotocol Livebook.Runtime do
   The `runtime` should be the struct updated with all information
   necessary for further communication.
 
-  In case the initialization is a particularly involved process, the
-  process may send updates to the caller:
+  In case the initialization is a particularly involved, the process
+  may send updates to the caller:
 
       * `{:runtime_connect_info, pid, info}`
 
   Where `info` is a few word text describing the current initialization
   step.
+
+  If the caller decides to abort the initialization, they can forecefully
+  kill the process. The runtime resources should already be tolerant
+  to abrupt Livebook termination and autodestroy through monitoring
+  and timeouts. However, when the initialization process gets killed,
+  it may be desirable to eagerly remove the resources it has already
+  allocated, which can be achieved with an additional watcher process.
   """
   @spec connect(t()) :: pid()
   def connect(runtime)

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -921,7 +921,7 @@ defmodule Livebook.Session.Data do
   end
 
   def apply_operation(data, {:disconnect_runtime, _client_id}) do
-    with :connected <- data.runtime_status do
+    with true <- data.runtime_status in [:connecting, :connected] do
       data
       |> with_actions()
       |> disconnect_runtime()

--- a/lib/livebook_web/live/session_live/fly_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/fly_runtime_component.ex
@@ -122,16 +122,27 @@ defmodule LivebookWeb.SessionLive.FlyRuntimeComponent do
           />
 
           <div class="mt-8">
-            <.button
-              phx-click="init"
-              phx-target={@myself}
-              disabled={
-                @runtime_status == :connecting or not @specs_changeset.valid? or
-                  volume_errors(@volume_id, @volumes, @region) != []
-              }
-            >
-              <%= label(@app_name, @runtime, @runtime_status) %>
-            </.button>
+            <div class="flex gap-2">
+              <.button
+                phx-click="init"
+                phx-target={@myself}
+                disabled={
+                  @runtime_status == :connecting or not @specs_changeset.valid? or
+                    volume_errors(@volume_id, @volumes, @region) != []
+                }
+              >
+                <%= label(@app_name, @runtime, @runtime_status) %>
+              </.button>
+              <.button
+                :if={@runtime_status == :connecting}
+                color="red"
+                outlined
+                phx-click="disconnect"
+                phx-target={@myself}
+              >
+                Disconnect
+              </.button>
+            </div>
             <div
               :if={reconnecting?(@app_name, @runtime) && @runtime_connect_info}
               class="mt-4 scroll-mb-8"
@@ -579,6 +590,11 @@ defmodule LivebookWeb.SessionLive.FlyRuntimeComponent do
     runtime = Runtime.Fly.new(config)
     Session.set_runtime(socket.assigns.session.pid, runtime)
     Session.connect_runtime(socket.assigns.session.pid)
+    {:noreply, socket}
+  end
+
+  def handle_event("disconnect", %{}, socket) do
+    Session.disconnect_runtime(socket.assigns.session.pid)
     {:noreply, socket}
   end
 

--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -676,7 +676,7 @@ defmodule LivebookWeb.SessionLive.Render do
           </.button>
 
           <.button
-            :if={@data_view.runtime_status == :connected}
+            :if={@data_view.runtime_status in [:connected, :connecting]}
             color="red"
             outlined
             type="button"

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -3940,11 +3940,8 @@ defmodule Livebook.Session.DataTest do
   end
 
   describe "apply_operation/2 given :disconnect_runtime" do
-    test "returns an error if the runtime is not connected" do
-      data =
-        data_after_operations!([
-          {:connect_runtime, @cid}
-        ])
+    test "returns an error if the runtime is disconnected" do
+      data = Data.new()
 
       operation = {:disconnect_runtime, @cid}
 


### PR DESCRIPTION
Sometimes connecting may take quite a bit, and the user may realise that they want to change the config. Instead of waiting for the connection to finish, this allows them to hit "Disconnect".

`Runtime.connect` is already designed to return a pid that the session monitors. When the disconnect happens while connecting, the session is going to kill that process directly. For the Fly runtime, we have an additional watcher that eagerly deletes the machine in such case (if created).

Initially I thought about extending `Runtime.disconnect` to handle connecting state, but we would need to keep track of pid in each runtime struct and also have more duplication. Since the session already expects pid responsible for connecting, I think a direct kill is fine.