### PR TITLE
Restrict app slug validation to only allow lowercase letters

### DIFF
--- a/lib/livebook/notebook/app_settings.ex
+++ b/lib/livebook/notebook/app_settings.ex
@@ -91,7 +91,7 @@ defmodule Livebook.Notebook.AppSettings do
       :show_source,
       :output_type
     ])
-    |> validate_format(:slug, ~r/^[a-zA-Z0-9-]+$/,
+    |> validate_format(:slug, ~r/^[a-z0-9-]+$/,
       message: "should only contain alphanumeric characters and dashes"
     )
     |> cast_access_attrs(attrs)


### PR DESCRIPTION
This aligns the validation with Teams. It's better to ensure lowercase to avoid ambiguities.