### PR TITLE
Add usage note to secrets form

### DIFF
--- a/lib/livebook_web/live/hub/secret_form_component.ex
+++ b/lib/livebook_web/live/hub/secret_form_component.ex
@@ -36,7 +36,7 @@ defmodule LivebookWeb.Hub.SecretFormComponent do
         <%= @title %>
       </h3>
       <p class="text-gray-700">
-        A notebook can read the secret value from LB_ prefixed environment variable.
+        A notebook can read the secret value as a LB_ prefixed environment variable.
       </p>
       <div :if={@error_message} class="error-box">
         <%= @error_message %>

--- a/lib/livebook_web/live/hub/secret_form_component.ex
+++ b/lib/livebook_web/live/hub/secret_form_component.ex
@@ -35,6 +35,9 @@ defmodule LivebookWeb.Hub.SecretFormComponent do
       <h3 class="text-2xl font-semibold text-gray-800">
         <%= @title %>
       </h3>
+      <p class="text-gray-700">
+        A notebook can read the secret value from LB_ prefixed environment variable.
+      </p>
       <div :if={@error_message} class="error-box">
         <%= @error_message %>
       </div>

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -41,6 +41,9 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
       <h3 class="text-2xl font-semibold text-gray-800">
         <%= @title %>
       </h3>
+      <p class="text-gray-700">
+        The notebook can read the secret value from LB_ prefixed environment variable.
+      </p>
       <.grant_access_message
         :if={@grant_access_secret}
         secret={@grant_access_secret}

--- a/lib/livebook_web/live/session_live/secrets_component.ex
+++ b/lib/livebook_web/live/session_live/secrets_component.ex
@@ -42,7 +42,7 @@ defmodule LivebookWeb.SessionLive.SecretsComponent do
         <%= @title %>
       </h3>
       <p class="text-gray-700">
-        The notebook can read the secret value from LB_ prefixed environment variable.
+        The notebook can read the secret value as a LB_ prefixed environment variable.
       </p>
       <.grant_access_message
         :if={@grant_access_secret}


### PR DESCRIPTION
Closes #2778.

<img width="609" alt="image" src="https://github.com/user-attachments/assets/8c7e1c02-0e9d-46ea-a47a-b73aa457eccd">