### PR TITLE
Accepts 'auto' as value for LIVEBOOK_CLUSTER env var

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -694,8 +694,11 @@ defmodule Livebook.Config do
         "dns:" <> query ->
           query
 
+        "auto" ->
+          "auto"
+
         other ->
-          abort!(~s{expected #{env} to be "dns:query", got: #{inspect(other)}})
+          abort!(~s{expected #{env} to be either "dns:query" or "auto", got: #{inspect(other)}})
       end
     end
   end

--- a/test/livebook/config_test.exs
+++ b/test/livebook/config_test.exs
@@ -43,6 +43,20 @@ defmodule Livebook.ConfigTest do
     end
   end
 
+  describe "dns_cluster_query!/1" do
+    test "parses DNS query" do
+      with_env([TEST_LIVEBOOK_CLUSTER: "dns:myapp.internal"], fn ->
+        assert Config.dns_cluster_query!("TEST_LIVEBOOK_CLUSTER") == "myapp.internal"
+      end)
+    end
+
+    test "parses auto mode" do
+      with_env([TEST_LIVEBOOK_CLUSTER: "auto"], fn ->
+        assert Config.dns_cluster_query!("TEST_LIVEBOOK_CLUSTER") == "auto"
+      end)
+    end
+  end
+
   defp with_env(env_vars, fun) do
     existing =
       Enum.map(env_vars, fn {env, _value} ->


### PR DESCRIPTION
Before this PR, when setting the `LIVEBOOK_CLUSTER` env var to `auto`, the following error message was happening:

```
ERROR!!! [Livebook] expected LIVEBOOK_CLUSTER to be "dns:query", got: "auto"
```