### PR TITLE
Bump actions/upload-artifact

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -95,24 +95,19 @@ jobs:
           # Render simple template from environment variables.
           envsubst < ./.github/uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
           cat docker-compose.rendered.yml
-      - name: Upload Rendered Compose File as Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: preview-spec
-          path: docker-compose.rendered.yml
-          retention-days: 2
       - name: Serialize PR Event to File
         run: |
           cat << EOF > event.json
           ${{ toJSON(github.event) }}
           EOF
-      - name: Upload PR Event as Artifact
+      - name: Upload Rendered Compose File and PR Event as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: preview-spec
-          path: event.json
+          path: |
+            docker-compose.rendered.yml
+            event.json
           retention-days: 2
-          overwrite: true
 
   delete-preview:
     name: Mark preview for deletion
@@ -131,4 +126,3 @@ jobs:
           name: preview-spec
           path: event.json
           retention-days: 2
-          overwrite: true

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -96,7 +96,7 @@ jobs:
           envsubst < ./.github/uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
           cat docker-compose.rendered.yml
       - name: Upload Rendered Compose File as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: docker-compose.rendered.yml
@@ -107,7 +107,7 @@ jobs:
           ${{ toJSON(github.event) }}
           EOF
       - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: event.json
@@ -125,7 +125,7 @@ jobs:
           ${{ toJSON(github.event) }}
           EOF
       - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: event.json

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -112,6 +112,7 @@ jobs:
           name: preview-spec
           path: event.json
           retention-days: 2
+          overwrite: true
 
   delete-preview:
     name: Mark preview for deletion
@@ -130,3 +131,4 @@ jobs:
           name: preview-spec
           path: event.json
           retention-days: 2
+          overwrite: true


### PR DESCRIPTION
`actions/upload-artifact@v3` is deprecated, opening PR to make sure the Uffizzi workflow works as expected.