### PR TITLE
Do not store identity payload in the session

### DIFF
--- a/lib/livebook_web/live/hooks/user_hook.ex
+++ b/lib/livebook_web/live/hooks/user_hook.ex
@@ -7,8 +7,11 @@ defmodule LivebookWeb.UserHook do
       socket
       |> assign_new(:current_user, fn ->
         connect_params = get_connect_params(socket) || %{}
-        user_data = connect_params["user_data"]
-        LivebookWeb.UserPlug.build_current_user(session, user_data)
+        identity_data = session["identity_data"]
+        # user_data from connect params takes precedence, since the
+        # cookie may have been altered by the client.
+        user_data = connect_params["user_data"] || session["user_data"]
+        LivebookWeb.UserPlug.build_current_user(session, identity_data, user_data)
       end)
       |> attach_hook(:current_user_subscription, :handle_info, &info/2)
 

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -59,7 +59,8 @@ defmodule LivebookWeb.Router do
   end
 
   live_session :default,
-    on_mount: [LivebookWeb.AuthHook, LivebookWeb.UserHook, LivebookWeb.Confirm] do
+    on_mount: [LivebookWeb.AuthHook, LivebookWeb.UserHook, LivebookWeb.Confirm],
+    session: {LivebookWeb.UserPlug, :extra_lv_session, []} do
     scope "/", LivebookWeb do
       pipe_through [:browser, :auth]
 
@@ -138,7 +139,8 @@ defmodule LivebookWeb.Router do
   end
 
   live_session :apps,
-    on_mount: [LivebookWeb.AppAuthHook, LivebookWeb.UserHook, LivebookWeb.Confirm] do
+    on_mount: [LivebookWeb.AppAuthHook, LivebookWeb.UserHook, LivebookWeb.Confirm],
+    session: {LivebookWeb.UserPlug, :extra_lv_session, []} do
     scope "/", LivebookWeb do
       pipe_through [:browser, :user]
 

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -52,4 +52,14 @@ defmodule LivebookWeb.UserPlugTest do
 
     assert conn.cookies["lb_user_data"] == cookie_value
   end
+
+  test "assigns identity data and user data" do
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{})
+      |> fetch_cookies()
+      |> call()
+
+    assert %{identity_data: %{}, user_data: %{}} = conn.assigns
+  end
 end


### PR DESCRIPTION
Currently we store the user identity payload in the session, however it can be large (e.g. metadata about user belonging to multiple groups) and in turn it can exceed the session cookie size limit. The only reason we store it in the session is to access it in LV. This PR implements an alternative approach, which is to store the identity in `conn` assigns and use [`live_session`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Router.html#live_session/3) `:session` option MFA to specify the assign should be merged into LV session.

I did the same for `user_data`, which we put in the session for the same reason.

The second change concerns Livebook Teams ZTA. The current implementation also stores the whole identity data in the session, which can lead to the same issue. However, we fetch the metadata on every plug run and the only info we need to store in the session is the access token. Also done in this PR.