### PR TITLE
Remove danger hint from close session confirmation when it has a file

### DIFF
--- a/lib/livebook_web/helpers/session_helpers.ex
+++ b/lib/livebook_web/helpers/session_helpers.ex
@@ -208,7 +208,8 @@ defmodule LivebookWeb.SessionHelpers do
       title: "Close session",
       description: description,
       confirm_text: "Close session",
-      confirm_icon: "close-circle-line"
+      confirm_icon: "close-circle-line",
+      danger: !assigns.file
     )
   end
 

--- a/lib/livebook_web/helpers/session_helpers.ex
+++ b/lib/livebook_web/helpers/session_helpers.ex
@@ -209,7 +209,7 @@ defmodule LivebookWeb.SessionHelpers do
       description: description,
       confirm_text: "Close session",
       confirm_icon: "close-circle-line",
-      danger: !assigns.file
+      danger: assigns.file == nil
     )
   end
 

--- a/lib/livebook_web/helpers/session_helpers.ex
+++ b/lib/livebook_web/helpers/session_helpers.ex
@@ -209,7 +209,7 @@ defmodule LivebookWeb.SessionHelpers do
       description: description,
       confirm_text: "Close session",
       confirm_icon: "close-circle-line",
-      danger: assigns.file == nil
+      danger: session.file == nil
     )
   end
 


### PR DESCRIPTION
Hey, 

Would you be willing to remove the `danger` from the Close Session modal in the case there is a file persisted file?

Effectively if there is a saved file we get:
<img width="575" alt="Screenshot 2024-12-05 at 05 57 23" src="https://github.com/user-attachments/assets/b39dc9e7-90ea-4386-af99-4e654adceac0">

If there is not, we keep the Danger looks:
<img width="572" alt="Screenshot 2024-12-05 at 05 57 40" src="https://github.com/user-attachments/assets/81529fc5-9f17-42ef-9f40-e1ef13dcb601">

Thank you,
