### PR TITLE
Fix K8s runtime failing to connect due to missing CA certificates

### DIFF
--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -783,6 +783,8 @@ defmodule Livebook.Utils do
       connect_options: fn request ->
         uri = URI.parse(request.url)
 
+        # We use a step, because the configuration depends on the URL,
+        # but we allow any specified :connect_options to take precedence.
         connect_options =
           uri
           |> mint_connect_options_for_uri()

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -782,7 +782,12 @@ defmodule Livebook.Utils do
     Req.Request.append_request_steps(req,
       connect_options: fn request ->
         uri = URI.parse(request.url)
-        connect_options = mint_connect_options_for_uri(uri)
+
+        connect_options =
+          uri
+          |> mint_connect_options_for_uri()
+          |> Keyword.merge(Req.Request.get_option(request, :connect_options, []))
+
         Req.Request.merge_options(request, connect_options: connect_options)
       end
     )


### PR DESCRIPTION
# Example of `k8s` runtime error and the proposed solution

## Setup

#### Load the local kubeconfig

```elixir
kubeconfig =
  [{Kubereq.Kubeconfig.File, path: "~/.kube/config"}]
  |> Kubereq.Kubeconfig.load()
  |> Kubereq.Kubeconfig.set_current_context("colima")
```

#### Create the context for the error producing function call

The entrypoint for the error is the call

<!-- livebook:{"force_markdown":true} -->

```elixir
Livebook.K8sAPI.create_access_review(kubeconfig,
  verb: "create",
  group: "authorization.k8s.io",
  version: "v1",
  resource: "selfsubjectaccessreviews"
)
```

at [this location](https://github.com/livebook-dev/livebook/blob/71ce29d03f0e9d1012577b0e6c47c4e2ef1d28ab/lib/livebook_web/live/session_live/k8s_runtime_component.ex#L648). Let us setup some context to reproduce the error.

```elixir
resource_attributes =
  [
    verb: "create",
    group: "authorization.k8s.io",
    version: "v1",
    resource: "selfsubjectaccessreviews"
  ]
  |> Keyword.validate!([
    :name,
    :namespace,
    :path,
    :resource,
    :subresource,
    :verb,
    :version,
    group: ""
  ])
  |> Enum.into(%{})

access_review = %{
  "apiVersion" => "authorization.k8s.io/v1",
  "kind" => "SelfSubjectAccessReview",
  "spec" => %{
    "resourceAttributes" => resource_attributes
  }
}
```

## The error

The `Kubereq.create` action at [this location](https://github.com/livebook-dev/livebook/blob/71ce29d03f0e9d1012577b0e6c47c4e2ef1d28ab/lib/livebook/k8s_api.ex#L270) results in the "Unknown CA" error. We can simulate this call as follows.

```elixir
Req.new()
|> Livebook.Utils.req_attach_defaults()
|> Kubereq.attach(
  kubeconfig: kubeconfig,
  api_version: "authorization.k8s.io/v1",
  kind: "SelfSubjectAccessReview"
)
|> Kubereq.create(access_review)
```

## Eliminating the error

The error can be eliminated (and TLS authentication will successfully complete) if we remove `Livebook.Utils.req_attach_defaults/1`

```elixir
Req.new()
|> Kubereq.attach(
  kubeconfig: kubeconfig,
  api_version: "authorization.k8s.io/v1",
  kind: "SelfSubjectAccessReview"
)
|> Kubereq.create(access_review)
```

## The explanation

#### Improper binding order for `:connect_options`

Inspecting [`Livebook.Utils.req_attach_defaults/1`](https://github.com/livebook-dev/livebook/blob/71ce29d03f0e9d1012577b0e6c47c4e2ef1d28ab/lib/livebook/utils.ex#L781) it is apparent that `Req.Request.append_request_steps/2` is used to directly set `:connect_options` for the request. Unfortunately, this has the effect of overriding any downstream modifications of `:connect_options` that use `Req.merge/2`. In particular, it breaks what I would call the "natural" semantics of the statement

<!-- livebook:{"force_markdown":true} -->

```elixir
Req.new()
|> Livebook.Utils.req_attach_defaults()
|> Req.merge(connect_options: connect_options)
```

where one would expect that the last binding of `:connect_options` in the pipeline will take precedence. Instead, with the current implementation, the `Req.merge/2` call (above) has no effect. One can observe that this results in the `k8s` runtime error by noticing that correct, cluster-specific `:connect_options` are [set here](https://github.com/mruoss/kubereq/blob/70db386613bdb861bb68acf0ef058d9ac6be73eb/lib/kubereq/utils.ex#L17) using `Req.merge/2`.

However, the current behaviour of `Livebook.Utils.req_attach_defaults/1` may be the actual intention behind it's implementation -- to accomodate for other issues that I am not aware of.

## A proposed fix for Livebook

Currently, `Livebook.Utils.req_attach_defaults/1` sets `:connect_options` by overwriting it, like so:

<!-- livebook:{"force_markdown":true} -->

```elixir
def req_attach_defaults(req) do
  Req.Request.append_request_steps(req,
    connect_options: fn request ->
      uri = URI.parse(request.url)
      connect_options = mint_connect_options_for_uri(uri)
      Req.Request.merge_options(request, connect_options: connect_options)
    end
  )
end
```

The natural fix is to have `Livebook.Utils.req_attach_defaults/1` merge the existing `:connect_options` for the request into the default options that it produces. An example showing this modficiation can be tested in the executable cell below. It has been verified that this modification fixes the issue.

```elixir
Req.new()
|> Req.Request.append_request_steps(
  connect_options: fn request ->
    uri = URI.parse(request.url)

    connect_options =
      uri
      |> Livebook.Utils.mint_connect_options_for_uri()
      |> Keyword.merge(Req.Request.get_option(request, :connect_options, []))

    Req.Request.merge_options(request, connect_options: connect_options)
  end
)
|> Kubereq.attach(
  kubeconfig: kubeconfig,
  api_version: "authorization.k8s.io/v1",
  kind: "SelfSubjectAccessReview"
)
|> Kubereq.create(access_review)
```
