### PR TITLE
Improve file select to list files matching search anywhere in the name

### DIFF
--- a/lib/livebook_web/live/file_select_component.ex
+++ b/lib/livebook_web/live/file_select_component.ex
@@ -228,7 +228,7 @@ defmodule LivebookWeb.FileSelectComponent do
 
           <div
             :if={@highlighted_file_infos != []}
-            class="grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 border-b border-dashed border-grey-200 mb-2 pb-2"
+            class="grid grid-cols-2 lg:grid-cols-3 gap-2 border-b border-dashed border-grey-200 mb-2 pb-2"
           >
             <%= for file_info <- Enum.take(@highlighted_file_infos, visible_files_limit()) do %>
               <.file
@@ -242,7 +242,7 @@ defmodule LivebookWeb.FileSelectComponent do
             <.more_files_indicator length={length(@highlighted_file_infos)} />
           </div>
 
-          <div class="grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2">
+          <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
             <%= for file_info <- Enum.take(@unhighlighted_file_infos, visible_files_limit()) do %>
               <.file
                 id={"#{@id}-file-#{file_info.id}"}
@@ -263,7 +263,7 @@ defmodule LivebookWeb.FileSelectComponent do
   defp new_item_section(assigns) do
     ~H"""
     <div
-      class="hidden grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 border-b border-dashed border-grey-200 mb-2 pb-2"
+      class="hidden grid grid-cols-2 lg:grid-cols-3 gap-2 border-b border-dashed border-grey-200 mb-2 pb-2"
       id={@id}
     >
       <form


### PR DESCRIPTION
See https://github.com/livebook-dev/livebook/discussions/2927. This improves the matching files list to include ones matching the search in the middle of the name. I also adjusted the number of columns, so each file gets more width.

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/c8b9c33e-d560-4f46-b95b-f20aac175848" />