### PR TITLE
Improve UX when loading JS output fails or takes long time

### DIFF
--- a/lib/livebook_web/channels/js_view_channel.ex
+++ b/lib/livebook_web/channels/js_view_channel.ex
@@ -28,8 +28,12 @@ defmodule LivebookWeb.JSViewChannel do
 
     socket =
       update_in(socket.assigns.ref_with_info[ref], fn
-        nil -> %{pid: pid, count: 1, connect_queue: [id]}
-        info -> %{info | count: info.count + 1, connect_queue: info.connect_queue ++ [id]}
+        nil ->
+          monitor_ref = Process.monitor(pid, tag: {:connect_down, ref})
+          %{pid: pid, monitor_ref: monitor_ref, count: 1, connect_queue: [id]}
+
+        info ->
+          %{info | count: info.count + 1, connect_queue: info.connect_queue ++ [id]}
       end)
 
     if socket.assigns.ref_with_info[ref].count == 1 do
@@ -66,13 +70,10 @@ defmodule LivebookWeb.JSViewChannel do
   def handle_in("disconnect", %{"ref" => ref}, socket) do
     socket =
       case socket.assigns.ref_with_info do
-        %{^ref => %{count: 1}} ->
-          Livebook.Session.unsubscribe_from_runtime_events(
-            socket.assigns.session_id,
-            "js_live",
-            ref
-          )
-
+        %{^ref => %{count: 1, monitor_ref: monitor_ref}} ->
+          Process.demonitor(monitor_ref, [:flush])
+          session_id = socket.assigns.session_id
+          Livebook.Session.unsubscribe_from_runtime_events(session_id, "js_live", ref)
           {_, socket} = pop_in(socket.assigns.ref_with_info[ref])
           socket
 
@@ -97,9 +98,20 @@ defmodule LivebookWeb.JSViewChannel do
         {id, queue}
       end)
 
-    with {:error, error} <- try_push(socket, "init:#{ref}:#{id}", nil, payload) do
+    with {:error, error} <- try_push(socket, "init:#{ref}:#{id}", [true], payload) do
       message = "Failed to serialize initial widget data, " <> error
       push(socket, "error:#{ref}", %{"message" => message, "init" => true})
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_info({{:connect_down, ref}, _ref, :process, _pid, _reason}, socket) do
+    Livebook.Session.unsubscribe_from_runtime_events(socket.assigns.session_id, "js_live", ref)
+    {%{connect_queue: ids}, socket} = pop_in(socket.assigns.ref_with_info[ref])
+
+    for id <- ids do
+      :ok = try_push(socket, "init:#{ref}:#{id}", [false], nil)
     end
 
     {:noreply, socket}

--- a/lib/livebook_web/live/js_view_component.ex
+++ b/lib/livebook_web/live/js_view_component.ex
@@ -6,7 +6,7 @@ defmodule LivebookWeb.JSViewComponent do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign_new(:timeout_message, fn -> "Not available" end)}
+     |> assign_new(:unreachable_message, fn -> "Not available" end)}
   end
 
   @impl true
@@ -26,8 +26,11 @@ defmodule LivebookWeb.JSViewComponent do
       data-p-connect-token={hook_prop(connect_token(@js_view.pid))}
       data-p-iframe-port={hook_prop(LivebookWeb.IframeEndpoint.port())}
       data-p-iframe-url={hook_prop(Livebook.Config.iframe_url())}
-      data-p-timeout-message={hook_prop(@timeout_message)}
+      data-p-unreachable-message={hook_prop(@unreachable_message)}
     >
+      <div class="delay-200 py-2" data-el-skeleton>
+        <.content_skeleton empty={false} />
+      </div>
     </div>
     """
   end

--- a/lib/livebook_web/live/output.ex
+++ b/lib/livebook_web/live/output.ex
@@ -91,7 +91,7 @@ defmodule LivebookWeb.Output do
       js_view={@js_view}
       session_id={@session_id}
       client_id={@client_id}
-      timeout_message="Output data no longer available, please reevaluate this cell"
+      unreachable_message="Output data no longer available, please reevaluate this cell"
     />
     """
   end


### PR DESCRIPTION
Currently, when JS view loads (JS output or smart cell), we setup a 2s timeout and show a failure message afterwards. The issue is that if the output is not available (runtime down), we should show a message right away; on the other hand, if the loading involves a huge payload, it may take longer than 2s, so we should not show the message.

This PR improves both scenarios by using monitoring the JS runtime process instead of relying on timeout. In case the loading takes longer, we also show a skeleton to avoid user confusion.

I don't remember exactly, but I guess we wanted to avoid monitoring runtime processes from the channel, which at this point I think is ok.

Refs: [(1)](https://github.com/livebook-dev/livebook/discussions/2901#discussioncomment-12044971), [(2)](https://elixirforum.com/t/output-data-no-longer-available-message-with-req-athena/70049).