### PR TITLE
Migrate to JSON

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,8 +14,7 @@ config :logger, :console,
   format: "$date $time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-# Use Jason for JSON parsing in Phoenix
-config :phoenix, :json_library, Jason
+config :phoenix, :json_library, JSON
 
 # Additional mime types
 config :mime, :types, %{

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -341,7 +341,7 @@ defmodule Livebook.Application do
       if encrypted_secrets do
         case Livebook.Teams.decrypt(encrypted_secrets, secret_key) do
           {:ok, json} ->
-            for {name, value} <- Jason.decode!(json) do
+            for {name, value} <- JSON.decode!(json) do
               %Livebook.Secrets.Secret{name: name, value: value, hub_id: id}
             end
 
@@ -358,7 +358,7 @@ defmodule Livebook.Application do
       if encrypted_file_systems do
         case Livebook.Teams.decrypt(encrypted_file_systems, secret_key) do
           {:ok, json} ->
-            for %{"type" => type} = dumped_data <- Jason.decode!(json),
+            for %{"type" => type} = dumped_data <- JSON.decode!(json),
                 do: Livebook.FileSystems.load(type, dumped_data)
 
           :error ->

--- a/lib/livebook/hubs/dockerfile.ex
+++ b/lib/livebook/hubs/dockerfile.ex
@@ -276,7 +276,7 @@ defmodule Livebook.Hubs.Dockerfile do
     secret_key = Livebook.Teams.derive_key(hub.teams_key)
 
     data
-    |> Jason.encode!()
+    |> JSON.encode!()
     |> Livebook.Teams.encrypt(secret_key)
   end
 

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -396,7 +396,7 @@ defmodule Livebook.Hubs.TeamClient do
 
     dumped_data =
       decrypted_value
-      |> Jason.decode!()
+      |> JSON.decode!()
       |> Map.put("external_id", file_system.id)
 
     FileSystems.load(file_system.type, dumped_data)

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -212,7 +212,7 @@ defmodule Livebook.LiveMarkdown.Export do
       "kind" => cell.kind,
       # Attributes may include arbitrary values, including sequences
       # like "-->" that would mess our format, so we always encode them
-      "attrs" => cell.attrs |> ensure_order() |> Jason.encode!() |> Base.encode64(padding: false),
+      "attrs" => cell.attrs |> JSON.encode!(&encode_sorting/2) |> Base.encode64(padding: false),
       "chunks" => cell.chunks && Enum.map(cell.chunks, &Tuple.to_list/1)
     })
   end
@@ -275,10 +275,17 @@ defmodule Livebook.LiveMarkdown.Export do
   defp render_output(_output, _ctx), do: :ignored
 
   defp encode_js_data(data) when is_binary(data), do: {:ok, data}
-  defp encode_js_data(data), do: data |> ensure_order() |> Jason.encode()
+
+  defp encode_js_data(data) do
+    try do
+      {:ok, JSON.encode!(data, &encode_sorting/2)}
+    rescue
+      _error -> :error
+    end
+  end
 
   defp render_metadata(metadata) do
-    metadata_json = metadata |> ensure_order() |> Jason.encode!()
+    metadata_json = JSON.encode_to_iodata!(metadata, &encode_sorting/2)
     ["<!-- livebook:", metadata_json, " -->"]
   end
 
@@ -349,7 +356,11 @@ defmodule Livebook.LiveMarkdown.Export do
         case Livebook.Hubs.notebook_stamp(hub, notebook_source, metadata) do
           {:ok, stamp} ->
             offset = IO.iodata_length(notebook_source)
-            json = %{"offset" => offset, "stamp" => stamp} |> ensure_order() |> Jason.encode!()
+
+            json =
+              %{"offset" => offset, "stamp" => stamp}
+              |> JSON.encode_to_iodata!(&encode_sorting/2)
+
             footer = ["\n", "<!-- livebook:", json, " -->", "\n"]
             {footer, []}
 
@@ -391,16 +402,27 @@ defmodule Livebook.LiveMarkdown.Export do
     end
   end
 
