### PR TITLE
Fix ZTA key label

### DIFF
--- a/lib/livebook_web/components/app_components.ex
+++ b/lib/livebook_web/components/app_components.ex
@@ -156,7 +156,7 @@ defmodule LivebookWeb.AppComponents do
             :if={zta_metadata = zta_metadata(@form[:zta_provider].value)}
             field={@form[:zta_key]}
             type={Map.get(zta_metadata, :input, "text")}
-            label={zta_metadata.name}
+            label={zta_metadata.value}
             placeholder={Map.get(zta_metadata, :placeholder, "")}
             phx-debounce
             disabled={@disabled}


### PR DESCRIPTION
https://github.com/livebook-dev/livebook/blob/9c4b381664c7ed438d78780ca2e34e04ed447ea8/lib/livebook/config.ex#L18-L25

When showing the extra ZTA field, we currently use the ZTA name as label, but that name is already picked in the select. I think the label should come from the `metadata.value`, but opening PR just to double-check. I will update in Teams afterwards.