### PR TITLE
Log message when starting a new standalone runtime does not work

### DIFF
--- a/lib/livebook/runtime/standalone.ex
+++ b/lib/livebook/runtime/standalone.ex
@@ -163,7 +163,12 @@ defmodule Livebook.Runtime.Standalone do
             {:DOWN, ^manager_ref, :process, _object, _reason} -> :ok
           end
       after
-        10_000 -> :timeout
+        10_000 ->
+          IO.puts(
+            "Communication between Livebook main node (#{inspect(parent_node)}) and new standalone runtime node (#{inspect(node())}) timed out."
+          )
+
+          :timeout
       end
 
       # We explicitly halt at the end, just in case `System.no_halt(true)`

--- a/lib/livebook/runtime/standalone.ex
+++ b/lib/livebook/runtime/standalone.ex
@@ -165,8 +165,7 @@ defmodule Livebook.Runtime.Standalone do
       after
         10_000 ->
           IO.puts(
-            "Communication between Livebook main node (#{inspect(parent_node)}) and new standalone runtime node (#{inspect(node())}) timed out."
-          )
+            "Error: timeout during initial communication between standalone runtime (node: #{inspect(node())}) and Livebook (node: #{inspect(parent_node)})."
 
           :timeout
       end

--- a/lib/livebook/runtime/standalone.ex
+++ b/lib/livebook/runtime/standalone.ex
@@ -165,7 +165,9 @@ defmodule Livebook.Runtime.Standalone do
       after
         10_000 ->
           IO.puts(
-            "Error: timeout during initial communication between standalone runtime (node: #{inspect(node())}) and Livebook (node: #{inspect(parent_node)})."
+            "Error: timeout during initial communication between standalone runtime" <>
+              " (node: #{inspect(node())}) and Livebook (node: #{inspect(parent_node)})."
+          )
 
           :timeout
       end


### PR DESCRIPTION
## Why/problem
A Teams user reported the following problem:

> I was wondering if anyone has encountered this error, when trying to connect to a Standalone runtime inside the ghcr.io/livebook-dev/livebook:0.14.5 container:
> 
> Connecting runtime failed - Elixir terminated unexpectedly, please check your logs for errors. Reason: :normal
> 
> I could not find any logs for the container (though I may be looking in the wrong place). I'm not great at devOps so there may be something simple wrong with my deployment settings.

It was a little bit hard to find the root cause, because no error messages were logged, even when activating `LIVEBOOK_DEBUG` to `true`.

I debugged the problem and believe that it happened because they were setting a wrong name for the node, the `LIVEBOOK_NODE` env var, using a wrong IP or something.

I was able to replicate a similar, running Livebook locally like this: `LIVEBOOK_NODE=foo@127.1.1.1 mix phx.server`, given that `127.1.1.1` is not a reachable/valid IP from my machine's network.

When that happens, Livebook UI shows this error when starting a new notebook:

![CleanShot 2025-01-14 at 16 05 49](https://github.com/user-attachments/assets/66961194-c8d6-4432-a563-88832a9480c0)

Although the error message in the UI suggests looking at the log, there's no log messages for that.

This PR is about improving that.