-  defp ensure_order(%{} = map) when not is_struct(map) do
-    map
+  # Wraps JSON.protocol_encode/2 to encode maps as sorted objects
+  defp encode_sorting(term, encoder) when is_non_struct_map(term) do
+    term
     |> Enum.sort()
-    |> Enum.map(fn {key, value} -> {key, ensure_order(value)} end)
-    |> Jason.OrderedObject.new()
+    |> encode_object(encoder)
   end
 
-  defp ensure_order(list) when is_list(list) do
-    Enum.map(list, &ensure_order/1)
+  defp encode_sorting(term, encoder), do: JSON.protocol_encode(term, encoder)
+
+  defp encode_object([], _encoder), do: "{}"
+
+  defp encode_object(pairs, encoder) do
+    [[_comma | entry] | entries] =
+      Enum.map(pairs, fn {key, value} ->
+        [?,, encode_key(key, encoder), ?:, encoder.(value, encoder)]
+      end)
+
+    [?{, entry, entries, ?}]
   end
 
-  defp ensure_order(term), do: term
+  defp encode_key(key, encoder) when is_binary(key) or is_atom(key), do: encoder.(key, encoder)
+  defp encode_key(key, _encoder) when is_integer(key), do: [?", Integer.to_string(key), ?"]
+  defp encode_key(key, _encoder) when is_float(key), do: [?", Float.to_string(key), ?"]
 end

--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -177,7 +177,7 @@ defmodule Livebook.LiveMarkdown.Import do
   end
 
   defp livebook_json_to_element(json) do
-    data = Jason.decode!(json)
+    data = JSON.decode!(json)
 
     case data do
       %{"livebook_object" => "cell_input"} ->
@@ -251,7 +251,7 @@ defmodule Livebook.LiveMarkdown.Import do
           attrs
 
         encoded when is_binary(encoded) ->
-          encoded |> Base.decode64!(padding: false) |> Jason.decode!()
+          encoded |> Base.decode64!(padding: false) |> JSON.decode!()
       end
 
     chunks = if(chunks = data["chunks"], do: Enum.map(chunks, &List.to_tuple/1))

--- a/lib/livebook/runtime/definitions.ex
+++ b/lib/livebook/runtime/definitions.ex
@@ -70,11 +70,6 @@ defmodule Livebook.Runtime.Definitions do
     dependency: %{dep: {:explorer, "~> 0.10.0"}, config: []}
   }
 
