### PR TITLE
Tell users to install kubectl if missing

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -421,6 +421,14 @@ defmodule Livebook.Config do
   """
   def app_version(), do: @app_version
 
+  @app? Mix.target() == :app
+
+  @doc """
+  Returns whether running at the desktop app.
+  """
+  @spec app?() :: boolean()
+  def app?(), do: @app?
+
   @doc """
   Returns the GitHub org/repo where the releases are created.
   """

--- a/lib/livebook_web/live/session_live/k8s_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/k8s_runtime_component.ex
@@ -803,7 +803,7 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
         """
         #{warning}
 
-        For livebook Desktop, this can be done by creating a file at #{path} with:
+        For Livebook Desktop, this can be done by creating a file at #{path} with:
 
             #{command}
         """

--- a/lib/livebook_web/live/session_live/k8s_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/k8s_runtime_component.ex
@@ -783,20 +783,30 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
   end
 
   defp kubectl_warning() do
-    if System.find_executable("kubectl") == nil do
+    if System.find_executable("kubectl") == nil || true do
       warning = "Could not find kubectl in PATH. Make sure to install it and add it to PATH."
 
-      if Livebook.Config.app?() do
+      if Livebook.Config.app?() || true do
         windows? = match?({:win32, _}, :os.type())
 
-        path =
+        {path, command} =
           if windows? do
-            "%USERPROFILE%\\.livebookdesktop.bat"
+            path = "#{System.get_env("USERPROFILE", "%USERPROFILE%")}\\.livebookdesktop.bat"
+            command = ~s|set "PATH=C:\\path\\to\\dir\\;%PATH%"|
+            {path, command}
           else
-            "~/.livebookdesktop.sh"
+            path = "#{System.get_env("HOME", "$HOME")}/.livebookdesktop.sh"
+            command = ~s|export PATH="/path/to/dir:$PATH"|
+            {path, command}
           end
 
-        warning <> " Set PATH in #{path} in order for Livebook Desktop to use it."
+        """
+        #{warning}
+
+        For livebook Desktop, this can be done by creating a file at #{path} with:
+
+            #{command}
+        """
       else
         warning
       end

--- a/lib/livebook_web/live/session_live/k8s_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/k8s_runtime_component.ex
@@ -87,6 +87,10 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
   def render(assigns) do
     ~H"""
     <div>
+      <div :if={warning = kubectl_warning()} class="mb-2">
+        <.message_box kind={:warning} message={warning} />
+      </div>
+
       <p class="text-gray-700">
         Start a temporary Kubernetes Pod with an Elixir node to evaluate code.
         The Pod is automatically deleted, once you disconnect the runtime.
@@ -776,5 +780,26 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
       docker_tag: socket.assigns.docker_tag,
       pod_template: socket.assigns.pod_template.template
     }
+  end
+
+  defp kubectl_warning() do
+    if System.find_executable("kubectl") == nil do
+      warning = "Could not find kubectl in PATH. Make sure to install it and add it to PATH."
+
+      if Livebook.Config.app?() do
+        windows? = match?({:win32, _}, :os.type())
+
+        path =
+          if windows? do
+            "%USERPROFILE%\\.livebookdesktop.bat"
+          else
+            "~/.livebookdesktop.sh"
+          end
+
+        warning <> " Set PATH in #{path} in order for Livebook Desktop to use it."
+      else
+        warning
+      end
+    end
   end
 end

--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -8,7 +8,6 @@ set RELEASE_DISTRIBUTION=none
 set MIX_ARCHIVES=!RELEASE_ROOT!\vendor\archives
 set MIX_REBAR3=!RELEASE_ROOT!\vendor\rebar3
 if not defined LIVEBOOK_SHUTDOWN_ENABLED set LIVEBOOK_SHUTDOWN_ENABLED=true
-set LIVEBOOK_DESKTOP=true
 if not defined LIVEBOOK_PORT (set LIVEBOOK_PORT=0)
 set PATH=!RELEASE_ROOT!\vendor\otp\erts-<%= @release.erts_version%>\bin;!RELEASE_ROOT!\vendor\otp\bin;!RELEASE_ROOT!\vendor\elixir\bin;!PATH!
 

--- a/rel/app/env.sh.eex
+++ b/rel/app/env.sh.eex
@@ -8,7 +8,6 @@ export RELEASE_DISTRIBUTION="none"
 export MIX_ARCHIVES="${RELEASE_ROOT}/vendor/archives"
 export MIX_REBAR3="${RELEASE_ROOT}/vendor/rebar3"
 export LIVEBOOK_SHUTDOWN_ENABLED=${LIVEBOOK_SHUTDOWN_ENABLED:-true}
-export LIVEBOOK_DESKTOP=true
 [ -z "$LIVEBOOK_PORT" ] && export LIVEBOOK_PORT=0
 export PATH="$RELEASE_ROOT/vendor/otp/erts-<%= @release.erts_version%>/bin:$RELEASE_ROOT/vendor/otp/bin:$RELEASE_ROOT/vendor/elixir/bin:$PATH"
 


### PR DESCRIPTION
My understanding is that it's hard to guess properly where kubectl is installed across OSes, so Desktop users will need to add it to PATH explicitly. This adds a corresponding hint in the UI.