### PR TITLE
Do not override RELEASE_DISTRIBUTION in release to allow rpc

### DIFF
--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -3,7 +3,7 @@ if exist "!USERPROFILE!\.livebookdesktop.bat" (
 )
 
 set RELEASE_MODE=interactive
-if not defined RELEASE_DISTRIBUTION set set RELEASE_DISTRIBUTION=none
+if not defined RELEASE_DISTRIBUTION set RELEASE_DISTRIBUTION=none
 
 set vendor_dir=!RELEASE_ROOT!\vendor\livebook-!RELEASE_VSN!
 set MIX_ARCHIVES=!vendor_dir!\archives

--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -3,7 +3,7 @@ if exist "!USERPROFILE!\.livebookdesktop.bat" (
 )
 
 set RELEASE_MODE=interactive
-set RELEASE_DISTRIBUTION=none
+if not defined RELEASE_DISTRIBUTION set set RELEASE_DISTRIBUTION=none
 
 set vendor_dir=!RELEASE_ROOT!\vendor\livebook-!RELEASE_VSN!
 set MIX_ARCHIVES=!vendor_dir!\archives

--- a/rel/app/env.sh.eex
+++ b/rel/app/env.sh.eex
@@ -3,7 +3,7 @@ if [ -f "$HOME/.livebookdesktop.sh" ]; then
 fi
 
 export RELEASE_MODE="interactive"
-export RELEASE_DISTRIBUTION="none"
+if [ -z "${RELEASE_DISTRIBUTION}" ]; then export RELEASE_DISTRIBUTION="none"; fi
 
 vendor_dir="${RELEASE_ROOT}/vendor/livebook-${RELEASE_VSN}"
 export MIX_ARCHIVES="${vendor_dir}/archives"

--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -3,7 +3,7 @@ if exist "!RELEASE_ROOT!\user\env.bat" (
 )
 
 set RELEASE_MODE=interactive
-if not defined RELEASE_DISTRIBUTION set set RELEASE_DISTRIBUTION=none
+if not defined RELEASE_DISTRIBUTION set RELEASE_DISTRIBUTION=none
 
 if defined LIVEBOOK_NODE set RELEASE_NODE=!LIVEBOOK_NODE!
 if defined LIVEBOOK_COOKIE set RELEASE_COOKIE=!LIVEBOOK_COOKIE!

--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -3,7 +3,7 @@ if exist "!RELEASE_ROOT!\user\env.bat" (
 )
 
 set RELEASE_MODE=interactive
-set RELEASE_DISTRIBUTION=none
+if not defined RELEASE_DISTRIBUTION set set RELEASE_DISTRIBUTION=none
 
 if defined LIVEBOOK_NODE set RELEASE_NODE=!LIVEBOOK_NODE!
 if defined LIVEBOOK_COOKIE set RELEASE_COOKIE=!LIVEBOOK_COOKIE!

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -19,7 +19,7 @@ if [ -f "${RELEASE_ROOT}/user/env.sh" ]; then
 fi
 
 export RELEASE_MODE="interactive"
-export RELEASE_DISTRIBUTION="none"
+if [ -z "${RELEASE_DISTRIBUTION}" ]; then export RELEASE_DISTRIBUTION="none"; fi
 
 # Mirror these values, so that it is easier to use "bin/release rpc",
 # though it still requires setting RELEASE_DISTRIBUTION=name


### PR DESCRIPTION
We start distribution programmatically as part of boot, so we set `RELEASE_DISTRIBUTION=none`. However, when debugging inside a release we may want to connect via a remote shell. This should work if we run it as `RELEASE_DISTRIBUTION=name /bin/app/livebook remote`, however currently we always override it with `RELEASE_DISTRIBUTION=none`. This PR changes it, such that we check if `RELEASE_DISTRIBUTION` is defined.