### PR TITLE
WIP: Hiding code blocks (via Custom Views?)

### DIFF
--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -341,6 +341,10 @@ solely client-side operations.
   @apply hidden;
 }
 
+[data-js-hide-code] [data-type="code"] [data-p-language] {
+  @apply hidden;
+}
+
 [data-js-spotlight]
   :is(
     [data-el-section-headline]:not([data-js-focused]),

--- a/assets/js/hooks/custom_view_settings.js
+++ b/assets/js/hooks/custom_view_settings.js
@@ -13,6 +13,9 @@ const CustomViewSettings = {
     const customMarkdownCheckbox = this.el.querySelector(
       `[name="show_markdown"][value="true"]`,
     );
+    const customCodeCheckbox = this.el.querySelector(
+      `[name="show_code"][value="true"]`,
+    );
     const customOutputCheckbox = this.el.querySelector(
       `[name="show_output"][value="true"]`,
     );
@@ -22,6 +25,7 @@ const CustomViewSettings = {
 
     customSectionCheckbox.checked = settings.custom_view_show_section;
     customMarkdownCheckbox.checked = settings.custom_view_show_markdown;
+    customCodeCheckbox.checked = settings.custom_view_show_code;
     customOutputCheckbox.checked = settings.custom_view_show_output;
     customSpotlightCheckbox.checked = settings.custom_view_spotlight;
 
@@ -30,6 +34,9 @@ const CustomViewSettings = {
     });
     customMarkdownCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ custom_view_show_markdown: event.target.checked });
