### PR TITLE
Update Elixir and Erlang versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MIX_ENV: test
-      ELIXIR_ERL_OPTIONS: "-epmd_module Elixir.Livebook.EPMD"
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v4
@@ -65,7 +64,6 @@ jobs:
     if: github.event_name == 'push'
     env:
       MIX_ENV: test
-      ELIXIR_ERL_OPTIONS: "-epmd_module Elixir.Livebook.EPMD"
     steps:
       - name: Configure Git
         run: git config --global core.autocrlf input

--- a/lib/livebook/intellisense/identifier_matcher.ex
+++ b/lib/livebook/intellisense/identifier_matcher.ex
@@ -742,7 +742,7 @@ defmodule Livebook.Intellisense.IdentifierMatcher do
   defp function_or_macro(_, fun, arity), do: {fun, arity, :function}
 
   defp append_funs_type(funs, type) do
-    Enum.map(funs, &Tuple.append(&1, type))
+    Enum.map(funs, fn {name, arity} -> {name, arity, type} end)
   end
 
   defp match_module_type(mod, hint, ctx) do

--- a/lib/livebook/k8s/pod.ex
+++ b/lib/livebook/k8s/pod.ex
@@ -177,38 +177,6 @@ defmodule Livebook.K8s.Pod do
   end
 
   defp access_main_container() do
-    access_find(&(&1["name"] == @main_container_name))
-  end
-
-  # TODO: use Access.find/1 once we require Elixir v1.17
-  defp access_find(predicate) when is_function(predicate, 1) do
-    fn op, data, next -> find(op, data, predicate, next) end
-  end
-
-  defp find(:get, data, predicate, next) when is_list(data) do
-    data |> Enum.find(predicate) |> next.()
-  end
-
-  defp find(:get_and_update, data, predicate, next) when is_list(data) do
-    get_and_update_find(data, [], predicate, next)
-  end
-
-  defp find(_op, data, _predicate, _next) do
-    raise "Access.find/1 expected a list, got: #{inspect(data)}"
-  end
-
-  defp get_and_update_find([], updates, _predicate, _next) do
-    {nil, :lists.reverse(updates)}
-  end
-
-  defp get_and_update_find([head | rest], updates, predicate, next) do
-    if predicate.(head) do
-      case next.(head) do
-        {get, update} -> {get, :lists.reverse([update | updates], rest)}
-        :pop -> {head, :lists.reverse(updates, rest)}
-      end
-    else
-      get_and_update_find(rest, [head | updates], predicate, next)
-    end
+    Access.find(&(&1["name"] == @main_container_name))
   end
 end

--- a/lib/livebook/live_markdown/markdown_helpers.ex
+++ b/lib/livebook/live_markdown/markdown_helpers.ex
@@ -345,7 +345,7 @@ defmodule Livebook.LiveMarkdown.MarkdownHelpers do
 
   defp max_length_per_column(cell_grid) do
     cell_grid
-    |> List.zip()
+    |> Enum.zip()
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.map(fn cells ->
       cells

--- a/lib/livebook/runtime/erl_dist/runtime_server.ex
+++ b/lib/livebook/runtime/erl_dist/runtime_server.ex
@@ -855,18 +855,11 @@ defmodule Livebook.Runtime.ErlDist.RuntimeServer do
     # We propagate Mix.install/2 project dir in the transient state,
     # so that future runtimes can set it as the starting point for
     # Mix.install/2
-    if dir = state.mix_install_project_dir == nil && install_project_dir() do
+    if dir = state.mix_install_project_dir == nil && Mix.install_project_dir() do
       send(state.owner, {:runtime_transient_state, %{mix_install_project_dir: dir}})
       %{state | mix_install_project_dir: dir}
     else
       state
-    end
-  end
-
-  defp install_project_dir() do
-    # TODO: remove the check once we require Elixir v1.16.2
-    if Code.ensure_loaded?(Mix) && function_exported?(Mix, :install_project_dir, 0) do
-      Mix.install_project_dir()
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ end
 defmodule Livebook.MixProject do
   use Mix.Project
 
-  @elixir_requirement "~> 1.16"
+  @elixir_requirement "~> 1.18.0-rc.0"
   @version "0.15.0-dev"
   @description "Automate code & data workflows with interactive notebooks"
 

--- a/test/livebook/runtime/evaluator_test.exs
+++ b/test/livebook/runtime/evaluator_test.exs
@@ -697,7 +697,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
                       %{
                         column: 6,
                         details:
-                          "\e[31m** (Protocol.UndefinedError) protocol Enumerable not implemented for 1 of type Integer. " <>
+                          "\e[31m** (Protocol.UndefinedError) protocol Enumerable not implemented for type Integer. " <>
                             _,
                         end_line: 10,
                         line: 9,
@@ -1565,7 +1565,7 @@ defmodule Livebook.Runtime.EvaluatorTest do
                in function  list_to_binary/1
                   called as list_to_binary(1)
                   *** argument 1: not an iolist term
-               in call from erl_eval:do_apply/7 (erl_eval.erl, line 900)\
+               in call from erl_eval:do_apply/7 (erl_eval.erl, line 915)\
              """
     end
   end

--- a/versions
+++ b/versions
@@ -1,5 +1,5 @@
-elixir="1.17.2"
-otp="27.0"
+elixir="1.18.0-rc.0"
+otp="27.2"
 openssl="1.1.1s"
 rebar3="3.22.0"
-ubuntu="jammy-20240530"
+ubuntu="jammy-20240808"


### PR DESCRIPTION
In particular `ELIXIR_ERL_OPTIONS="-epmd_module Elixir.Livebook.EPMD"` is no longer necessary when running with OTP 27.2+ locally.