### PR TITLE
Backport "logs to Teams connection flow (#2914)" to v0.14

### DIFF
--- a/lib/livebook/teams/connection.ex
+++ b/lib/livebook/teams/connection.ex
@@ -44,16 +44,20 @@ defmodule Livebook.Teams.Connection do
       {:ok, conn, websocket, ref} ->
         send(data.listener, :connected)
         send(self(), {:loop_ping, ref})
+        Logger.info("Teams WebSocket connection - established")
 
         {:keep_state, %{data | http_conn: conn, ref: ref, websocket: websocket}}
 
       {:transport_error, reason} ->
         send(data.listener, {:connection_error, reason})
+        Logger.warning("Teams WebSocket connection - transport error: #{inspect(reason)}")
+
         {:keep_state_and_data, {{:timeout, :backoff}, @backoff, nil}}
 
       {:server_error, error} ->
         reason = LivebookProto.Error.decode(error).details
         send(data.listener, {:server_error, reason})
+        Logger.warning("Teams WebSocket connection - server error : #{inspect(reason)}")
 
         {:keep_state, data}
     end
@@ -70,6 +74,7 @@ defmodule Livebook.Teams.Connection do
         {:keep_state, %{data | http_conn: conn, websocket: websocket}}
 
       {:error, conn, websocket, _reason} ->
+        Logger.warning("Teams WebSocket connection - ping error")
         {:keep_state, %{data | http_conn: conn, websocket: websocket}}
     end
   end


### PR DESCRIPTION
This could help current beta users running the latest stable branch of Livebook docker container.

We could ask them to update this version to help debug the problem with the Teams Connection.

We could merge this and release a new v0.14.x before releasing the v0.15.