### PR TITLE
Makes the notebook execute without errors when GitHubs API rate limit

### DIFF
--- a/lib/livebook/notebook/learn/github_stars.livemd
+++ b/lib/livebook/notebook/learn/github_stars.livemd
@@ -141,7 +141,16 @@ Execute the cell below. You should see a list of GitHub users who starred the re
 
 ```elixir
 repo_name = "livebook-dev/livebook"
-{:ok, stargazers} = GitHubApi.stargazers(repo_name)
+
+stargazers =
+  case GitHubApi.stargazers(repo_name) do
+    {:ok, stargazers} ->
+      stargazers
+
+    {:error, error_message} ->
+      IO.puts(error_message)
+      []
+  end
 ```
 
 ## Data processing


### PR DESCRIPTION
Before, when running as an app, we were getting an error, and the app was not being successfully deployed:

![image](https://github.com/user-attachments/assets/ec8e2b8a-da73-4fac-a5f6-370c002d427f)
![image](https://github.com/user-attachments/assets/b5739417-7fe4-42b0-bf2c-d03752e932f5)

## To-do
- [ ] after merging this, update Livebook Teams copy of the notebook