-  jason = %{
-    name: "jason",
-    dependency: %{dep: {:jason, "~> 1.4"}, config: []}
-  }
-
   stb_image = %{
     name: "stb_image",
     dependency: %{dep: {:stb_image, "~> 0.6.9"}, config: []}
@@ -309,11 +304,11 @@ defmodule Livebook.Runtime.Definitions do
       data =
         Kino.FS.file_path("{{NAME}}")
         |> File.read!()
-        |> Jason.decode!()
+        |> JSON.decode!()
 
       Kino.Tree.new(data)\
       """,
-      packages: [kino, jason]
+      packages: [kino]
     },
     %{
       type: :file_action,

--- a/lib/livebook/runtime/dependencies.ex
+++ b/lib/livebook/runtime/dependencies.ex
@@ -169,11 +169,11 @@ defmodule Livebook.Runtime.Dependencies do
 
   ## Examples
 
-      iex> Livebook.Runtime.Dependencies.parse_term(~s|{:jason, "~> 1.3.0"}|)
-      {:ok, {:jason, "~> 1.3.0"}}
+      iex> Livebook.Runtime.Dependencies.parse_term(~s|{:req, "~> 0.5.0"}|)
+      {:ok, {:req, "~> 0.5.0"}}
 
-      iex> Livebook.Runtime.Dependencies.parse_term(~s|{:jason, "~> 1.3.0", runtime: false, meta: "data"}|)
-      {:ok, {:jason, "~> 1.3.0", runtime: false, meta: "data"}}
+      iex> Livebook.Runtime.Dependencies.parse_term(~s|{:req, "~> 0.5.0", runtime: false, meta: "data"}|)
+      {:ok, {:req, "~> 0.5.0", runtime: false, meta: "data"}}
 
       iex> Livebook.Runtime.Dependencies.parse_term(~s|%{name: "Jake", numbers: [1, 2, 3.4]}|)
       {:ok, %{name: "Jake", numbers: [1, 2, 3.4]}}

--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -120,7 +120,7 @@ defmodule Livebook.Teams.Requests do
     type = FileSystems.type(file_system)
     %{name: name} = FileSystem.external_metadata(file_system)
     attrs = FileSystem.dump(file_system)
-    json = Jason.encode!(attrs)
+    json = JSON.encode!(attrs)
 
     params = %{
       name: name,
@@ -142,7 +142,7 @@ defmodule Livebook.Teams.Requests do
     type = FileSystems.type(file_system)
     %{name: name} = FileSystem.external_metadata(file_system)
     attrs = FileSystem.dump(file_system)
-    json = Jason.encode!(attrs)
+    json = JSON.encode!(attrs)
 
     params = %{
       id: file_system.external_id,

--- a/lib/livebook_web/channels/js_view_channel.ex
+++ b/lib/livebook_web/channels/js_view_channel.ex
@@ -140,7 +140,7 @@ defmodule LivebookWeb.JSViewChannel do
     rescue
       error ->
         case error do
-          %Protocol.UndefinedError{protocol: Jason.Encoder, value: value} ->
+          %Protocol.UndefinedError{protocol: JSON.Encoder, value: value} ->
             {:error, "value #{inspect(value)} is not JSON-serializable, use another data type"}
 
           error ->

--- a/lib/livebook_web/components/core_components.ex
+++ b/lib/livebook_web/components/core_components.ex
@@ -1061,7 +1061,7 @@ defmodule LivebookWeb.CoreComponents do
   def exec_js(socket, js, opts \\ []) do
     opts = Keyword.validate!(opts, [:to])
 
-    Phoenix.LiveView.push_event(socket, "lb:exec_js", %{js: Jason.encode!(js.ops), to: opts[:to]})
+    Phoenix.LiveView.push_event(socket, "lb:exec_js", %{js: JSON.encode!(js.ops), to: opts[:to]})
   end
 
   @doc """
@@ -1080,6 +1080,6 @@ defmodule LivebookWeb.CoreComponents do
   end
 
   def hook_prop(value) do
-    Jason.encode!(value)
+    JSON.encode!(value)
   end
 end

--- a/lib/livebook_web/helpers/codec_helpers.ex
+++ b/lib/livebook_web/helpers/codec_helpers.ex
@@ -90,7 +90,7 @@ defmodule LivebookWeb.CodecHelpers do
   """
   @spec encode_annotated_binary!(term(), binary()) :: binary()
   def encode_annotated_binary!(meta, binary) do
-    meta = Jason.encode!(meta)
+    meta = JSON.encode!(meta)
     meta_size = byte_size(meta)
     <<meta_size::size(32), meta::binary, binary::binary>>
   end
@@ -101,7 +101,7 @@ defmodule LivebookWeb.CodecHelpers do
   @spec decode_annotated_binary!(binary()) :: {term(), binary()}
   def decode_annotated_binary!(raw) do
     <<meta_size::size(32), meta::binary-size(meta_size), binary::binary>> = raw
-    meta = Jason.decode!(meta)
+    meta = JSON.decode!(meta)
     {meta, binary}
   end
 end

--- a/lib/livebook_web/live/session_live/save_runtime_config_component.ex
+++ b/lib/livebook_web/live/session_live/save_runtime_config_component.ex
@@ -174,7 +174,7 @@ defmodule LivebookWeb.SessionLive.SaveRuntimeConfigComponent do
   def handle_event("load_config", %{"name" => name}, socket) do
     secret = Enum.find(socket.assigns.hub_secrets, &(&1.name == name))
 
-    case Jason.decode(secret.value) do
+    case JSON.decode(secret.value) do
       {:ok, config_defaults} ->
         send_event(socket.assigns.target, {:load_config, config_defaults})
         {:noreply, socket}
@@ -214,7 +214,7 @@ defmodule LivebookWeb.SessionLive.SaveRuntimeConfigComponent do
   defp config_secret_changeset(socket, attrs) do
     secret_prefix = socket.assigns.secret_prefix
     hub = socket.assigns.hub
-    value = Jason.encode!(socket.assigns.save_config_payload)
+    value = JSON.encode!(socket.assigns.save_config_payload)
     secret = %Livebook.Secrets.Secret{hub_id: hub.id, name: nil, value: value}
 
     secret

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -61,7 +61,7 @@ defmodule LivebookWeb.UserPlug do
     else
       encoded =
         %{"name" => nil, "hex_color" => Livebook.EctoTypes.HexColor.random()}
-        |> Jason.encode!()
+        |> JSON.encode!()
         |> Base.encode64()
 
       # We disable HttpOnly, so that it can be accessed on the client
@@ -76,7 +76,7 @@ defmodule LivebookWeb.UserPlug do
   defp mirror_user_data_in_session(conn) when conn.halted, do: conn
 
   defp mirror_user_data_in_session(conn) do
-    user_data = conn.cookies["lb_user_data"] |> Base.decode64!() |> Jason.decode!()
+    user_data = conn.cookies["lb_user_data"] |> Base.decode64!() |> JSON.decode!()
     put_session(conn, :user_data, user_data)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -109,7 +109,6 @@ defmodule Livebook.MixProject do
       {:phoenix_live_dashboard, "~> 0.8.4"},
       {:telemetry_metrics, "~> 1.0"},
       {:telemetry_poller, "~> 1.0"},
-      {:jason, "~> 1.0"},
       {:bandit, "~> 1.0"},
       {:plug, "~> 1.16"},
       {:plug_crypto, "~> 2.0"},

--- a/test/livebook/intellisense_test.exs
+++ b/test/livebook/intellisense_test.exs
@@ -321,15 +321,15 @@ defmodule Livebook.IntellisenseTest do
       context = eval(do: nil)
 
       assert %{
-               label: "Jason",
+               label: "Req",
                kind: :module,
                documentation: """
-               A blazing fast JSON parser and generator in pure Elixir.
+               The high-level API.
 
                (module)\
                """,
-               insert_text: "Jason"
-             } in Intellisense.get_completion_items("Jas", context, node())
+               insert_text: "Req"
+             } in Intellisense.get_completion_items("R", context, node())
     end
 
     test "Elixir no completion" do

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -1289,7 +1289,7 @@ defmodule Livebook.LiveMarkdown.ExportTest do
 
   defp stamp_metadata(notebook, source) do
     [_, json] = Regex.run(~r/<!-- livebook:(.*) -->\n$/, source)
-    %{"offset" => offset, "stamp" => stamp} = Jason.decode!(json)
+    %{"offset" => offset, "stamp" => stamp} = JSON.decode!(json)
 
     hub = Livebook.Hubs.fetch_hub!(notebook.hub_id)
     source = binary_slice(source, 0, offset)

--- a/test/livebook/runtime/dependencies_test.exs
+++ b/test/livebook/runtime/dependencies_test.exs
@@ -7,7 +7,7 @@ defmodule Livebook.Runtime.DependenciesTest do
 
   doctest Dependencies
 
-  @jason {:jason, "~> 1.3.0"}
+  @req {:req, "~> 0.5.0"}
 
   describe "add_dependencies/3" do
     test "adds dependencies and config" do
@@ -35,19 +35,19 @@ defmodule Livebook.Runtime.DependenciesTest do
 
   describe "add_mix_deps/3" do
     test "prepends Mix.install/2 call if there is none" do
-      assert Dependencies.add_mix_deps("", [@jason]) ==
+      assert Dependencies.add_mix_deps("", [@req]) ==
                {:ok,
                 """
                 Mix.install([
-                  {:jason, "~> 1.3.0"}
+                  {:req, "~> 0.5.0"}
                 ])\
                 """}
 
-      assert Dependencies.add_mix_deps("# Comment", [@jason]) ==
+      assert Dependencies.add_mix_deps("# Comment", [@req]) ==
                {:ok,
                 """
                 Mix.install([
-                  {:jason, "~> 1.3.0"}
+                  {:req, "~> 0.5.0"}
                 ])
 
                 # Comment\
@@ -63,12 +63,12 @@ defmodule Livebook.Runtime.DependenciesTest do
 
                # Final comment\
                """,
-               [@jason]
+               [@req]
              ) ==
                {:ok,
                 """
                 Mix.install([
-                  {:jason, "~> 1.3.0"}
+                  {:req, "~> 0.5.0"}
                 ])
 
                 # Outer comment
@@ -85,16 +85,16 @@ defmodule Livebook.Runtime.DependenciesTest do
       assert Dependencies.add_mix_deps(
                """
                Mix.install([
-                 {:req, "~> 0.2.0"}
+                 {:kino, "~> 0.14.0"}
                ])\
                """,
-               [@jason]
+               [@req]
              ) ==
                {:ok,
                 """
                 Mix.install([
-                  {:req, "~> 0.2.0"},
-                  {:jason, "~> 1.3.0"}
+                  {:kino, "~> 0.14.0"},
+                  {:req, "~> 0.5.0"}
                 ])\
                 """}
 
@@ -103,22 +103,22 @@ defmodule Livebook.Runtime.DependenciesTest do
                # Outer comment
                Mix.install([
                  # Inner comment leading
-                 {:req, "~> 0.2.0"}
+                 {:kino, "~> 0.14.0"}
                  # Inner comment trailing
                ])
 
                # Result
                :ok\
                """,
-               [@jason]
+               [@req]
              ) ==
                {:ok,
                 """
                 # Outer comment
                 Mix.install([
                   # Inner comment leading
-                  {:req, "~> 0.2.0"},
-                  {:jason, "~> 1.3.0"}
+                  {:kino, "~> 0.14.0"},
+                  {:req, "~> 0.5.0"}
                   # Inner comment trailing
                 ])
 
@@ -130,21 +130,21 @@ defmodule Livebook.Runtime.DependenciesTest do
                """
                Mix.install(
                  [
-                   {:req, "~> 0.2.0"}
+                  {:kino, "~> 0.14.0"}
                  ],
                  system_env: [
                    # {"XLA_TARGET", "cuda111"}
                  ]
                )\
                """,
-               [@jason]
+               [@req]
              ) ==
                {:ok,
                 """
                 Mix.install(
                   [
-                    {:req, "~> 0.2.0"},
-                    {:jason, "~> 1.3.0"}
+                    {:kino, "~> 0.14.0"},
+                    {:req, "~> 0.5.0"}
                   ],
                   system_env: [
                     # {"XLA_TARGET", "cuda111"}
@@ -156,46 +156,46 @@ defmodule Livebook.Runtime.DependenciesTest do
     test "does not add the dependency if it already exists" do
       code = """
       Mix.install([
-        {:jason, "~> 1.3.0"}
+        {:req, "~> 0.5.0"}
       ])\
       """
 
-      assert Dependencies.add_mix_deps(code, [@jason]) == {:ok, code}
+      assert Dependencies.add_mix_deps(code, [@req]) == {:ok, code}
 
       code = """
       Mix.install([
-        {:jason, "~> 1.3.0", runtime: false}
+        {:req, "~> 0.5.0", runtime: false}
       ])\
       """
 
-      assert Dependencies.add_mix_deps(code, [@jason]) == {:ok, code}
+      assert Dependencies.add_mix_deps(code, [@req]) == {:ok, code}
     end
 
     test "given multiple dependencies adds the missing ones" do
       assert Dependencies.add_mix_deps(
                """
                Mix.install([
-                 {:jason, "~> 1.3.0"}
+                 {:req, "~> 0.5.0"}
                ])\
                """,
-               [{:vega_lite, "~> 0.1.3"}, {:jason, "~> 1.3.0"}, {:req, "~> 0.2.0"}]
+               [{:vega_lite, "~> 0.1.3"}, {:req, "~> 0.5.0"}, {:kino, "~> 0.14.0"}]
              ) ==
                {:ok,
                 """
                 Mix.install([
-                  {:jason, "~> 1.3.0"},
+                  {:req, "~> 0.5.0"},
                   {:vega_lite, "~> 0.1.3"},
-                  {:req, "~> 0.2.0"}
+                  {:kino, "~> 0.14.0"}
                 ])\
                 """}
 
       code = """
       Mix.install([
-        {:jason, "~> 1.3.0", runtime: false}
+        {:req, "~> 0.5.0", runtime: false}
       ])\
       """
 
-      assert Dependencies.add_mix_deps(code, [@jason]) == {:ok, code}
+      assert Dependencies.add_mix_deps(code, [@req]) == {:ok, code}
     end
 
     test "returns an error if the code has a syntax error" do
@@ -205,7 +205,7 @@ defmodule Livebook.Runtime.DependenciesTest do
           # Comment
           [,1]
           """,
-          [@jason]
+          [@req]
         )
 
       assert clean_message(message) ==
