### PR TITLE
Fix Docker warning about deprecated ENV usage

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -10,11 +10,11 @@ You can deploy Livebook inside your infrastructure using Docker. The Dockerfile 
 FROM ghcr.io/livebook-dev/livebook
 
 # Configure your port accordingly
-ENV LIVEBOOK_PORT 7860
+ENV LIVEBOOK_PORT=7860
 EXPOSE 7860
 
 # If you have a persistent volume, configure it here
-ENV LIVEBOOK_DATA_PATH "/data"
+ENV LIVEBOOK_DATA_PATH="/data"
 USER root
 RUN mkdir -p /data
 RUN chmod 777 /data

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -11,7 +11,7 @@ To do this in Docker, you will need to build it differently. Below is an example
 ```docker
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
 # Set environment variables for path and language
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin 
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Install system dependencies and clean cache in one layer
 RUN microdnf install -y unzip autoconf git ncurses-devel openssl-devel gcc gcc-c++ make automake perl clang wget tar cmake glibc-locale-source glibc-langpack-en && \

--- a/lib/livebook/hubs/dockerfile.ex
+++ b/lib/livebook/hubs/dockerfile.ex
@@ -115,18 +115,18 @@ defmodule Livebook.Hubs.Dockerfile do
         "auto" ->
           """
           # Clustering configuration (note that we need the same Livebook secrets across all nodes)
-          ENV LIVEBOOK_CLUSTER "auto"
-          ENV LIVEBOOK_SECRET_KEY_BASE "#{secret_key_base}"
-          ENV LIVEBOOK_COOKIE "#{cookie}"
+          ENV LIVEBOOK_CLUSTER="auto"
+          ENV LIVEBOOK_SECRET_KEY_BASE="#{secret_key_base}"
+          ENV LIVEBOOK_COOKIE="#{cookie}"
           """
 
         "dns" ->
           """
           # Clustering configuration (note that we need the same Livebook secrets across all nodes)
-          ENV LIVEBOOK_NODE "livebook_server@MACHINE_IP"
-          ENV LIVEBOOK_CLUSTER "dns:QUERY"
-          ENV LIVEBOOK_SECRET_KEY_BASE "#{secret_key_base}"
-          ENV LIVEBOOK_COOKIE "#{cookie}"
+          ENV LIVEBOOK_NODE="livebook_server@MACHINE_IP"
+          ENV LIVEBOOK_CLUSTER="dns:QUERY"
+          ENV LIVEBOOK_SECRET_KEY_BASE="#{secret_key_base}"
+          ENV LIVEBOOK_COOKIE="#{cookie}"
           """
 
         _ ->
@@ -135,8 +135,8 @@ defmodule Livebook.Hubs.Dockerfile do
 
     apps_config = """
     # Apps configuration
-    ENV LIVEBOOK_APPS_PATH "/apps"
-    ENV LIVEBOOK_APPS_PATH_WARMUP "manual"
+    ENV LIVEBOOK_APPS_PATH="/apps"
+    ENV LIVEBOOK_APPS_PATH_WARMUP="manual"
     """
 
     notebook =
@@ -210,21 +210,21 @@ defmodule Livebook.Hubs.Dockerfile do
       ARG TEAMS_KEY="#{hub.teams_key}"
 
       # Teams Hub configuration for airgapped deployment
-      ENV LIVEBOOK_TEAMS_KEY ${TEAMS_KEY}
-      ENV LIVEBOOK_TEAMS_AUTH "offline:#{hub.hub_name}:#{hub.org_public_key}"
+      ENV LIVEBOOK_TEAMS_KEY=${TEAMS_KEY}
+      ENV LIVEBOOK_TEAMS_AUTH="offline:#{hub.hub_name}:#{hub.org_public_key}"
       """
 
     secrets =
       if used_secrets != [] do
         """
-        ENV LIVEBOOK_TEAMS_SECRETS "#{encrypt_secrets_to_dockerfile(used_secrets, hub)}"
+        ENV LIVEBOOK_TEAMS_SECRETS="#{encrypt_secrets_to_dockerfile(used_secrets, hub)}"
         """
       end
 
     file_systems =
       if hub_file_systems != [] do
         """
-        ENV LIVEBOOK_TEAMS_FS "#{encrypt_file_systems_to_dockerfile(hub_file_systems, hub)}"
+        ENV LIVEBOOK_TEAMS_FS="#{encrypt_file_systems_to_dockerfile(hub_file_systems, hub)}"
         """
       end
 
@@ -248,7 +248,7 @@ defmodule Livebook.Hubs.Dockerfile do
 
   defp format_envs(list) do
     Enum.map_join(list, fn {key, value} ->
-      ~s/ENV #{key} "#{String.replace(value, ~S["], ~S[\"])}"\n/
+      ~s/ENV #{key}="#{String.replace(value, ~S["], ~S[\"])}"\n/
     end)
   end
 

--- a/test/livebook/hubs/dockerfile_test.exs
+++ b/test/livebook/hubs/dockerfile_test.exs
@@ -23,8 +23,8 @@ defmodule Livebook.Hubs.DockerfileTest do
              FROM ghcr.io/livebook-dev/livebook:#{@version}
 
              # Apps configuration
-             ENV LIVEBOOK_APPS_PATH "/apps"
-             ENV LIVEBOOK_APPS_PATH_WARMUP "manual"
+             ENV LIVEBOOK_APPS_PATH="/apps"
+             ENV LIVEBOOK_APPS_PATH_WARMUP="manual"
 
              # Notebook
              COPY notebook.livemd /apps/
@@ -48,7 +48,7 @@ defmodule Livebook.Hubs.DockerfileTest do
       assert dockerfile =~
                """
                # Personal Hub secrets
-               ENV LB_TEST "test"
+               ENV LB_TEST="test"
                """
 
       refute dockerfile =~ "ENV LB_SESSION"
@@ -81,8 +81,8 @@ defmodule Livebook.Hubs.DockerfileTest do
       assert dockerfile =~
                """
                # Personal Hub secrets
-               ENV LB_TEST "test"
-               ENV LB_TEST2 "test"
+               ENV LB_TEST="test"
+               ENV LB_TEST2="test"
                """
 
       refute dockerfile =~ "ENV LB_SESSION"
@@ -101,12 +101,12 @@ defmodule Livebook.Hubs.DockerfileTest do
              ARG TEAMS_KEY="lb_tk_fn0pL3YLWzPoPFWuHeV3kd0o7_SFuIOoU4C_k6OWDYg"
 
              # Teams Hub configuration for airgapped deployment
-             ENV LIVEBOOK_TEAMS_KEY ${TEAMS_KEY}
-             ENV LIVEBOOK_TEAMS_AUTH "offline:org-name-387:lb_opk_fpxnp3r5djwxnmirx3tu276hialoivf3"
+             ENV LIVEBOOK_TEAMS_KEY=${TEAMS_KEY}
+             ENV LIVEBOOK_TEAMS_AUTH="offline:org-name-387:lb_opk_fpxnp3r5djwxnmirx3tu276hialoivf3"
 
              # Apps configuration
-             ENV LIVEBOOK_APPS_PATH "/apps"
-             ENV LIVEBOOK_APPS_PATH_WARMUP "manual"
+             ENV LIVEBOOK_APPS_PATH="/apps"
+             ENV LIVEBOOK_APPS_PATH_WARMUP="manual"
 
              # Notebook
              COPY notebook.livemd /apps/
@@ -191,7 +191,7 @@ defmodule Livebook.Hubs.DockerfileTest do
 
       dockerfile = Dockerfile.airgapped_dockerfile(config, hub, [], [], file, [], %{})
 
-      assert dockerfile =~ ~s/ENV LIVEBOOK_CLUSTER "auto"/
+      assert dockerfile =~ ~s/ENV LIVEBOOK_CLUSTER="auto"/
     end
 
     test "deploying with dns cluster setup" do
@@ -201,8 +201,8 @@ defmodule Livebook.Hubs.DockerfileTest do
 
       dockerfile = Dockerfile.airgapped_dockerfile(config, hub, [], [], file, [], %{})
 
-      assert dockerfile =~ ~s/ENV LIVEBOOK_NODE "livebook_server@MACHINE_IP"/
-      assert dockerfile =~ ~s/ENV LIVEBOOK_CLUSTER "dns:QUERY"/
+      assert dockerfile =~ ~s/ENV LIVEBOOK_NODE="livebook_server@MACHINE_IP"/
+      assert dockerfile =~ ~s/ENV LIVEBOOK_CLUSTER="dns:QUERY"/
     end
 
     test "deploying with deployment group environment variables" do
@@ -222,9 +222,9 @@ defmodule Livebook.Hubs.DockerfileTest do
 
       assert dockerfile =~ """
              # Deployment group environment variables
-             ENV LIVEBOOK_IDENTITY_PROVIDER "cloudflare:foobar"
-             ENV LIVEBOOK_TEAMS_URL "http://localhost:8000"
-             ENV MY_JSON "{\\"foo\\": \\"bar\\"}"\
+             ENV LIVEBOOK_IDENTITY_PROVIDER="cloudflare:foobar"
+             ENV LIVEBOOK_TEAMS_URL="http://localhost:8000"
+             ENV MY_JSON="{\\"foo\\": \\"bar\\"}"\
              """
     end
   end


### PR DESCRIPTION
Reference  here: https://docs.docker.com/reference/build-checks/legacy-key-value-format. 

It has been deprecated in [2020](https://github.com/docker/cli/pull/2743)