### PR TITLE
Add logs for code evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,6 @@ The following environment variables can be used to configure Livebook on boot:
     configuration. Defaults to "livebook" under the default user data
     directory.
 
-  * `LIVEBOOK_DEBUG` - enables verbose logging, when set to "true". Disabled
-    by default.
-
   * `LIVEBOOK_DEFAULT_RUNTIME` - sets the runtime type that is used by default
     when none is started explicitly for the given notebook. Must be either
     "standalone" (Standalone), "attached:NODE:COOKIE" (Attached node)
@@ -260,6 +257,13 @@ The following environment variables can be used to configure Livebook on boot:
 
   * `LIVEBOOK_IP` - sets the ip address to start the web application on.
     Must be a valid IPv4 or IPv6 address.
+
+  * `LIVEBOOK_LOG_LEVEL` - sets the logger level, allowing for more verbose
+    logging, either of: error, warning, notice, info, debug. Defaults to warning.
+
+  * `LIVEBOOK_LOG_METADATA` - a comma-separated list of metadata keys that should
+    be included in the log messages. Currently the only Livebook-spcecific key is
+    users (attached to evaluation logs). By default includes only request_id.
 
   * `LIVEBOOK_NODE` - sets the node name for running Livebook in a cluster.
     Note that Livebook always runs using long names distribution, so the

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -61,8 +61,10 @@ config :livebook, LivebookWeb.Endpoint,
     web_console_logger: true
   ]
 
-# Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+# Do not include timestamps in development logs
+config :logger, :console,
+  format: "$metadata[$level] $message\n",
+  metadata: []
 
 # Include HEEx debug annotations as HTML comments in rendered markup
 config :phoenix_live_view, :debug_heex_annotations, true

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -97,8 +97,12 @@ defmodule Livebook do
         Livebook.Config.secret!("LIVEBOOK_SECRET_KEY_BASE") ||
           Livebook.Utils.random_secret_key_base()
 
-    if Livebook.Config.debug!("LIVEBOOK_DEBUG") do
-      config :logger, level: :debug
+    if level = Livebook.Config.log_level!("LIVEBOOK_LOG_LEVEL") do
+      config :logger, level: level
+    end
+
+    if metadata = Livebook.Config.log_metadata!("LIVEBOOK_LOG_METADATA") do
+      config :logger, :console, metadata: metadata
     end
 
     if port = Livebook.Config.port!("LIVEBOOK_PORT") do

--- a/lib/livebook/app.ex
+++ b/lib/livebook/app.ex
@@ -86,7 +86,8 @@ defmodule Livebook.App do
           files_tmp_path: String.t(),
           app_spec: Livebook.Apps.AppSpec.t(),
           permanent: boolean(),
-          warnings: list(String.t())
+          warnings: list(String.t()),
+          deployed_by: Livebook.Users.User.t() | nil
         }
 
   @doc """
@@ -361,7 +362,8 @@ defmodule Livebook.App do
       mode: :app,
       app_pid: self(),
       auto_shutdown_ms: state.deployment_bundle.notebook.app_settings.auto_shutdown_ms,
-      started_by: user
+      started_by: user,
+      deployed_by: state.deployment_bundle.deployed_by
     ]
 
     case Livebook.Sessions.create_session(opts) do

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -444,15 +444,28 @@ defmodule Livebook.Config do
   end
 
   @doc """
