### PR TITLE
Rename "Running sessions" to "Running notebooks"

### DIFF
--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -132,7 +132,7 @@ defmodule LivebookWeb.HomeLive do
           <% end %>
         </div>
 
-        <div id="running-sessions" class="py-20 mb-32" role="region" aria-label="running sessions">
+        <div id="running-sessions" class="py-20 mb-32" role="region" aria-label="running notebooks">
           <.live_component
             module={LivebookWeb.HomeLive.SessionListComponent}
             id="session-list"
@@ -212,7 +212,7 @@ defmodule LivebookWeb.HomeLive do
         class="font-medium border-b border-gray-900 hover:border-transparent"
         href="#running-sessions"
       >
-        running sessions
+        running notebooks
       </a>
     </LayoutComponents.topbar>
     """

--- a/lib/livebook_web/live/home_live/session_list_component.ex
+++ b/lib/livebook_web/live/home_live/session_list_component.ex
@@ -38,7 +38,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
     <form id="bulk-action-form" phx-submit="bulk_action" phx-target={@myself}>
       <div class="mb-4 flex items-center md:items-end justify-between">
         <h2 class="uppercase font-semibold text-gray-500 text-sm md:text-base">
-          Running sessions (<%= length(@sessions) %>)
+          Running notebooks (<%= length(@sessions) %>)
         </h2>
         <div class="flex items-center gap-4">
           <div class="flex gap-2 w-48 justify-end">
@@ -93,7 +93,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
   defp session_list(%{sessions: []} = assigns) do
     ~H"""
     <.no_entries>
-      You do not have any running sessions.
+      You do not have any running notebooks.
       <%= if @show_autosave_note? do %>
         <br />
         Looking for unsaved notebooks? <.link
@@ -108,7 +108,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
 
   defp session_list(assigns) do
     ~H"""
-    <div class="flex flex-col" role="group" aria-label="running sessions list">
+    <div class="flex flex-col" role="group" aria-label="running notebooks list">
       <div
         :for={session <- @sessions}
         class="py-4 flex items-center border-b last:border-b-0 border-gray-300"

--- a/lib/livebook_web/live/home_live/session_list_component.ex
+++ b/lib/livebook_web/live/home_live/session_list_component.ex
@@ -191,7 +191,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
               phx-value-id={session.id}
             >
               <.remix_icon icon="shut-down-line" />
-              <span>Disconnect runtime</span>
+              <span>Disconnect</span>
             </button>
           </.menu_item>
           <.menu_item variant="danger">
@@ -294,7 +294,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
             phx-click={set_action("disconnect")}
           >
             <.remix_icon icon="shut-down-line" />
-            <span>Disconnect runtime</span>
+            <span>Disconnect</span>
           </button>
         </.menu_item>
         <.menu_item>
@@ -306,7 +306,7 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
             phx-click={set_action("close_all")}
           >
             <.remix_icon icon="close-circle-line" />
-            <span>Close sessions</span>
+            <span>Close</span>
           </button>
           <input id="bulk-action-input" class="hidden" type="text" name="action" />
         </.menu_item>
@@ -367,10 +367,10 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
 
     {:noreply,
      confirm(socket, on_confirm,
-       title: "Disconnect runtime",
+       title: "Disconnect",
        description:
          "Are you sure you want to disconnect #{pluralize(length(selected_sessions), "session", "sessions")}?",
-       confirm_text: "Disconnect runtime",
+       confirm_text: "Disconnect",
        confirm_icon: "shut-down-line"
      )}
   end
@@ -403,9 +403,9 @@ defmodule LivebookWeb.HomeLive.SessionListComponent do
 
     {:noreply,
      confirm(socket, on_confirm,
-       title: "Close sessions",
+       title: "Close",
        description: description,
-       confirm_text: "Close sessions",
+       confirm_text: "Close",
        confirm_icon: "close-circle-line"
      )}
   end

--- a/test/livebook_web/live/home_live_test.exs
+++ b/test/livebook_web/live/home_live_test.exs
@@ -9,8 +9,8 @@ defmodule LivebookWeb.HomeLiveTest do
 
   test "disconnected and connected render", %{conn: conn} do
     {:ok, view, disconnected_html} = live(conn, ~p"/")
-    assert disconnected_html =~ "Running sessions"
-    assert render(view) =~ "Running sessions"
+    assert disconnected_html =~ "Running notebooks"
+    assert render(view) =~ "Running notebooks"
   end
 
   test "redirects to session upon creation", %{conn: conn} do


### PR DESCRIPTION
Rename "New notebook" to "New session"

This PR is only a UX change.

In the Livebook app code I only changed the wording of the menu actions and not the underlying function calls as I did not want to generate unwanted side effects for any code expecting specific function names.

I also did not comprehensively search out and resolve backing code referencing "notebook" or "session".

To resolve all uses of "notebook" and "session" throughout the codebase then either I'd need a clear spec for what is considered a notebook vs what is considered a session or the PR should be done by  a Livebook dev that already knows how to disambiguate the two concepts.

As part of renaming "New notebook" to "New session" José suggested that the bulk actions also be simplified to simply "Disconnect" and "Close"

Resolves #2872

Related discussion: https://github.com/livebook-dev/livebook/discussions/2871