### PR TITLE
Extend configuration for update check to include version

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :livebook,
   shutdown_callback: nil,
   teams_auth?: false,
   teams_url: "https://teams.livebook.dev",
-  github_release_info: [repo: "livebook-dev/livebook", version: Mix.Project.config()[:version]],
+  github_release_info: %{repo: "livebook-dev/livebook", version: Mix.Project.config()[:version]},
   update_instructions_url: nil,
   within_iframe: false
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :livebook,
   shutdown_callback: nil,
   teams_auth?: false,
   teams_url: "https://teams.livebook.dev",
-  github_release_repo: "livebook-dev/livebook",
+  github_release_info: [repo: "livebook-dev/livebook", version: Mix.Project.config()[:version]],
   update_instructions_url: nil,
   within_iframe: false
 

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -424,6 +424,7 @@ defmodule Livebook.Config do
   @doc """
   Returns the GitHub org/repo where the releases are created.
   """
+  @spec github_release_info() :: %{repo: String.t(), version: String.t()}
   def github_release_info() do
     Application.get_env(:livebook, :github_release_info)
   end

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -414,25 +414,18 @@ defmodule Livebook.Config do
     Application.get_env(:livebook, :warn_on_live_teams_server, false)
   end
 
-  @livebook_version Mix.Project.config()[:version]
+  @app_version Mix.Project.config()[:version]
 
   @doc """
-  Livebook can be used as both an application as well as a library embedded
-  in other appilcations. This function always returns the version of the library
+  Returns the current version of running Livebook.
   """
-  def livebook_version(), do: @livebook_version
-
-  @doc """
-  Returns the current version of the running Livebook application. Note: this version
-  can be different from the livebook_version when livebook is used as a library.
-  """
-  def app_version(), do: Application.get_env(:livebook, :app_version, livebook_version())
+  def app_version(), do: @app_version
 
   @doc """
   Returns the GitHub org/repo where the releases are created.
   """
-  def github_release_repo() do
-    Application.get_env(:livebook, :github_release_repo)
+  def github_release_info() do
+    Application.get_env(:livebook, :github_release_info)
   end
 
   @doc """

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -414,12 +414,19 @@ defmodule Livebook.Config do
     Application.get_env(:livebook, :warn_on_live_teams_server, false)
   end
 
-  @app_version Mix.Project.config()[:version]
+  @livebook_version Mix.Project.config()[:version]
 
   @doc """
-  Returns the current version of running Livebook.
+  Livebook can be used as both an application as well as a library embedded
+  in other appilcations. This function always returns the version of the library
   """
-  def app_version(), do: @app_version
+  def livebook_version(), do: @livebook_version
+
+  @doc """
+  Returns the current version of the running Livebook application. Note: this version
+  can be different from the livebook_version when livebook is used as a library.
+  """
+  def app_version(), do: Application.get_env(:livebook, :app_version, livebook_version())
 
   @doc """
   Returns the GitHub org/repo where the releases are created.

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -147,8 +147,8 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp new_version(release) do
-  with current_version <- Keyword.fetch!(Livebook.Config.github_release_info(), :version),
-        %{
+    with current_version <- Keyword.fetch!(Livebook.Config.github_release_info(), :version),
+         %{
            "tag_name" => "v" <> version,
            "published_at" => published_at,
            "draft" => false

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -128,7 +128,7 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp fetch_latest_version() do
-    repo = Keyword.fetch!(Livebook.Config.github_release_info(), :repo)
+    repo = Livebook.Config.github_release_info().repo
     url = "https://api.github.com/repos/#{repo}/releases/latest"
     headers = [{"accept", "application/vnd.github.v3+json"}]
 
@@ -147,7 +147,7 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp new_version(release) do
-    with current_version <- Keyword.fetch!(Livebook.Config.github_release_info(), :version),
+    with current_version <- Livebook.Config.github_release_info().version,
          %{
            "tag_name" => "v" <> version,
            "published_at" => published_at,

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -128,7 +128,8 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp fetch_latest_version() do
-    url = "https://api.github.com/repos/#{Livebook.Config.github_release_repo()}/releases/latest"
+    repo = Keyword.fetch!(Livebook.Config.github_release_info(), :repo)
+    url = "https://api.github.com/repos/#{repo}/releases/latest"
     headers = [{"accept", "application/vnd.github.v3+json"}]
 
     case Livebook.Utils.HTTP.request(:get, url, headers: headers) do
@@ -146,9 +147,8 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp new_version(release) do
-    current_version = Livebook.Config.app_version()
-
-    with %{
+  with current_version <- Keyword.fetch!(Livebook.Config.github_release_info(), :version),
+        %{
            "tag_name" => "v" <> version,
            "published_at" => published_at,
            "draft" => false

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -147,8 +147,9 @@ defmodule Livebook.UpdateCheck do
   end
 
   defp new_version(release) do
-    with current_version <- Livebook.Config.github_release_info().version,
-         %{
+    current_version = Livebook.Config.github_release_info().version
+
+    with %{
            "tag_name" => "v" <> version,
            "published_at" => published_at,
            "draft" => false


### PR DESCRIPTION
The `Livebook.Config.app_version/0` is hard coded and can't be changed. This hard coded version corresponds more to the library version and not to the app version (and therefore can't be overwritten).

This PR introduces that distinction by introducing a new `Livebook.Config.livebook_version/0` function  and make the `Livebook.Config.app_version/0` overwritable through `config/config.exs`.

You can find a more information  [here](https://github.com/livebook-dev/livebook/discussions/2742#discussioncomment-10653995)


