### PR TITLE
Add erlang-module support (update)

### DIFF
--- a/lib/livebook/runtime/erl_dist/runtime_server.ex
+++ b/lib/livebook/runtime/erl_dist/runtime_server.ex
@@ -772,7 +772,9 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
 
   defp evaluator_tmp_dir(state) do
     if tmp_dir = state.tmp_dir do
-      Path.join(tmp_dir, "tmp")
+      path = Path.join(tmp_dir, "tmp")
+      File.mkdir_p!(path)
+      path
     end
   end
 

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -436,8 +436,8 @@ defmodule Livebook.Runtime.Evaluator do
 
     start_time = System.monotonic_time()
 
-    tmp_dir = Map.get(state, :tmp_dir)
-    {eval_result, code_markers} = eval(language, code, context.binding, context.env, tmp_dir)
+    {eval_result, code_markers} =
+      eval(language, code, context.binding, context.env, state.tmp_dir)
 
     evaluation_time_ms = time_diff_ms(start_time)
 

--- a/lib/livebook/runtime/evaluator.ex
+++ b/lib/livebook/runtime/evaluator.ex
@@ -752,9 +752,8 @@ defmodule Livebook.Runtime.Evaluator do
           {{:ok, result, binding, env}, []}
 
         :error ->
-          error = "compile.forms failed - syntax error"
-          {{:error, :error, error, []}, []}
-          # process_erlang_error(env, code, {1,1}, :compile,"Compile forms failed")
+          # TODO: Return errors and warnings and convert them to diagnostics
+          {{:error, :error, "compilation failed", []}, []}
       end
     catch
       kind, error ->

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -1300,6 +1300,75 @@ defmodule Livebook.Runtime.EvaluatorTest do
       assert_receive {:runtime_evaluation_response, :code_1, terminal_text("6"), metadata()}
     end
 
+    test "evaluate erlang-module code", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(
+        evaluator,
+        :erlang,
+        "-module(tryme). -export([go/0]). go() ->{ok,went}.",
+        :code_4,
+        []
+      )
+
+      assert_receive {:runtime_evaluation_response, :code_4, terminal_text(_), metadata()}
+    end
+
+    test "evaluate erlang-module error function already defined", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(
+        evaluator,
+        :erlang,
+        "-module(tryme). -export([go/0]). go() ->{ok,went}. go() ->{ok,went}.",
+        :code_4,
+        []
+      )
+
+      assert_receive {
+        :runtime_evaluation_response,
+        :code_4,
+        error(message),
+        metadata()
+      }
+
+      assert message =~ "compile.forms failed - syntax error"
+    end
+
+    test "evaluate erlang-module error - expression after module", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(
+        evaluator,
+        :erlang,
+        "-module(tryme). -export([go/0]). go() ->{ok,went}. go() ->{ok,went}. A = 1.",
+        :code_4,
+        []
+      )
+
+      assert_receive {
+        :runtime_evaluation_response,
+        :code_4,
+        error(message),
+        metadata()
+      }
+
+      assert message =~ "compile.forms failed - syntax error"
+    end
+
+    test "evaluate erlang-module error - two modules", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(
+        evaluator,
+        :erlang,
+        "-module(one). -export([go/0]). go() ->{ok,one}. -module(two). -export([go/0]). go() ->{ok,two}.",
+        :code_4,
+        []
+      )
+
+      assert_receive {
+        :runtime_evaluation_response,
+        :code_4,
+        error(message),
+        metadata()
+      }
+
+      assert message =~ "compile.forms failed - syntax error"
+    end
+
     test "mixed erlang/elixir bindings", %{evaluator: evaluator} do
       Evaluator.evaluate_code(evaluator, :elixir, "x = 1", :code_1, [])
       Evaluator.evaluate_code(evaluator, :erlang, "Y = X.", :code_2, [:code_1])

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -1328,7 +1328,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
         metadata()
       }
 
-      assert message =~ "compile.forms failed - syntax error"
+      assert message =~ "compilation failed"
     end
 
     test "evaluate erlang-module error - expression after module", %{evaluator: evaluator} do
@@ -1347,7 +1347,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
         metadata()
       }
 
-      assert message =~ "compile.forms failed - syntax error"
+      assert message =~ "compilation failed"
     end
 
     test "evaluate erlang-module error - two modules", %{evaluator: evaluator} do
@@ -1366,7 +1366,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
         metadata()
       }
 
-      assert message =~ "compile.forms failed - syntax error"
+      assert message =~ "compilation failed"
     end
 
     test "mixed erlang/elixir bindings", %{evaluator: evaluator} do


### PR DESCRIPTION
Single modules are now allowed to be defined in an Erlang-cell.

In this case the entire code-block is interpreted as an erlang-module 
and if there are no errors the module is compiled and loaded.

If the cell containing the module is deleted subsequent code invocations will fail.

Stale indicator is not working yet due to missing notion of functions, this will be fixed in a next version.