### PR TITLE
Fix auth with Livebook teams when user not belongs to org

### DIFF
--- a/lib/livebook/zta/livebook_teams.ex
+++ b/lib/livebook/zta/livebook_teams.ex
@@ -53,8 +53,8 @@ defmodule Livebook.ZTA.LivebookTeams do
 
   defp handle_request(conn, _team, %{"teams_identity" => _, "failed_reason" => reason}) do
     {conn
-     |> redirect(to: conn.request_path)
      |> put_session(:teams_failed_reason, reason)
+     |> redirect(to: conn.request_path)
      |> halt(), nil}
   end
 


### PR DESCRIPTION
This PR fixes a bug that happened in the following scenario.

- an app server belongs to a deployment group that is configured to require auth via Teams
- a user logged in to Teams tries to access that app server, but they don't belong to the org that owns that app server

Before this PR, the following exception was happening: `(Plug.Conn.AlreadySentError) the response was already sent`