### PR TITLE
Wrap module names in the outline

### DIFF
--- a/lib/livebook_web/live/session_live/render.ex
+++ b/lib/livebook_web/live/session_live/render.ex
@@ -525,14 +525,13 @@ defmodule LivebookWeb.SessionLive.Render do
           <ul :if={section_item.identifier_definitions != []} class="mt-2 ml-5 list-none items-center">
             <li :for={definition <- section_item.identifier_definitions}>
               <button
-                class="flex items-center max-w-full text-gray-600 hover:text-gray-900 text-sm gap-1"
+                class="flex items-baseline max-w-full text-gray-600 hover:text-gray-900 text-sm gap-1"
                 data-el-outline-definition-item
                 data-file={definition.file}
                 data-line={definition.line}
-                title={definition.label}
               >
                 <.remix_icon icon="braces-line" class="font-normal opacity-50" />
-                <span class="font-mono truncate">
+                <span class="font-mono break-all text-left">
                   <%= definition.label %>
                 </span>
               </button>


### PR DESCRIPTION
Closes #2808.

![image](https://github.com/user-attachments/assets/2234fb38-d303-486f-b777-aa3bd1162abd)

Another idea is to wrap after dots:

![image](https://github.com/user-attachments/assets/7dc0cba4-4272-4d1a-b827-6757cf1e79fb)

It looks a bit weird, because the wrapped word feels more like a child item in the list.

Alternative suggestions are welcome :)