+    });
+    customCodeCheckbox.addEventListener("change", (event) => {
+      settingsStore.update({ custom_view_show_code: event.target.checked });
     });
     customOutputCheckbox.addEventListener("change", (event) => {
       settingsStore.update({ custom_view_show_output: event.target.checked });

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -1118,6 +1118,7 @@ const Session = {
       this.setView(view, {
         showSection: false,
         showMarkdown: false,
+        showCode: true,
         showOutput: true,
         spotlight: false,
       });
@@ -1125,6 +1126,7 @@ const Session = {
       this.setView(view, {
         showSection: true,
         showMarkdown: true,
+        showCode: true,
         showOutput: true,
         spotlight: true,
       });
@@ -1134,6 +1136,7 @@ const Session = {
           this.setView(view, {
             showSection: settings.custom_view_show_section,
             showMarkdown: settings.custom_view_show_markdown,
+            showCode: settings.custom_view_show_code,
             showOutput: settings.custom_view_show_output,
             spotlight: settings.custom_view_spotlight,
           });
@@ -1167,6 +1170,7 @@ const Session = {
 
     this.el.toggleAttribute("data-js-hide-section", !options.showSection);
     this.el.toggleAttribute("data-js-hide-markdown", !options.showMarkdown);
+    this.el.toggleAttribute("data-js-hide-code", !options.showCode);
     this.el.toggleAttribute("data-js-hide-output", !options.showOutput);
     this.el.toggleAttribute("data-js-spotlight", options.spotlight);
   },
@@ -1179,6 +1183,7 @@ const Session = {
 
     this.el.removeAttribute("data-js-hide-section");
     this.el.removeAttribute("data-js-hide-markdown");
+    this.el.removeAttribute("data-js-hide-code");
     this.el.removeAttribute("data-js-hide-output");
     this.el.removeAttribute("data-js-spotlight");
   },

--- a/assets/js/lib/settings.js
+++ b/assets/js/lib/settings.js
@@ -29,6 +29,7 @@ const DEFAULTSETTINGS = {
   editor_mode: EDITOR_MODE.default,
   custom_view_show_section: true,
   custom_view_show_markdown: true,
+  custom_view_show_code: true,
   custom_view_show_output: true,
   custom_view_spotlight: false,
 };

--- a/lib/livebook_web/live/session_live/custom_view_component.ex
+++ b/lib/livebook_web/live/session_live/custom_view_component.ex
@@ -23,6 +23,7 @@ defmodule LivebookWeb.SessionLive.CustomViewComponent do
       >
         <.switch_field name="show_section" label="Show sections" value={false} />
         <.switch_field name="show_markdown" label="Show markdown" value={false} />
+        <.switch_field name="show_code" label="Show code" value={false} />
         <.switch_field name="show_output" label="Show outputs" value={false} />
         <.switch_field name="spotlight" label="Spotlight focused" value={false} />
       </div>


### PR DESCRIPTION
Continuing [this thread](https://elixirforum.com/t/livebook-view-rich-outputs-markdown-but-no-code/66178/11?u=christhekeele) with @josevalim from the forums, I'd like to propose the ability to hide code blocks from view.

My use-case here is playbooks, where once written, the code takes backseat to operational Markdown instruction, Kino input configuration, and rich outputs. Between Apps and Custom view, there is not quite a way to focus a Livebook like this today.

---

### Approach

The ***easiest*** way (*discuss: is there a **better** way?*) to accomplish this looks to be the addition of a new option in Custom Views to hide code blocks.

This PR serves as a starting point around the discussion for that UX: adding a `[data-js-hide-code]` flag inline with other view options, and naively making the `[data-type="code"] [data-p-language]` code editor `@hidden` when it is present (aka when the menu item is toggled off).

<img width="553" alt="Screenshot 2024-09-20 at 11 01 43 PM" src="https://github.com/user-attachments/assets/0f16916e-b13c-414e-8f27-2d0d8f5a9e9f">

---

### Problems

Assuming this is an avenue worth investigating, this naive implementation immediately highlights a few UX issues around where and how various UI elements anchored to the code editor appear.

Simple and rich outputs still look good:

<img width="920" alt="Screenshot 2024-09-23 at 12 16 01 PM" src="https://github.com/user-attachments/assets/b23bc29d-3847-45b8-b61f-49a4e1d2cb99">

<img width="919" alt="Screenshot 2024-09-23 at 12 16 08 PM" src="https://github.com/user-attachments/assets/1183714c-5d6c-473f-a640-64713f698d15">

However, key contextual elements reliant on hover state become inaccessible in various ways:

1. The Evaluation Button
  
    <img width="128" alt="Screenshot 2024-09-23 at 12 13 59 PM" src="https://github.com/user-attachments/assets/daf4d206-4a0a-4905-b467-fed3bf6157d2">
  
2. The Block Settings

    <img width="218" alt="Screenshot 2024-09-23 at 12 14 04 PM" src="https://github.com/user-attachments/assets/8914278d-fe6c-4f79-8ae3-f2743f6fec52">

3. The Section Insertion

    <img width="271" alt="Screenshot 2024-09-23 at 12 14 10 PM" src="https://github.com/user-attachments/assets/c7e19cc6-fcc0-4d6a-a4d5-91cfd9da669a">

Additionally, the Evaluation Status, meant to be shown in the bottom-right of the editor, floats up and over previous section content or the block settings (if forced to be visible) in awkward ways:

<img width="101" alt="Screenshot 2024-09-23 at 12 14 20 PM" src="https://github.com/user-attachments/assets/8d177668-a9e8-46db-8b40-c9149f40a421">
<img width="919" alt="Screenshot 2024-09-23 at 12 16 08 PM" src="https://github.com/user-attachments/assets/f3b358e4-79da-4048-bc25-32fc2035401e">
<img width="936" alt="Screenshot 2024-09-23 at 12 05 28 PM" src="https://github.com/user-attachments/assets/351c4f80-4a55-4144-a351-34846127a438">

---

### Solution

I'm not an adept frontend or UX designer, so my 2 cents shouldn't go too far, and I'm not up to the task of implementing this. But in my mind, a satisfactory solution would be if, when code blocks are set to be hidden:

- Forcing the Evaluation Button to be permanently visible, and perhaps a hair larger
- Floating the Evaluation Status immediately to the right of the button
- Hovering in Section Insertion as normal, inline with the button, in the center
- Having Block Settings appear on on the right as normal, on hover over output or this button row in general

---

### Other thoughts

Open to thoughts and other completely different ideas for implementation!

A nice-to-have might be to have a way to exit hide-code mode, or have an individual temporary override toggle per code block cell, right there—either in the Evaluation Button dropdown, or in the Block Settings on the right as a new element.

<img width="949" alt="Screenshot 2024-09-23 at 12 42 08 PM" src="https://github.com/user-attachments/assets/57af0a4f-e05c-4075-b152-1cce0d5563d9">
<img width="931" alt="Screenshot 2024-09-23 at 12 44 32 PM" src="https://github.com/user-attachments/assets/541422e1-1a1f-49a2-882c-07c2693df7e6">

If this toggle were moved into the Block Settings, it might make sense to always leave that as an option, for temporarily hiding the code editor in any context. How this would interact with a Custom View option merits more consideration, and we could perhaps redirect this effort to simply focus on per-cell hiding behaviour. However, my use-case does want a really easy, single-button, holistic control over hiding code blocks. But maybe we start smaller?