### PR TITLE
Fix handling of erlang syntax errors

### DIFF
--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -785,29 +785,10 @@ defmodule Livebook.Runtime.Evaluator do
   end
 
   defp make_snippet(code, location) do
-    start_line = 1
-    start_column = 1
-    line = :erl_anno.line(location)
-
-    case :erl_anno.column(location) do
-      :undefined ->
-        nil
-
-      column ->
-        lines = :string.split(code, "\n", :all)
-        snippet = :lists.nth(line - start_line + 1, lines)
-
-        offset =
-          if line == start_line do
-            column - start_column
-          else
-            column - 1
-          end
-
-        case :string.trim(code, :leading) do
-          [] -> nil
-          _ -> %{content: snippet, offset: offset}
-        end
+    if :erl_anno.column(location) != :undefined and :string.trim(code, :leading) != [] do
+      line = :erl_anno.line(location)
+      lines = :string.split(code, "\n", :all)
+      :lists.nth(line, lines)
     end
   end
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -1373,22 +1373,56 @@ defmodule Livebook.Runtime.EvaluatorTest do
       # Incomplete input
       Evaluator.evaluate_code(evaluator, :erlang, "X =", :code_1, [])
       assert_receive {:runtime_evaluation_response, :code_1, error(message), metadata()}
-      assert "\e[31m** (TokenMissingError)" <> _ = message
+
+      assert clean_message(message) === """
+             ** (TokenMissingError) token missing on nofile:1:4:
+                 error: syntax error before:
+                 │
+               1 │ X =
+                 │    ^
+                 │
+                 └─ nofile:1:4\
+             """
 
       # Parser error
       Evaluator.evaluate_code(evaluator, :erlang, "X ==/== a.", :code_2, [])
       assert_receive {:runtime_evaluation_response, :code_2, error(message), metadata()}
-      assert "\e[31m** (SyntaxError)" <> _ = message
+
+      assert clean_message(message) === """
+             ** (SyntaxError) invalid syntax found on nofile:1:5:
+                 error: syntax error before: /=
+                 │
+               1 │ X ==/== a.
+                 │     ^
+                 │
+                 └─ nofile:1:5\
+             """
 
       # Tokenizer error
       Evaluator.evaluate_code(evaluator, :erlang, "$a$", :code_3, [])
       assert_receive {:runtime_evaluation_response, :code_3, error(message), metadata()}
-      assert "\e[31m** (SyntaxError)" <> _ = message
+
+      assert clean_message(message) === """
+             ** (SyntaxError) invalid syntax found on nofile:1:3:
+                 error: unterminated character
+                 │
+               1 │ $a$
+                 │   ^
+                 │
+                 └─ nofile:1:3\
+             """
 
       # Erlang exception
       Evaluator.evaluate_code(evaluator, :erlang, "list_to_binary(1).", :code_4, [])
       assert_receive {:runtime_evaluation_response, :code_4, error(message), metadata()}
-      assert "\e[31mexception error: bad argument" <> _ = message
+
+      assert clean_message(message) === """
+             exception error: bad argument
+               in function  list_to_binary/1
+                  called as list_to_binary(1)
+                  *** argument 1: not an iolist term
+               in call from erl_eval:do_apply/7 (erl_eval.erl, line 900)\
+             """
     end
   end
 


### PR DESCRIPTION
I noticed that `SyntaxError` or `MissingTokenError` in Erlang cells are currently triggering an `ArgumentError` when trying to generate the error message:

> ** (TokenMissingError) got ArgumentError with message "argument error" while retrieving Exception.message/1 for %TokenMissingError{...}

This is due to `error.snippet` being a map `%{content: "erlang", offset: 6}` instead of a string, this PR fixes it to just a string: `"erlang"` as expected by `TokenMissingError.message/1`.
I couldn't figure out where this `offset` was being used so I just removed it, but perhaps the fix is more involved in some other cases?

## Before

<img width="846" alt="Screenshot 2024-09-29 at 11 11 23" src="https://github.com/user-attachments/assets/205e0f7b-3837-4491-91c6-8858a327212e">

## After

<img width="854" alt="Screenshot 2024-09-29 at 11 11 32" src="https://github.com/user-attachments/assets/c9060783-e032-44cb-b810-61ee1d5f7fbe">
