### PR TITLE
Fix teams websocket connection not reconnecting after a graceful close

### DIFF
--- a/lib/livebook/teams/connection.ex
+++ b/lib/livebook/teams/connection.ex
@@ -144,6 +144,6 @@ defmodule Livebook.Teams.Connection do
   end
 
   defp ensure_closed(data) do
-    WebSocket.disconnect(data.http_conn, data.websocket, data.ref)
+    _ = WebSocket.disconnect(data.http_conn, data.websocket, data.ref)
   end
 end

--- a/lib/livebook/teams/web_socket.ex
+++ b/lib/livebook/teams/web_socket.ex
@@ -134,6 +134,7 @@ defmodule Livebook.Teams.WebSocket do
   """
   @spec receive(conn(), ref(), websocket(), term()) ::
           {:ok, conn(), websocket(), list(binary())}
+          | {:closed, conn(), websocket(), list(binary())}
           | {:error, conn(), websocket(), String.t()}
   def receive(conn, ref, websocket, message \\ receive(do: (message -> message))) do
     with {:ok, conn, [{:data, ^ref, data}]} <- Mint.WebSocket.stream(conn, message),
@@ -142,19 +143,21 @@ defmodule Livebook.Teams.WebSocket do
       {:ok, conn, websocket, response}
     else
       {:close, response} ->
-        handle_disconnect(conn, websocket, ref, response)
+        with {:ok, conn, websocket} <- disconnect(conn, websocket, ref) do
+          {:closed, conn, websocket, response}
+        end
 
       {:error, conn, exception} when is_exception(exception) ->
         {:error, conn, websocket, Exception.message(exception)}
 
       {:error, conn, exception, []} when is_exception(exception) ->
         {:error, conn, websocket, Exception.message(exception)}
-    end
-  end
 
-  defp handle_disconnect(conn, websocket, ref, response) do
-    with {:ok, conn, websocket} <- disconnect(conn, websocket, ref) do
-      {:ok, conn, websocket, response}
+      :unknown ->
+        # Message does not belong to this socket. For example, this
+        # can be a leftover :tcp_close or :ssl_close from a previously
+        # gracefully closed socket.
+        {:ok, conn, websocket, []}
     end
   end
 


### PR DESCRIPTION
In the current websocket logic, when we receive a "close" frame, we gracefully close the connection and return `{:ok, conn, websocket, data}`, so the caller is not aware the connection is closed.

I could reproduce it by changing local Teams to close the user socket after a few seconds. It is not entirely deterministic, so it would run for a while until the connection gets stuck. This happens specifically if we don't receive `:tcp_closed` after the graceful close. My guess is that it's more likely over the network. Receiving `:tcp_closed` after the graceful shutdown actually makes the connection crash, but the reporting user did not have that crash in the logs, which indicates that `:tcp_closed` was indeed not received.