### PR TITLE
Fix RELEASE_COOKIE for Windows 11

### DIFF
--- a/rel/app/env.bat.eex
+++ b/rel/app/env.bat.eex
@@ -16,8 +16,8 @@ if defined LIVEBOOK_NODE set RELEASE_NODE=!LIVEBOOK_NODE!
 if defined LIVEBOOK_COOKIE set RELEASE_COOKIE=!LIVEBOOK_COOKIE!
 
 if not defined RELEASE_COOKIE (
-  for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
-  set RELEASE_COOKIE=cookie-!TIMESTAMP:~0,11!-!RANDOM!
+  REM Create random cookie. Removes spaces using : =%. Do not remove this comment.
+  set RELEASE_COOKIE=cookie-%DATE: =%_%TIME: =%_%RANDOM%
 )
 
 cd !HOMEDRIVE!!HOMEPATH!

--- a/rel/server/env.bat.eex
+++ b/rel/server/env.bat.eex
@@ -11,8 +11,8 @@ set RELEASE_MODE=interactive
 set RELEASE_DISTRIBUTION=none
 
 if not defined RELEASE_COOKIE (
-  for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
-  set RELEASE_COOKIE=cookie-!TIMESTAMP:~0,11!-!RANDOM!
+  REM Create random cookie. Removes spaces using : =%. Do not remove this comment.
+  set RELEASE_COOKIE=cookie-%DATE: =%_%TIME: =%_%RANDOM%
 )
 
 cd !HOMEDRIVE!!HOMEPATH!


### PR DESCRIPTION
Prior to this patch, generated RELEASE_COOKIE looked like this:

    cookie-20250513171232.469000+120-21387

Unfortunately, `wmic` is no longer present in Windows 11.

With this patch, the generated value is:

    cookie-13/05/2025_17:47:39.45_27799
