### PR TITLE
Don't report form control change on first render

### DIFF
--- a/lib/livebook_web/live/output/control_form_component.ex
+++ b/lib/livebook_web/live/output/control_form_component.ex
@@ -3,7 +3,7 @@ defmodule LivebookWeb.Output.ControlFormComponent do
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, data: %{})}
+    {:ok, assign(socket, data: nil)}
   end
 
   @impl true
@@ -17,7 +17,7 @@ defmodule LivebookWeb.Output.ControlFormComponent do
         {field, assigns.input_views[input.id].value}
       end)
 
-    if data != prev_data do
+    if prev_data != nil and data != prev_data do
       change_data =
         for {field, value} <- data,
             assigns.control.attrs.report_changes[field],


### PR DESCRIPTION
Currently this:

```elixir
form =
  Kino.Control.form(
    [text: Kino.Input.text("foo")],
    report_changes: true,
    submit: "Send"
  )

Kino.listen(form, &IO.inspect/1)

form
```

emits a change event immediately. The reason issue is that we unexpectedly emit change when the form is first render, so if a subscription happens before the first render, there is an extra event.