-  Parses and validates debug mode from env.
+  Parses and validates log level from env.
   """
-  def debug!(env) do
-    if debug = System.get_env(env) do
-      cond do
-        debug in ["1", "true"] -> true
-        debug in ["0", "false"] -> false
-        true -> abort!("expected #{env} to be a boolean, got: #{inspect(debug)}")
+  def log_level!(env) do
+    levels = ~w(error warning notice info debug)
+
+    if level = System.get_env(env) do
+      if level in levels do
+        String.to_atom(level)
+      else
+        abort!("expected #{env} to be one of #{Enum.join(levels, ", ")}, got: #{inspect(levels)}")
       end
+    end
+  end
+
+  @doc """
+  Parses and validates log metadata keys from env.
+  """
+  def log_metadata!(env) do
+    if metadata = System.get_env(env) do
+      for item <- String.split(metadata, ","),
+          key = String.trim(item),
+          do: String.to_atom(key)
     end
   end
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -83,6 +83,8 @@ defmodule Livebook.Session do
 
   use GenServer, restart: :temporary
 
+  require Logger
+
   alias Livebook.NotebookManager
   alias Livebook.Session.{Data, FileGuard}
   alias Livebook.{Utils, Notebook, Text, Runtime, LiveMarkdown, FileSystem}
@@ -2549,6 +2551,15 @@ defmodule Livebook.Session do
   defp handle_action(state, _action), do: state
 
   defp start_evaluation(state, cell, section, evaluation_opts) do
+    Logger.info(
+      """
+      Evaluating code
+        Session mode: #{state.data.mode}
+        Code: #{inspect(cell.source)}\
+      """,
+      user: Livebook.Utils.logger_user_meta(Map.values(state.data.users_map))
+    )
+
     path =
       case state.data.file || default_notebook_file(state) do
         nil -> ""

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -833,4 +833,22 @@ defmodule Livebook.Utils do
       []
     end
   end
+
+  @doc """
+  Returns logger metadata from user or identity data.
+
+  Expects a list corresponding to one or more users.
+  """
+  @spec logger_user_meta(list(Livebook.Users.User.t() | map())) :: String.t()
+  def logger_user_meta(datas) when is_list(datas) do
+    list =
+      for data <- datas do
+        for key <- [:id, :name, :email],
+            value = Map.get(data, key),
+            do: {key, value},
+            into: %{}
+      end
+
+    inspect(list)
+  end
 end

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -835,12 +835,10 @@ defmodule Livebook.Utils do
   end
 
   @doc """
-  Returns logger metadata from user or identity data.
-
-  Expects a list corresponding to one or more users.
+  Returns logger metadata for a list of users or their identity data.
   """
-  @spec logger_user_meta(list(Livebook.Users.User.t() | map())) :: String.t()
-  def logger_user_meta(datas) when is_list(datas) do
+  @spec logger_users_metadata(list(Livebook.Users.User.t() | map())) :: String.t()
+  def logger_users_metadata(datas) when is_list(datas) do
     list =
       for data <- datas do
         for key <- [:id, :name, :email],
@@ -849,6 +847,6 @@ defmodule Livebook.Utils do
             into: %{}
       end
 
-    inspect(list)
+    [users: inspect(list)]
   end
 end

--- a/test/livebook/app_test.exs
+++ b/test/livebook/app_test.exs
@@ -245,7 +245,8 @@ defmodule Livebook.AppTest do
       files_tmp_path: Livebook.Apps.generate_files_tmp_path(app_spec.slug),
       app_spec: app_spec,
       permanent: false,
-      warnings: []
+      warnings: [],
+      deployed_by: nil
     }
   end
 


### PR DESCRIPTION
This adds extra logs whenever code is evaluated, showing the code. The metadata includes people connected to the session (or in case of app previews, the person who deployed the app).

When running Livebook with new env vars `LIVEBOOK_LOG_LEVEL=info LIVEBOOK_LOG_METADATA=request_id,users`, the log looks like this:

```
18:25:46.105 users=[%{id: "awj6fkaaznjy6ydzhb77id2czn3cmejd", name: "Jonatan Kłosko"}] [info] Evaluating code
  Session mode: default
  Code: "# This is a Code cell - as the name suggests that's where the code goes.\n# To evaluate this cell, you can either press the \"Evaluate\" button above\n# or use `Ctrl + Enter` (or Cmd + Enter on a Mac)!\n\nmessage = \"hey, grab yourself a cup of 🍵\""
```

The user information includes id, name and email (if available), so it's best combined with an identity provider.