@@ -223,12 +223,12 @@ defmodule Livebook.Runtime.DependenciesTest do
     test "adds config if specified" do
       config = [nx: [default_backend: EXLA.Backend]]
 
-      assert Dependencies.add_mix_deps("", [@jason], config) ==
+      assert Dependencies.add_mix_deps("", [@req], config) ==
                {:ok,
                 """
                 Mix.install(
                   [
-                    {:jason, "~> 1.3.0"}
+                    {:req, "~> 0.5.0"}
                   ],
                   config: [nx: [default_backend: EXLA.Backend]]
                 )\
@@ -237,7 +237,7 @@ defmodule Livebook.Runtime.DependenciesTest do
       assert Dependencies.add_mix_deps(
                """
                Mix.install([
-                 {:jason, "~> 1.3.0"}
+                 {:req, "~> 0.5.0"}
                ])\
                """,
                [],
@@ -247,7 +247,7 @@ defmodule Livebook.Runtime.DependenciesTest do
                 """
                 Mix.install(
                   [
-                    {:jason, "~> 1.3.0"}
+                    {:req, "~> 0.5.0"}
                   ],
                   config: [nx: [default_backend: EXLA.Backend]]
                 )\
@@ -259,7 +259,7 @@ defmodule Livebook.Runtime.DependenciesTest do
                """
                Mix.install(
                  [
-                   {:jason, "~> 1.3.0"}
+                   {:req, "~> 0.5.0"}
                  ],
                  config: [
                    # Comment 1
@@ -285,7 +285,7 @@ defmodule Livebook.Runtime.DependenciesTest do
                 """
                 Mix.install(
                   [
-                    {:jason, "~> 1.3.0"}
+                    {:req, "~> 0.5.0"}
                   ],
                   config: [
                     # Comment 1
@@ -305,7 +305,7 @@ defmodule Livebook.Runtime.DependenciesTest do
                """
                Mix.install(
                  [
-                   {:jason, "~> 1.3.0"}
+                   {:req, "~> 0.5.0"}
                  ],
                  [config: []]
                )\
@@ -317,7 +317,7 @@ defmodule Livebook.Runtime.DependenciesTest do
                 """
                 Mix.install(
                   [
-                    {:jason, "~> 1.3.0"}
+                    {:req, "~> 0.5.0"}
                   ],
                   config: [nx: [default_backend: EXLA.Backend]]
                 )\

--- a/test/livebook/runtime/fly_test.exs
+++ b/test/livebook/runtime/fly_test.exs
@@ -83,7 +83,7 @@ defmodule Livebook.Runtime.FlyTest do
     {output, 0} =
       System.cmd("fly", args ++ ["--app", fly.app_name, "--access-token", fly.token, "--json"])
 
-    Jason.decode!(output)
+    JSON.decode!(output)
   end
 
   defp fly!() do

--- a/test/livebook/runtime/k8s_test.exs
+++ b/test/livebook/runtime/k8s_test.exs
@@ -113,7 +113,7 @@ defmodule Livebook.Runtime.K8sTest do
     cmd!(
       ~w(kubectl get pod --selector=livebook.dev/runtime=integration-test --field-selector=status.phase==Running --output json)
     )
-    |> Jason.decode!()
+    |> JSON.decode!()
     |> Map.fetch!("items")
   end
 

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -221,7 +221,7 @@ defmodule Livebook.SessionTest do
 
       Session.subscribe(session.id)
 
-      Session.add_dependencies(session.pid, [%{dep: {:jason, "~> 1.3.0"}, config: []}])
+      Session.add_dependencies(session.pid, [%{dep: {:req, "~> 0.5.0"}, config: []}])
 
       assert_receive {:operation,
                       {:apply_cell_delta, "__server__", "setup", :primary, _delta, _selection, 0}}
@@ -233,7 +233,7 @@ defmodule Livebook.SessionTest do
                      %{
                        source: """
                        Mix.install([
-                         {:jason, "~> 1.3.0"}
+                         {:req, "~> 0.5.0"}
                        ])\
                        """
                      }
@@ -249,7 +249,7 @@ defmodule Livebook.SessionTest do
 
       Session.subscribe(session.id)
 
-      Session.add_dependencies(session.pid, [%{dep: {:jason, "~> 1.3.0"}, config: []}])
+      Session.add_dependencies(session.pid, [%{dep: {:req, "~> 0.5.0"}, config: []}])
 
       assert_receive {:error, "failed to add dependencies to the setup cell, reason:" <> _}
     end

--- a/test/livebook/zta/cloudflare_test.exs
+++ b/test/livebook/zta/cloudflare_test.exs
@@ -37,7 +37,7 @@ defmodule Livebook.ZTA.CloudflareTest do
     Bypass.expect(bypass, fn conn ->
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{keys: [key]}))
+      |> send_resp(200, JSON.encode!(%{keys: [key]}))
     end)
 
     conn = conn(:get, "/") |> put_req_header("cf-access-jwt-assertion", token)
@@ -56,7 +56,7 @@ defmodule Livebook.ZTA.CloudflareTest do
     Bypass.expect_once(context.user_identity, fn conn ->
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(expected_user))
+      |> send_resp(200, JSON.encode!(expected_user))
     end)
 
     start_supervised!({Cloudflare, context.options})
