### PR TITLE
Small fix to intro docs for Outline icon reference

### DIFF
--- a/lib/livebook/notebook/learn/intro_to_livebook.livemd
+++ b/lib/livebook/notebook/learn/intro_to_livebook.livemd
@@ -34,7 +34,7 @@ the status indicator on the bottom right of the second cell become yellow.
 ## Sections
 
 You can leverage so called **sections** to nicely group related cells together.
-Click on the "Book" icon (<i class="ri-livebook-sections"></i>) in the sidebar
+Click on the "Outline" icon (<i class="ri-node-tree"></i>) in the sidebar
 to reveal a list of all sections. As you can see, this approach helps to easily
 jump around the notebook, especially once it grows.
 


### PR DESCRIPTION
## Before:

<img width="494" alt="Cursor_and_Welcome_to_Livebook_-_Livebook" src="https://github.com/user-attachments/assets/834cb669-e6fe-4489-a93f-31a690c0aeac">

## After:

<img width="502" alt="Welcome_to_Livebook_-_Livebook" src="https://github.com/user-attachments/assets/9416ee93-5751-48ad-84d2-8d7065a44f27">
