### PR TITLE
Fix file system failures when running Teams integration tests

### DIFF
--- a/lib/livebook/hubs.ex
+++ b/lib/livebook/hubs.ex
@@ -72,8 +72,8 @@ defmodule Livebook.Hubs do
   @spec save_hub(Provider.t()) :: Provider.t()
   def save_hub(struct) do
     attributes = Provider.dump(struct)
-    :ok = Storage.insert(@namespace, struct.id, Map.to_list(attributes))
     :ok = connect_hub(struct)
+    :ok = Storage.insert(@namespace, struct.id, Map.to_list(attributes))
     :ok = Broadcasts.hub_changed(struct.id)
 
     struct


### PR DESCRIPTION
Running tests with Teams integration quite consistently results in this error:

```
exited in: GenServer.call({:via, Registry, {Livebook.HubsRegistry, "team-org-number-33016086"}}, :get_file_systems, 5000)
```

I think this happens because we insert the hub into ETS first, and only then start the process, so a concurrent process can see the new hub and try to list its file systems, while the process may not be alive yet. I swapped the order such that we always start the process first, and I could no longer reproduce the error in a few runs, so I'm pretty sure that was actually the issue.