@@ -104,7 +104,7 @@ defmodule Livebook.ZTA.CloudflareTest do
     Bypass.expect_once(bypass, fn conn ->
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{keys: ["invalid_key"]}))
+      |> send_resp(200, JSON.encode!(%{keys: ["invalid_key"]}))
     end)
 
     start_supervised!({Cloudflare, options})

--- a/test/livebook/zta/google_iap_test.exs
+++ b/test/livebook/zta/google_iap_test.exs
@@ -35,7 +35,7 @@ defmodule Livebook.ZTA.GoogleIAPTest do
     Bypass.expect(bypass, fn conn ->
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{keys: [key]}))
+      |> send_resp(200, JSON.encode!(%{keys: [key]}))
     end)
 
     conn = conn(:get, "/") |> put_req_header("x-goog-iap-jwt-assertion", token)
@@ -83,7 +83,7 @@ defmodule Livebook.ZTA.GoogleIAPTest do
     Bypass.expect_once(bypass, fn conn ->
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{keys: ["invalid_key"]}))
+      |> send_resp(200, JSON.encode!(%{keys: ["invalid_key"]}))
     end)
 
     start_supervised!({GoogleIAP, options})

--- a/test/livebook/zta/tailscale_test.exs
+++ b/test/livebook/zta/tailscale_test.exs
@@ -13,7 +13,7 @@ defmodule Livebook.ZTA.TailscaleTest do
     |> put_resp_content_type("application/json")
     |> send_resp(
       200,
-      Jason.encode!(%{
+      JSON.encode!(%{
         UserProfile: %{
           ID: 1_234_567_890,
           DisplayName: "John",

--- a/test/livebook_teams/hubs/team_client_test.exs
+++ b/test/livebook_teams/hubs/team_client_test.exs
@@ -119,7 +119,7 @@ defmodule Livebook.Hubs.TeamClientTest do
       type = Livebook.FileSystems.type(file_system)
       %{name: name} = Livebook.FileSystem.external_metadata(file_system)
       attrs = Livebook.FileSystem.dump(file_system)
-      credentials = Jason.encode!(attrs)
+      credentials = JSON.encode!(attrs)
 
       secret_key = Livebook.Teams.derive_key(team.teams_key)
       value = Livebook.Teams.encrypt(credentials, secret_key)
@@ -148,7 +148,7 @@ defmodule Livebook.Hubs.TeamClientTest do
       }
 
       updated_attrs = Livebook.FileSystem.dump(updated_file_system)
-      updated_credentials = Jason.encode!(updated_attrs)
+      updated_credentials = JSON.encode!(updated_attrs)
       updated_value = Livebook.Teams.encrypt(updated_credentials, secret_key)
 
       updated_livebook_proto_file_system = %{
@@ -385,7 +385,7 @@ defmodule Livebook.Hubs.TeamClientTest do
       type = Livebook.FileSystems.type(file_system)
       %{name: name} = Livebook.FileSystem.external_metadata(file_system)
       attrs = Livebook.FileSystem.dump(file_system)
-      credentials = Jason.encode!(attrs)
+      credentials = JSON.encode!(attrs)
 
       secret_key = Livebook.Teams.derive_key(team.teams_key)
       value = Livebook.Teams.encrypt(credentials, secret_key)
@@ -414,7 +414,7 @@ defmodule Livebook.Hubs.TeamClientTest do
       }
 
       updated_attrs = Livebook.FileSystem.dump(updated_file_system)
-      updated_credentials = Jason.encode!(updated_attrs)
+      updated_credentials = JSON.encode!(updated_attrs)
       updated_value = Livebook.Teams.encrypt(updated_credentials, secret_key)
 
       updated_livebook_proto_file_system = %{

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -2003,12 +2003,12 @@ defmodule LivebookWeb.SessionLiveTest do
       # Search the predefined dependencies in the embedded runtime
       search_view
       |> element(~s{form[phx-change="search"]})
-      |> render_change(%{"search" => "ja"})
+      |> render_change(%{"search" => "re"})
 
       page = render(view)
-      assert page =~ "jason"
-      assert page =~ "A blazing fast JSON parser and generator in pure Elixir"
-      assert page =~ "1.3.0"
+      assert page =~ "req"
+      assert page =~ "Req is a batteries-included HTTP client for Elixir."
+      assert page =~ "0.5.0"
     end
   end
 

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -36,12 +36,12 @@ defmodule LivebookWeb.UserPlugTest do
     assert %{
              "name" => nil,
              "hex_color" => <<_::binary>>
-           } = conn.cookies["lb_user_data"] |> Base.decode64!() |> Jason.decode!()
+           } = conn.cookies["lb_user_data"] |> Base.decode64!() |> JSON.decode!()
   end
 
   test "keeps user_data cookie if present" do
     cookie_value =
-      %{name: "Jake Peralta", hex_color: "#000000"} |> Jason.encode!() |> Base.encode64()
+      %{name: "Jake Peralta", hex_color: "#000000"} |> JSON.encode!() |> Base.encode64()
 
     conn =
       conn(:get, "/")

--- a/test/support/hub_helpers.ex
+++ b/test/support/hub_helpers.ex
@@ -206,7 +206,7 @@ defmodule Livebook.HubHelpers do
     secret_key = Livebook.Teams.derive_key(hub.teams_key)
     %{name: name} = Livebook.FileSystem.external_metadata(file_system)
     attrs = Livebook.FileSystem.dump(file_system)
-    json = Jason.encode!(attrs)
+    json = JSON.encode!(attrs)
     value = Livebook.Teams.encrypt(json, secret_key)
 
     file_system_created =

--- a/test/support/k8s_cluster_stub.ex
+++ b/test/support/k8s_cluster_stub.ex
@@ -7,7 +7,7 @@ defmodule Livebook.K8sClusterStub do
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :json],
-    json_decoder: Jason
+    json_decoder: JSON
 
   plug :dispatch
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,11 +23,11 @@ defmodule Livebook.Runtime.Embedded.Packages do
   def list() do
     [
       %{
-        dependency: %{dep: {:jason, "~> 1.3.0"}, config: []},
-        description: "A blazing fast JSON parser and generator in pure Elixir",
-        name: "jason",
-        url: "https://hex.pm/packages/jason",
-        version: "1.3.0"
+        dependency: %{dep: {:req, "~> 0.5.0"}, config: []},
+        description: "Req is a batteries-included HTTP client for Elixir.",
+        name: "req",
+        url: "https://hex.pm/packages/req",
+        version: "0.5.0"
       }
     ]
   end


### PR DESCRIPTION
Since we already depend on Elixir 1.18, this replaces all usages of Jason with JSON.