### PR TITLE
fix: path should not be escaped in Swift code

### DIFF
--- a/rel/app/macos/Sources/Livebook/Livebook.swift
+++ b/rel/app/macos/Sources/Livebook/Livebook.swift
@@ -110,7 +110,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         for url in urls {
-            ElixirKit.API.publish("open", url.absoluteString)
+            ElixirKit.API.publish("open", "file://\(url.path)")       
         }
     }
 


### PR DESCRIPTION
Path should not be escaped in Swift otherwise it will be escaped in `notebook_open_url/2` again.

This closes #2899 and fixes the issue that the .livemd files cannot be opened by double-click them on macOS.
