### PR TITLE
Get initial namespace from k8s context in the k8s runtime settings

### DIFF
--- a/lib/livebook_web/live/session_live/k8s_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/k8s_runtime_component.ex
@@ -536,6 +536,7 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
 
   def handle_async(:cluster_check, {:ok, results}, socket) do
     [access_review_result, namespaces_result] = results
+    context_namespace = socket.assigns.kubeconfig.current_namespace
 
     access_review_result =
       case access_review_result do
@@ -548,7 +549,7 @@ defmodule LivebookWeb.SessionLive.K8sRuntimeComponent do
       case namespaces_result do
         {:ok, namespaces} ->
           namespace_options = Enum.map(namespaces, & &1.name)
-          {:ok, namespace_options, List.first(namespace_options)}
+          {:ok, namespace_options, context_namespace || List.first(namespace_options)}
 
         {:error, %{status: 403}} ->
           # No access to list namespaces, we will show an input instead


### PR DESCRIPTION
This is a tiny change to set the initial value of the namespace selector on the k8s runtime component. With version 0.3.1 of `kubereq`, the field `:current_namespace` was added to [`Kubereq.Kubeconfig`](https://hexdocs.pm/kubereq/Kubereq.Kubeconfig.html#t:t/0). It holds the namespace of the currently selected context in the Kubernetes config. On local environments, this can be set through `kubectl config set-context --current --namespace=default`. When running in a cluster, this will be set to the service account's namespace which is usually where you'd want to work.