### PR TITLE
Fix user information to include payload returned from identity provider

### DIFF
--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -42,13 +42,14 @@ defmodule Livebook.Users.User do
       name: nil,
       email: nil,
       avatar_url: nil,
+      payload: nil,
       hex_color: Livebook.EctoTypes.HexColor.random()
     }
   end
 
   def changeset(user, attrs \\ %{}) do
     user
-    |> cast(attrs, [:name, :email, :avatar_url, :hex_color])
+    |> cast(attrs, [:name, :email, :avatar_url, :hex_color, :payload])
     |> validate_required([:hex_color])
   end
 end

--- a/test/livebook/users/user_test.exs
+++ b/test/livebook/users/user_test.exs
@@ -6,12 +6,13 @@ defmodule Livebook.Users.UserTest do
   describe "change/2" do
     test "given valid attributes returns and updated user" do
       user = build(:user)
-      attrs = %{"name" => "Jake Peralta", "hex_color" => "#000000"}
+      attrs = %{"name" => "Jake Peralta", "hex_color" => "#000000", "payload" => %{"country" => "US"}}
       changeset = User.changeset(user, attrs)
 
       assert changeset.valid?
       assert get_field(changeset, :name) == "Jake Peralta"
       assert get_field(changeset, :hex_color) == "#000000"
+      assert get_field(changeset, :payload) == %{"country" => "US"}
     end
 
     test "given invalid color returns an error" do

--- a/test/livebook/users/user_test.exs
+++ b/test/livebook/users/user_test.exs
@@ -6,7 +6,13 @@ defmodule Livebook.Users.UserTest do
   describe "change/2" do
     test "given valid attributes returns and updated user" do
       user = build(:user)
-      attrs = %{"name" => "Jake Peralta", "hex_color" => "#000000", "payload" => %{"country" => "US"}}
+
+      attrs = %{
+        "name" => "Jake Peralta",
+        "hex_color" => "#000000",
+        "payload" => %{"country" => "US"}
+      }
+
       changeset = User.changeset(user, attrs)
 
       assert changeset.valid?


### PR DESCRIPTION
A user is trying to get identity information from their ZTA provider (Cloudflare, in this case) inside a Livebook app.

Livebook was supposed to put that information inside the payload field of the user struct, but this was not happening.

So, when running `Kino.Workspace.app_info()` from inside a Livebook multi-session app, this was being returned:

```elixir
Kino.Workspace.info
%{
  type: :multi_session,
  started_by: %{
    id: "239d3f11-f27c-5de4-bbf7-a8d013e8957e",
    name: "Jake Peralta",
    source: :zta,
    payload: nil,
    email: "jake.peralta@gmail.com"
  }
}
```

Notice how `payload` was nil. ☝️ 

With this PR, this is now being returned:

```elixir
Kino.Workspace.info
%{
  type: :multi_session,
  started_by: %{
    id: "239d3f11-f27c-5de4-bbf7-a8d013e8957e",
    name: "Jake Peralta",
    source: :zta,
    payload: %{
      "aud" => ["a8455c4c579173c8f0cc1fc010f740df3f1ccc7209ef32"],
      "country" => "US",
      "email" => "jake.peralta@gmail.com",
      "exp" => 17334,
      "iat" => 17334,
      "identity_nonce" => "Ye7i5ZHbI",
      "iss" => "https://99.cloudflareaccess.com",
      "nbf" => 1733488,
      "sub" => "239d3f11",
      "type" => "app"
    },
    email: "jake.peralta@gmail.com"
  }
}
```