### PR TITLE
Allow pre-release versions in attached runtime version check

### DIFF
--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -91,8 +91,13 @@ defmodule Livebook.Runtime.Attached do
     # changes are unlikely within the same minor version, so that's
     # the requirement we enforce.
 
-    current = Version.parse!(System.version())
-    same_minor = "#{current.major}.#{current.minor}.0"
+    current = System.version()
+
+    same_minor =
+      current
+      |> Version.parse!()
+      |> Map.replace!(:patch, 0)
+      |> Version.to_string()
 
     # Make sure Livebook does not enforce a higher patch version
     min_version =


### PR DESCRIPTION
I often run with the most recent Elixir version from GitHub locally. Currently Livebook does not allow connecting nodes both running `1.19.0-dev` because

> Connecting runtime failed - the node uses Elixir 1.19.0-dev, but ~> 1.19.0 is required

This PR changes the minor check to include a `-dev` suffix. I think any suffix would do, but that's what Elixir uses.