### PR TITLE
Update Docker base image to Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 * (Desktop) The server to start on a fixed port by default (`32123`) and fall back to random if taken ([#2867](https://github.com/livebook-dev/livebook/pull/2867))
-* Bumped versions to Elixir 1.18.2 and Erlang 27.2.1 in the Docker image and the desktop app
+* Bumped versions to Elixir 1.18.2 and Erlang 27.2.2 in the Docker image and the desktop app
 * Bumped the required Elixir version to 1.18
 * In case you set `RELEASE_DISTRIBUTION`, it has been ignored since v0.13, but now it must not be set
+* Changed the Docker image to use Ubuntu 24.04
 
 ### Removed
 

--- a/versions
+++ b/versions
@@ -1,5 +1,5 @@
 elixir="1.18.2"
-otp="27.2.1"
+otp="27.2.2"
 openssl="1.1.1s"
 rebar3="3.22.0"
-ubuntu="jammy-20240808"
+ubuntu="noble-20250127"


### PR DESCRIPTION
The multi-arch build (using QEMU) started to segfault on CI. I'm not exactly sure why, I thought it may be the change in `ubuntu-latest` or one of the actions, but I pinned a few versions and it would still segfault, perhaps the change is actually in one of the apt packages. Another thing I tried is changing the Dockerfile base image from Ubuntu 22 to 24 and that builds successfully, so let's do that.