### PR TITLE
Vendor elixir, otp, archives per Livebook version

### DIFF
--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -5,11 +5,12 @@ if exist "!USERPROFILE!\.livebookdesktop.bat" (
 set RELEASE_MODE=interactive
 set RELEASE_DISTRIBUTION=none
 
-set MIX_ARCHIVES=!RELEASE_ROOT!\vendor\archives
-set MIX_REBAR3=!RELEASE_ROOT!\vendor\rebar3
+set vendor_dir=!RELEASE_ROOT!\vendor\livebook-!RELEASE_VSN!
+set MIX_ARCHIVES=!vendor_dir!\archives
+set MIX_REBAR3=!vendor_dir!\rebar3
 if not defined LIVEBOOK_SHUTDOWN_ENABLED set LIVEBOOK_SHUTDOWN_ENABLED=true
 if not defined LIVEBOOK_PORT (set LIVEBOOK_PORT=0)
-set PATH=!RELEASE_ROOT!\vendor\otp\erts-<%= @release.erts_version%>\bin;!RELEASE_ROOT!\vendor\otp\bin;!RELEASE_ROOT!\vendor\elixir\bin;!PATH!
+set PATH=!vendor_dir!\otp\erts-<%= @release.erts_version%>\bin;!vendor_dir!\otp\bin;!vendor_dir!\elixir\bin;!PATH!
 
 if defined LIVEBOOK_NODE set RELEASE_NODE=!LIVEBOOK_NODE!
 if defined LIVEBOOK_COOKIE set RELEASE_COOKIE=!LIVEBOOK_COOKIE!

--- a/rel/app/env.sh.eex
+++ b/rel/app/env.sh.eex
@@ -5,11 +5,12 @@ fi
 export RELEASE_MODE="interactive"
 export RELEASE_DISTRIBUTION="none"
 
-export MIX_ARCHIVES="${RELEASE_ROOT}/vendor/archives"
-export MIX_REBAR3="${RELEASE_ROOT}/vendor/rebar3"
+vendor_dir="${RELEASE_ROOT}/vendor/livebook-${RELEASE_VSN}"
+export MIX_ARCHIVES="${vendor_dir}/archives"
+export MIX_REBAR3="${vendor_dir}/rebar3"
 export LIVEBOOK_SHUTDOWN_ENABLED=${LIVEBOOK_SHUTDOWN_ENABLED:-true}
 [ -z "$LIVEBOOK_PORT" ] && export LIVEBOOK_PORT=0
-export PATH="$RELEASE_ROOT/vendor/otp/erts-<%= @release.erts_version%>/bin:$RELEASE_ROOT/vendor/otp/bin:$RELEASE_ROOT/vendor/elixir/bin:$PATH"
+export PATH="${vendor_dir}/otp/erts-<%= @release.erts_version%>/bin:${vendor_dir}/otp/bin:${vendor_dir}/elixir/bin:$PATH"
 
 if [ ! -z "${LIVEBOOK_NODE}" ]; then export RELEASE_NODE=${LIVEBOOK_NODE}; fi
 if [ ! -z "${LIVEBOOK_COOKIE}" ]; then export RELEASE_COOKIE=${LIVEBOOK_COOKIE}; fi

--- a/rel/app/standalone.exs
+++ b/rel/app/standalone.exs
@@ -9,7 +9,7 @@ defmodule Standalone do
     erts_source = Path.join(:code.root_dir(), "erts-#{release.erts_version}")
     otp_bin_dir = Path.join(:code.root_dir(), "bin")
     otp_lib_dir = :code.lib_dir()
-    vendor_otp_dir = Path.join([release.path, "vendor", "otp"])
+    vendor_otp_dir = vendor_dir(release, "otp")
     File.rm_rf!(vendor_otp_dir)
     File.mkdir_p!(vendor_otp_dir)
 
@@ -74,7 +74,7 @@ defmodule Standalone do
   """
   @spec copy_elixir(Mix.Release.t(), elixir_version :: String.t()) :: Mix.Release.t()
   def copy_elixir(release, elixir_version) do
-    standalone_destination = Path.join(release.path, "vendor/elixir")
+    standalone_destination = vendor_dir(release, "elixir")
     download_elixir_at_destination(standalone_destination, elixir_version)
 
     filenames =
@@ -108,7 +108,7 @@ defmodule Standalone do
   """
   @spec copy_hex(Mix.Release.t()) :: Mix.Release.t()
   def copy_hex(release) do
-    release_archives_dir = Path.join(release.path, "vendor/archives")
+    release_archives_dir = vendor_dir(release, "archives")
     File.mkdir_p!(release_archives_dir)
 
     hex_version = Keyword.fetch!(Application.spec(:hex), :vsn)
@@ -132,7 +132,7 @@ defmodule Standalone do
       File.write!(path, binary, [:binary])
     end
 
-    destination = Path.join(release.path, "vendor/rebar3")
+    destination = vendor_dir(release, "rebar3")
     File.cp!(path, destination)
     make_executable(destination)
 
@@ -155,5 +155,9 @@ defmodule Standalone do
 
   defp cp_r!(source, destination) do
     File.cp_r!(source, destination, fn _, _ -> false end)
+  end
+
+  defp vendor_dir(release, path) do
+    Path.join([release.path, "vendor", "livebook-#{release.version}", path])
   end
 end


### PR DESCRIPTION
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/dd6b8129-208a-45d9-a2d0-c3ad0bff432f">

Dunno what the deal is with path to Elixir executable, maybe it's trimming the path when displaying or something but Elixir is obviously working correctly or we couldn't have evaluated that.

The downside of this approach is the size of otp directory which would be duplicated every time we bump it:

```
windows:~/AppData/Local/Livebook/rel$ du -sh vendor/livebook-0.15.0-dev/otp
222M    vendor/livebook-0.15.0-dev/otp
```

so instead of this, another idea would be for the installer to clean the directory before installing. On macOS this is not a problem because when people move Livebook.app to /Applications it seems to be overwriting the whole contents, does not keep prior files.