### PR TITLE
Do not symlink priv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,3 @@ npm-debug.log
 
 # The built Escript
 /livebook
-
-# We generate priv when building release or escript
-/priv/static
-/priv/iframe_static

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,6 @@ COPY config config
 RUN mix do deps.get, deps.compile
 
 # Compile and build the release
-COPY priv/.gitkeep priv/.gitkeep
 COPY rel rel
 COPY static static
 COPY iframe/priv/static/iframe iframe/priv/static/iframe

--- a/lib/mix/tasks/livebook.gen_priv.ex
+++ b/lib/mix/tasks/livebook.gen_priv.ex
@@ -1,18 +1,16 @@
 defmodule Mix.Tasks.Livebook.GenPriv do
   @moduledoc false
 
-  # Note that we need to include priv/.gitkeep in Dockerfile and Hex
-  # package files, so that priv/ is symlinked within _build/, before
-  # we generate the actual files.
-
   use Mix.Task
 
   @gzippable_exts ~w(.js .css .txt .text .html .json .svg .eot .ttf)
 
   @impl true
   def run([]) do
-    compress_and_copy("static", "priv/static")
-    compress_and_copy("iframe/priv/static/iframe", "priv/iframe_static")
+    app_path = Mix.Project.app_path()
+
+    compress_and_copy("static", Path.join(app_path, "priv/static"))
+    compress_and_copy("iframe/priv/static/iframe", Path.join(app_path, "priv/iframe_static"))
   end
 
   defp compress_and_copy(source_dir, target_dir) do

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Livebook.MixProject do
         "GitHub" => "https://github.com/livebook-dev/livebook"
       },
       files:
-        ~w(lib static priv/.gitkeep config mix.exs mix.lock README.md LICENSE CHANGELOG.md iframe/priv/static/iframe proto/lib)
+        ~w(lib static config mix.exs mix.lock README.md LICENSE CHANGELOG.md iframe/priv/static/iframe proto/lib)
     ]
   end
 


### PR DESCRIPTION
Closes #2964.

It looks like under some conditions on Windows, the top-level `priv/` is not symlinked into the build directory. This changes it so that we generate the priv in the build directory directly. It actually simplifies things because we no longer need to copy `.gitkeep`.