### PR TITLE
Simplify Teams integration setup and tests

### DIFF
--- a/lib/livebook_web/components/layout_components.ex
+++ b/lib/livebook_web/components/layout_components.ex
@@ -10,6 +10,7 @@ defmodule LivebookWeb.LayoutComponents do
   """
   attr :current_page, :string, required: true
   attr :current_user, Livebook.Users.User, required: true
+  attr :teams_auth, :atom, values: [:online, :offline]
   attr :saved_hubs, :list, required: true
 
   slot :inner_block, required: true
@@ -23,10 +24,10 @@ defmodule LivebookWeb.LayoutComponents do
         <.sidebar current_page={@current_page} current_user={@current_user} saved_hubs={@saved_hubs} />
       </div>
       <div class="grow overflow-y-auto">
-        <.topbar :if={Livebook.Config.teams_auth() == :online} variant="warning">
+        <.topbar :if={@teams_auth == :online} variant="warning">
           This Livebook instance has been configured for notebook deployment and is in read-only mode.
         </.topbar>
-        <.topbar :if={Livebook.Config.teams_auth() == :offline} variant="warning">
+        <.topbar :if={@teams_auth == :offline} variant="warning">
           You are running an offline Workspace for deployment. You cannot modify its settings.
         </.topbar>
 

--- a/lib/livebook_web/live/apps_dashboard_live.ex
+++ b/lib/livebook_web/live/apps_dashboard_live.ex
@@ -24,6 +24,7 @@ defmodule LivebookWeb.AppsDashboardLive do
     <LayoutComponents.layout
       current_page={~p"/apps-dashboard"}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <div class="space-y-2 p-4 md:px-12 md:py-7 max-w-screen-lg mx-auto">

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -40,6 +40,7 @@ defmodule LivebookWeb.HomeLive do
     <LayoutComponents.layout
       current_page={@self_path}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <:topbar_action>

--- a/lib/livebook_web/live/hooks/auth_hook.ex
+++ b/lib/livebook_web/live/hooks/auth_hook.ex
@@ -19,11 +19,15 @@ defmodule LivebookWeb.AuthHook do
     # But, for apps, we redirect directly from the app session
     current_user = socket.assigns.current_user
 
-    if current_user.access_type == :full and
-         Livebook.Hubs.TeamClient.user_full_access?(hub_id, current_user.groups) do
-      {:halt, socket}
+    if current_user.payload do
+      if current_user.access_type == :full and
+           Livebook.Hubs.TeamClient.user_full_access?(hub_id, current_user.groups) do
+        {:halt, socket}
+      else
+        {:halt, redirect(socket, to: ~p"/")}
+      end
     else
-      {:halt, redirect(socket, to: ~p"/")}
+      {:halt, socket}
     end
   end
 

--- a/lib/livebook_web/live/hooks/user_hook.ex
+++ b/lib/livebook_web/live/hooks/user_hook.ex
@@ -40,11 +40,16 @@ defmodule LivebookWeb.UserHook do
     # to the current app server, we don't need to check here.
     current_user = socket.assigns.current_user
     hub_id = deployment_group.hub_id
-    metadata = Livebook.ZTA.LivebookTeams.build_metadata(hub_id, current_user.payload)
 
-    case Livebook.Users.update_user(current_user, metadata) do
-      {:ok, user} -> {:cont, assign(socket, :current_user, user)}
-      _otherwise -> {:cont, socket}
+    if current_user.payload do
+      metadata = Livebook.ZTA.LivebookTeams.build_metadata(hub_id, current_user.payload)
+
+      case Livebook.Users.update_user(current_user, metadata) do
+        {:ok, user} -> {:cont, assign(socket, :current_user, user)}
+        _otherwise -> {:cont, socket}
+      end
+    else
+      {:cont, socket}
     end
   end
 

--- a/lib/livebook_web/live/hooks/user_hook.ex
+++ b/lib/livebook_web/live/hooks/user_hook.ex
@@ -15,6 +15,9 @@ defmodule LivebookWeb.UserHook do
         user_data = connect_params["user_data"] || session["user_data"]
         LivebookWeb.UserPlug.build_current_user(session, identity_data, user_data)
       end)
+      |> assign_new(:teams_auth, fn ->
+        LivebookWeb.AuthPlug.teams_auth(session)
+      end)
       |> attach_hook(:current_user_subscription, :handle_info, &handle_info/2)
       |> attach_hook(:server_authorization_subscription, :handle_info, &handle_info/2)
 

--- a/lib/livebook_web/live/hub/edit_live.ex
+++ b/lib/livebook_web/live/hub/edit_live.ex
@@ -41,6 +41,7 @@ defmodule LivebookWeb.Hub.EditLive do
     <LayoutComponents.layout
       current_page={~p"/hub/#{@hub.id}"}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <.hub_component

--- a/lib/livebook_web/live/hub/new_live.ex
+++ b/lib/livebook_web/live/hub/new_live.ex
@@ -35,7 +35,12 @@ defmodule LivebookWeb.Hub.NewLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <LayoutComponents.layout current_page="/hub" current_user={@current_user} saved_hubs={@saved_hubs}>
+    <LayoutComponents.layout
+      current_page="/hub"
+      current_user={@current_user}
+      saved_hubs={@saved_hubs}
+      teams_auth={@teams_auth}
+    >
       <LayoutComponents.topbar :if={Livebook.Config.warn_on_live_teams_server?()} variant="warning">
         <strong>Beware!</strong>
         You are running Livebook in development but this page communicates with production servers.

--- a/lib/livebook_web/live/learn_live.ex
+++ b/lib/livebook_web/live/learn_live.ex
@@ -27,6 +27,7 @@ defmodule LivebookWeb.LearnLive do
     <LayoutComponents.layout
       current_page={~p"/learn"}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <div class="p-4 md:px-12 md:py-7 max-w-screen-lg mx-auto space-y-4">

--- a/lib/livebook_web/live/open_live.ex
+++ b/lib/livebook_web/live/open_live.ex
@@ -42,6 +42,7 @@ defmodule LivebookWeb.OpenLive do
     <LayoutComponents.layout
       current_page={~p"/"}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <:topbar_action>

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -30,6 +30,7 @@ defmodule LivebookWeb.SettingsLive do
     <LayoutComponents.layout
       current_page={~p"/settings"}
       current_user={@current_user}
+      teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
     >
       <div id="settings-page" class="p-4 md:px-12 md:py-7 max-w-screen-md mx-auto space-y-16">

--- a/test/livebook_teams/apps_test.exs
+++ b/test/livebook_teams/apps_test.exs
@@ -1,21 +1,25 @@
 defmodule Livebook.Integration.AppsTest do
   use Livebook.TeamsIntegrationCase, async: true
 
-  alias Livebook.Apps
+  @moduletag workspace_for: :agent
+  setup :workspace
+
+  @moduletag subscribe_to_hubs_topics: [:connection, :secrets]
+  @moduletag subscribe_to_teams_topics: [:clients, :agents]
 
   describe "integration" do
     @tag :tmp_dir
-    test "deploying apps with hub secrets", %{user: user, node: node, tmp_dir: tmp_dir} do
-      Livebook.Hubs.Broadcasts.subscribe([:secrets])
-
-      hub = create_team_hub(user, node)
-      hub_id = hub.id
-      secret = insert_secret(hub_id: hub.id)
+    test "deploying apps with hub secrets",
+         %{team: team, org_key: org_key, node: node, tmp_dir: tmp_dir} do
+      hub_id = team.id
+      secret = TeamsRPC.create_secret(node, team, org_key)
       secret_name = secret.name
+      secret_value = secret.value
+
+      assert_receive {:secret_created,
+                      %{hub_id: ^hub_id, name: ^secret_name, value: ^secret_value}}
+
       slug = Livebook.Utils.random_short_id()
-
-      assert_receive {:secret_created, %{hub_id: ^hub_id, name: ^secret_name}}
-
       app_path = Path.join(tmp_dir, "app.livemd")
 
       source = """
@@ -35,12 +39,12 @@ defmodule Livebook.Integration.AppsTest do
       {source, []} = Livebook.LiveMarkdown.notebook_to_livemd(notebook)
       File.write!(app_path, source)
 
-      Apps.subscribe()
+      Livebook.Apps.subscribe()
 
-      assert [app_spec] = Apps.build_app_specs_in_dir(tmp_dir)
+      assert [app_spec] = Livebook.Apps.build_app_specs_in_dir(tmp_dir)
 
-      deployer_pid = Apps.Deployer.local_deployer()
-      Apps.Deployer.deploy_monitor(deployer_pid, app_spec)
+      deployer_pid = Livebook.Apps.Deployer.local_deployer()
+      Livebook.Apps.Deployer.deploy_monitor(deployer_pid, app_spec)
 
       assert_receive {:app_created, %{pid: pid, slug: ^slug}}
 
@@ -52,7 +56,16 @@ defmodule Livebook.Integration.AppsTest do
                         ]
                       }}
 
-      assert %{secrets: %{^secret_name => ^secret}} = Livebook.Session.get_data(session.pid)
+      assert %{
+               secrets: %{
+                 ^secret_name => %Livebook.Secrets.Secret{
+                   name: ^secret_name,
+                   value: ^secret_value,
+                   deployment_group_id: nil,
+                   hub_id: ^hub_id
+                 }
+               }
+             } = Livebook.Session.get_data(session.pid)
 
       Livebook.App.close(pid)
     end

--- a/test/livebook_teams/apps_test.exs
+++ b/test/livebook_teams/apps_test.exs
@@ -1,8 +1,8 @@
 defmodule Livebook.Integration.AppsTest do
   use Livebook.TeamsIntegrationCase, async: true
 
-  @moduletag workspace_for: :agent
-  setup :workspace
+  @moduletag teams_for: :agent
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection, :secrets]
   @moduletag subscribe_to_teams_topics: [:clients, :agents]

--- a/test/livebook_teams/hubs/team_client_test.exs
+++ b/test/livebook_teams/hubs/team_client_test.exs
@@ -3,14 +3,14 @@ defmodule Livebook.Hubs.TeamClientTest do
 
   alias Livebook.Hubs.TeamClient
 
-  setup :workspace
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:crud, :connection, :file_systems, :secrets]
   @moduletag subscribe_to_teams_topics: [:clients, :deployment_groups, :app_deployments, :agents]
 
   describe "connect" do
-    @describetag workspace_for: :user
-    @describetag workspace_persisted: false
+    @describetag teams_for: :user
+    @describetag teams_persisted: false
 
     test "successfully authenticates the websocket connection", %{team: team} do
       id = team.id
@@ -36,7 +36,7 @@ defmodule Livebook.Hubs.TeamClientTest do
   end
 
   describe "handle user_connected event" do
-    @describetag workspace_for: :user
+    @describetag teams_for: :user
 
     setup %{team: team} do
       user_connected =
@@ -306,7 +306,7 @@ defmodule Livebook.Hubs.TeamClientTest do
   end
 
   describe "handle agent_connected event" do
-    @describetag workspace_for: :agent
+    @describetag teams_for: :agent
 
     setup context do
       agent_connected =

--- a/test/livebook_teams/hubs_test.exs
+++ b/test/livebook_teams/hubs_test.exs
@@ -1,236 +1,198 @@
 defmodule Livebook.HubsTest do
   use Livebook.TeamsIntegrationCase, async: true
-
   alias Livebook.Hubs
 
-  setup do
-    Livebook.Hubs.Broadcasts.subscribe([:connection, :file_systems, :secrets])
-    Livebook.Teams.Broadcasts.subscribe([:clients])
+  @moduletag workspace_for: :user
+  setup :workspace
 
-    :ok
-  end
+  @moduletag subscribe_to_hubs_topics: [:connection, :file_systems, :secrets]
+  @moduletag subscribe_to_teams_topics: [:clients]
 
-  test "get_hubs/0 returns a list of persisted hubs", %{user: user, node: node} do
-    team = connect_to_teams(user, node)
+  test "get_hubs/0 returns a list of persisted hubs", %{team: team} do
     assert team in Hubs.get_hubs()
-
-    Hubs.delete_hub(team.id)
-    refute team in Hubs.get_hubs()
-  end
-
-  test "get_metadata/0 returns a list of persisted hubs normalized", %{user: user, node: node} do
-    team = connect_to_teams(user, node)
-    metadata = Hubs.Provider.to_metadata(team)
-
-    assert metadata in Hubs.get_metadata()
-
-    Hubs.delete_hub(team.id)
-    refute metadata in Hubs.get_metadata()
-  end
-
-  test "fetch_hub!/1 returns one persisted team", %{user: user, node: node} do
-    assert_raise Livebook.Storage.NotFoundError,
-                 ~s/could not find entry in "hubs" with ID "nonexistent"/,
-                 fn ->
-                   Hubs.fetch_hub!("nonexistent")
-                 end
-
-    team = connect_to_teams(user, node)
-
-    assert Hubs.fetch_hub!(team.id) == team
-  end
-
-  test "hub_exists?/1", %{user: user, node: node} do
-    team = build_team_hub(user, node)
-    refute Hubs.hub_exists?(team.id)
-    Hubs.save_hub(team)
     assert Hubs.hub_exists?(team.id)
   end
 
-  describe "save_hub/1" do
-    test "persists hub", %{user: user, node: node} do
-      team = build_team_hub(user, node)
-      Hubs.save_hub(team)
+  test "get_metadata/0 returns a list of persisted hubs normalized", %{team: team} do
+    assert %{provider: ^team} = metadata = Hubs.Provider.to_metadata(team)
+    assert metadata in Hubs.get_metadata()
+  end
 
+  @tag workspace_persisted: false
+  test "fetch_hub!/1 returns one persisted team", %{team: team} do
+    assert_raise Livebook.Storage.NotFoundError,
+                 ~s/could not find entry in "hubs" with ID "#{team.id}"/,
+                 fn ->
+                   Hubs.fetch_hub!(team.id)
+                 end
+
+    Hubs.save_hub(team)
+    assert Hubs.fetch_hub!(team.id) == team
+  end
+
+  describe "save_hub/1" do
+    @tag workspace_persisted: false
+    test "persists hub", %{team: team} do
+      refute Hubs.hub_exists?(team.id)
+      Hubs.save_hub(team)
       assert Hubs.fetch_hub!(team.id) == team
     end
 
-    test "updates hub", %{user: user, node: node} do
-      team = connect_to_teams(user, node)
+    test "updates hub", %{team: team} do
       Hubs.save_hub(%{team | hub_emoji: "🐈"})
-
       assert Hubs.fetch_hub!(team.id).hub_emoji == "🐈"
     end
   end
 
   describe "create_secret/2" do
-    test "creates a new secret", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      name = secret_name(hub)
-      value = hub.id
-      secret = build(:secret, name: name, value: value, hub_id: hub.id)
+    test "creates a new secret", %{team: team} do
+      name = secret_name(team)
+      value = team.id
+      secret = build(:secret, name: name, value: value, hub_id: team.id)
 
-      assert :ok = Hubs.create_secret(hub, secret)
-      assert secret in Hubs.get_secrets(hub)
+      assert :ok = Hubs.create_secret(team, secret)
+      assert secret in Hubs.get_secrets(team)
 
       # Guarantee uniqueness
-      assert {:error, errors} = Hubs.create_secret(hub, secret)
+      assert {:error, errors} = Hubs.create_secret(team, secret)
       assert "has already been taken" in errors[:name]
     end
 
-    test "returns changeset errors when data is invalid", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      secret = build(:secret, name: "LB_FOO", value: "BAR", hub_id: hub.id)
+    test "returns changeset errors when data is invalid", %{team: team} do
+      secret = build(:secret, name: "LB_FOO", value: "BAR", hub_id: team.id)
 
-      assert {:error, errors} = Hubs.create_secret(hub, secret)
+      assert {:error, errors} = Hubs.create_secret(team, secret)
       assert "cannot start with the LB_ prefix" in errors[:name]
     end
   end
 
   describe "update_secret/2" do
-    test "updates a secret", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      name = secret_name(hub)
-      value = hub.id
-      secret = build(:secret, name: name, value: value, hub_id: hub.id)
+    test "updates a secret", %{team: team} do
+      name = secret_name(team)
+      value = team.id
+      secret = build(:secret, name: name, value: value, hub_id: team.id)
 
-      assert Hubs.create_secret(hub, secret) == :ok
+      assert Hubs.create_secret(team, secret) == :ok
       assert_receive {:secret_created, %{name: ^name, value: ^value, hub_id: ^value}}
-      assert secret in Hubs.get_secrets(hub)
+      assert secret in Hubs.get_secrets(team)
 
       new_value = "BAZ"
       updated_secret = Map.replace!(secret, :value, new_value)
 
-      assert Hubs.update_secret(hub, updated_secret) == :ok
+      assert Hubs.update_secret(team, updated_secret) == :ok
       assert_receive {:secret_updated, %{name: ^name, value: ^new_value, hub_id: ^value}}
-      refute secret in Hubs.get_secrets(hub)
-      assert updated_secret in Hubs.get_secrets(hub)
+      refute secret in Hubs.get_secrets(team)
+      assert updated_secret in Hubs.get_secrets(team)
     end
 
-    test "returns changeset errors when data is invalid", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      name = secret_name(hub)
-      value = hub.id
-      secret = build(:secret, name: name, value: value, hub_id: hub.id)
+    test "returns changeset errors when data is invalid", %{team: team} do
+      name = secret_name(team)
+      value = team.id
+      secret = build(:secret, name: name, value: value, hub_id: team.id)
 
-      assert Hubs.create_secret(hub, secret) == :ok
+      assert Hubs.create_secret(team, secret) == :ok
       assert_receive {:secret_created, %{name: ^name, value: ^value}}
 
       updated_secret = Map.replace!(secret, :value, "")
 
-      assert {:error, errors} = Hubs.update_secret(hub, updated_secret)
+      assert {:error, errors} = Hubs.update_secret(team, updated_secret)
       assert "can't be blank" in errors[:value]
     end
   end
 
-  test "delete_secret/2 deletes a secret", %{user: user, node: node} do
-    hub = connect_to_teams(user, node)
-    name = secret_name(hub)
-    value = hub.id
-    secret = build(:secret, name: name, value: value, hub_id: hub.id)
+  test "delete_secret/2 deletes a secret", %{team: team} do
+    name = secret_name(team)
+    value = team.id
+    secret = build(:secret, name: name, value: value, hub_id: team.id)
 
-    assert Hubs.create_secret(hub, secret) == :ok
+    assert Hubs.create_secret(team, secret) == :ok
     assert_receive {:secret_created, %{name: ^name, value: ^value, hub_id: ^value}}
-    assert secret in Hubs.get_secrets(hub)
+    assert secret in Hubs.get_secrets(team)
 
-    assert Hubs.delete_secret(hub, secret) == :ok
+    assert Hubs.delete_secret(team, secret) == :ok
     assert_receive {:secret_deleted, %{name: ^name, value: ^value, hub_id: ^value}}
-    refute secret in Hubs.get_secrets(hub)
+    refute secret in Hubs.get_secrets(team)
 
     # Guarantee it's been removed and will return HTTP status 404
-    assert Hubs.delete_secret(hub, secret) ==
+    assert Hubs.delete_secret(team, secret) ==
              {:transport_error,
               "Something went wrong, try again later or please file a bug if it persists"}
   end
 
   describe "create_file_system/2" do
-    test "creates a new file system", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-
-      bucket_url = "https://#{hub.id}.s3.amazonaws.com"
+    test "creates a new file system", %{team: team} do
+      bucket_url = "https://#{team.id}.s3.amazonaws.com"
       file_system = build(:fs_s3, bucket_url: bucket_url)
       region = file_system.region
 
-      assert Hubs.create_file_system(hub, file_system) == :ok
+      assert Hubs.create_file_system(team, file_system) == :ok
       assert_receive {:file_system_created, %{bucket_url: ^bucket_url, region: ^region}}
 
       # Guarantee uniqueness
-      assert {:error, errors} = Hubs.create_file_system(hub, file_system)
+      assert {:error, errors} = Hubs.create_file_system(team, file_system)
       assert "has already been taken" in errors[:bucket_url]
     end
 
-    test "returns changeset errors when data is invalid", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
+    test "returns changeset errors when data is invalid", %{team: team} do
       file_system = build(:fs_s3, bucket_url: nil)
 
-      assert {:error, errors} = Hubs.create_file_system(hub, file_system)
+      assert {:error, errors} = Hubs.create_file_system(team, file_system)
       assert "can't be blank" in errors[:bucket_url]
     end
   end
 
   describe "update_file_system/2" do
-    test "updates a file system", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      bucket_url = "https://#{hub.id}.s3.amazonaws.com"
+    test "updates a file system", %{team: team} do
+      bucket_url = "https://#{team.id}.s3.amazonaws.com"
       file_system = build(:fs_s3, bucket_url: bucket_url)
 
-      assert Hubs.create_file_system(hub, file_system) == :ok
+      assert Hubs.create_file_system(team, file_system) == :ok
 
       assert_receive {:file_system_created,
                       %{bucket_url: ^bucket_url, external_id: external_id} = file_system}
 
-      assert file_system in Hubs.get_file_systems(hub)
+      assert file_system in Hubs.get_file_systems(team)
 
       updated_file_system = Map.replace!(file_system, :region, "eu-central-1")
 
-      assert Hubs.update_file_system(hub, updated_file_system) == :ok
+      assert Hubs.update_file_system(team, updated_file_system) == :ok
       assert_receive {:file_system_updated, %{external_id: ^external_id, region: "eu-central-1"}}
-      refute file_system in Hubs.get_file_systems(hub)
-      assert updated_file_system in Hubs.get_file_systems(hub)
+      refute file_system in Hubs.get_file_systems(team)
+      assert updated_file_system in Hubs.get_file_systems(team)
     end
 
-    test "returns changeset errors when data is invalid", %{user: user, node: node} do
-      hub = connect_to_teams(user, node)
-      teams_file_system = create_teams_file_system(hub, node)
-
-      file_system =
-        build(:fs_s3,
-          bucket_url: "https://fix_me.s3.amazonaws.com",
-          external_id: to_string(teams_file_system.id)
-        )
-
+    test "returns changeset errors when data is invalid",
+         %{team: team, node: node, org_key: org_key} do
+      file_system = TeamsRPC.create_file_system(node, team, org_key)
       update_file_system = Map.replace!(file_system, :bucket_url, "")
 
-      assert {:error, errors} = Hubs.update_file_system(hub, update_file_system)
+      assert {:error, errors} = Hubs.update_file_system(team, update_file_system)
       assert "can't be blank" in errors[:bucket_url]
     end
   end
 
-  test "delete_file_system/2 deletes a file system", %{user: user, node: node} do
-    hub = connect_to_teams(user, node)
-    bucket_url = "https://#{hub.id}.s3.amazonaws.com"
+  test "delete_file_system/2 deletes a file system", %{team: team} do
+    bucket_url = "https://#{team.id}.s3.amazonaws.com"
     file_system = build(:fs_s3, bucket_url: bucket_url)
 
-    assert Hubs.create_file_system(hub, file_system) == :ok
+    assert Hubs.create_file_system(team, file_system) == :ok
 
     assert_receive {:file_system_created,
                     %{bucket_url: ^bucket_url, external_id: external_id} = file_system}
 
-    assert file_system in Hubs.get_file_systems(hub)
+    assert file_system in Hubs.get_file_systems(team)
 
-    assert Hubs.delete_file_system(hub, file_system) == :ok
+    assert Hubs.delete_file_system(team, file_system) == :ok
     assert_receive {:file_system_deleted, %{external_id: ^external_id}}
-    refute file_system in Hubs.get_file_systems(hub)
+    refute file_system in Hubs.get_file_systems(team)
 
     # Guarantee it's been removed and will return HTTP status 404
-    assert Hubs.delete_file_system(hub, file_system) ==
+    assert Hubs.delete_file_system(team, file_system) ==
              {:transport_error,
               "Something went wrong, try again later or please file a bug if it persists"}
   end
 
-  test "generates and verifies stamp for a notebook", %{user: user, node: node} do
-    team = connect_to_teams(user, node)
-
+  test "generates and verifies stamp for a notebook", %{team: team} do
     notebook_source = """
     # Team notebook
 

--- a/test/livebook_teams/hubs_test.exs
+++ b/test/livebook_teams/hubs_test.exs
@@ -2,8 +2,8 @@ defmodule Livebook.HubsTest do
   use Livebook.TeamsIntegrationCase, async: true
   alias Livebook.Hubs
 
-  @moduletag workspace_for: :user
-  setup :workspace
+  @moduletag teams_for: :user
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection, :file_systems, :secrets]
   @moduletag subscribe_to_teams_topics: [:clients]
@@ -18,7 +18,7 @@ defmodule Livebook.HubsTest do
     assert metadata in Hubs.get_metadata()
   end
 
-  @tag workspace_persisted: false
+  @tag teams_persisted: false
   test "fetch_hub!/1 returns one persisted team", %{team: team} do
     assert_raise Livebook.Storage.NotFoundError,
                  ~s/could not find entry in "hubs" with ID "#{team.id}"/,
@@ -31,7 +31,7 @@ defmodule Livebook.HubsTest do
   end
 
   describe "save_hub/1" do
-    @tag workspace_persisted: false
+    @tag teams_persisted: false
     test "persists hub", %{team: team} do
       refute Hubs.hub_exists?(team.id)
       Hubs.save_hub(team)

--- a/test/livebook_teams/teams_test.exs
+++ b/test/livebook_teams/teams_test.exs
@@ -6,8 +6,8 @@ defmodule Livebook.TeamsTest do
   alias Livebook.Teams
   alias Livebook.Utils
 
-  @moduletag workspace_for: :user
-  setup :workspace
+  @moduletag teams_for: :user
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection, :file_systems, :secrets]
   @moduletag subscribe_to_teams_topics: [:clients, :deployment_groups, :app_deployments, :agents]
@@ -26,7 +26,7 @@ defmodule Livebook.TeamsTest do
               }} = Teams.create_org(org, %{})
     end
 
-    @tag workspace_persisted: false
+    @tag teams_persisted: false
     test "returns changeset errors when data is invalid" do
       org = build(:org)
 
@@ -71,7 +71,7 @@ defmodule Livebook.TeamsTest do
   end
 
   describe "get_org_request_completion_data/1" do
-    @tag workspace_persisted: false
+    @tag teams_persisted: false
     test "returns the org data when it has been confirmed", %{node: node, user: user} do
       teams_key = Teams.Org.teams_key()
       key_hash = :crypto.hash(:sha256, teams_key) |> Base.url_encode64(padding: false)

--- a/test/livebook_teams/web/admin_live_test.exs
+++ b/test/livebook_teams/web/admin_live_test.exs
@@ -3,8 +3,8 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @moduletag workspace_for: :agent
-  setup :workspace
+  @moduletag teams_for: :agent
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]

--- a/test/livebook_teams/web/admin_live_test.exs
+++ b/test/livebook_teams/web/admin_live_test.exs
@@ -1,81 +1,33 @@
 defmodule LivebookWeb.Integration.AdminLiveTest do
-  # Not async, because we alter global config (app server instance)
   use Livebook.TeamsIntegrationCase, async: false
 
   import Phoenix.LiveViewTest
 
-  describe "topbar" do
-    setup %{teams_auth: teams_auth} do
-      Application.put_env(:livebook, :teams_auth, teams_auth)
-      on_exit(fn -> Application.delete_env(:livebook, :teams_auth) end)
+  @moduletag workspace_for: :agent
+  setup :workspace
 
-      :ok
-    end
-
-    for page <- ["/", "/settings", "/learn", "/hub", "/apps-dashboard"] do
-      @tag page: page, teams_auth: :online
-      test "GET #{page} shows the app server instance topbar warning", %{conn: conn, page: page} do
-        {:ok, view, _} = live(conn, page)
-
-        assert render(view) =~
-                 "This Livebook instance has been configured for notebook deployment and is in read-only mode."
-      end
-
-      @tag page: page, teams_auth: :offline
-      test "GET #{page} shows the offline hub topbar warning", %{conn: conn, page: page} do
-        {:ok, view, _} = live(conn, page)
-
-        assert render(view) =~
-                 "You are running an offline Workspace for deployment. You cannot modify its settings."
-      end
-    end
-  end
+  @moduletag subscribe_to_hubs_topics: [:connection]
+  @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]
 
   describe "authorization" do
-    setup %{conn: conn, node: node} do
-      Livebook.Teams.Broadcasts.subscribe([:agents, :app_server])
-      Livebook.Apps.subscribe()
-
-      {_agent_key, org, deployment_group, team} = create_agent_team_hub(node)
-
-      # we wait until the agent_connected is received by livebook
-      hub_id = team.id
-      deployment_group_id = to_string(deployment_group.id)
-      org_id = to_string(org.id)
-
-      assert_receive {:agent_joined,
-                      %{
-                        hub_id: ^hub_id,
-                        org_id: ^org_id,
-                        deployment_group_id: ^deployment_group_id
-                      }}
-
-      start_supervised!(
-        {Livebook.ZTA.LivebookTeams, name: LivebookWeb.ZTA, identity_key: team.id}
-      )
-
-      {conn, code} = authenticate_user_on_teams(conn, node, team)
-
-      {:ok, conn: conn, code: code, deployment_group: deployment_group, org: org, team: team}
-    end
+    setup :livebook_teams_auth
 
     test "renders unauthorized admin page if user doesn't have full access",
          %{conn: conn, node: node, code: code} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["dev-"],
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["dev-"],
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -83,7 +35,7 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       assert conn
              |> get(~p"/settings")
@@ -92,20 +44,19 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
 
     test "shows admin page if user have full access",
          %{conn: conn, node: node, code: code} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :app_server,
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :app_server,
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -113,7 +64,7 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       {:ok, _view, html} = live(conn, ~p"/settings")
       assert html =~ "System settings"
@@ -122,21 +73,20 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
     test "renders unauthorized if loses the access in real-time",
          %{conn: conn, node: node, code: code} = context do
       {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :app_server,
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :app_server,
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -144,15 +94,15 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       {:ok, view, _html} = live(conn, ~p"/settings")
       assert render(view) =~ "System settings"
 
-      erpc_call(node, :update_authorization_group, [
-        authorization_group,
-        %{access_type: :apps, prefixes: ["ops-"]}
-      ])
+      TeamsRPC.update_authorization_group(node, authorization_group, %{
+        access_type: :apps,
+        prefixes: ["ops-"]
+      })
 
       id = to_string(deployment_group.id)
       assert_receive {:server_authorization_updated, %{id: ^id}}
@@ -168,22 +118,21 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
     test "shows admin page if authentication is disabled",
          %{conn: conn, node: node, code: code} = context do
       {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["ops-"],
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["ops-"],
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -191,20 +140,44 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       assert conn
              |> get(~p"/settings")
              |> html_response(401) =~ "Not authorized"
 
       {:ok, %{teams_auth: false} = deployment_group} =
-        erpc_call(node, :toggle_teams_authentication, [deployment_group])
+        TeamsRPC.toggle_teams_authentication(node, deployment_group)
 
       id = to_string(deployment_group.id)
       assert_receive {:server_authorization_updated, %{id: ^id, teams_auth: false}}
 
       {:ok, view, _html} = live(conn, ~p"/settings")
       assert render(view) =~ "System settings"
+    end
+  end
+
+  describe "topbar" do
+    setup %{teams_auth: teams_auth, conn: conn} do
+      {:ok, conn: init_test_session(conn, %{teams_auth_test_override: teams_auth})}
+    end
+
+    for page <- ["/", "/open", "/settings", "/learn", "/hub", "/apps-dashboard"] do
+      @tag page: page, teams_auth: :online
+      test "GET #{page} shows the app server instance topbar warning", %{conn: conn, page: page} do
+        {:ok, view, _} = live(conn, page)
+
+        assert render(view) =~
+                 "This Livebook instance has been configured for notebook deployment and is in read-only mode."
+      end
+
+      @tag page: page, teams_auth: :offline
+      test "GET #{page} shows the offline hub topbar warning", %{conn: conn, page: page} do
+        {:ok, view, _} = live(conn, page)
+
+        assert render(view) =~
+                 "You are running an offline Workspace for deployment. You cannot modify its settings."
+      end
     end
   end
 end

--- a/test/livebook_teams/web/app_session_live_test.exs
+++ b/test/livebook_teams/web/app_session_live_test.exs
@@ -3,8 +3,8 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @moduletag workspace_for: :agent
-  setup :workspace
+  @moduletag teams_for: :agent
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]

--- a/test/livebook_teams/web/app_session_live_test.exs
+++ b/test/livebook_teams/web/app_session_live_test.exs
@@ -3,52 +3,37 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
 
   import Phoenix.LiveViewTest
 
+  @moduletag workspace_for: :agent
+  setup :workspace
+
+  @moduletag subscribe_to_hubs_topics: [:connection]
+  @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]
+
+  setup do
+    Livebook.Apps.subscribe()
+    :ok
+  end
+
   describe "authorized apps" do
-    setup %{conn: conn, node: node} do
-      Livebook.Teams.Broadcasts.subscribe([:agents, :app_deployments, :app_server])
-      Livebook.Apps.subscribe()
-
-      {_agent_key, org, deployment_group, team} = create_agent_team_hub(node)
-
-      # we wait until the agent_connected is received by livebook
-      hub_id = team.id
-      deployment_group_id = to_string(deployment_group.id)
-      org_id = to_string(org.id)
-
-      assert_receive {:agent_joined,
-                      %{
-                        hub_id: ^hub_id,
-                        org_id: ^org_id,
-                        deployment_group_id: ^deployment_group_id
-                      }}
-
-      start_supervised!(
-        {Livebook.ZTA.LivebookTeams, name: LivebookWeb.ZTA, identity_key: team.id}
-      )
-
-      {conn, code} = authenticate_user_on_teams(conn, node, team)
-
-      {:ok, conn: conn, code: code, deployment_group: deployment_group, org: org, team: team}
-    end
+    setup :livebook_teams_auth
 
     @tag :tmp_dir
     test "shows app if user doesn't have full access",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["dev-"],
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["dev-"],
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -56,7 +41,7 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slug = "dev-app"
       pid = deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
@@ -69,20 +54,19 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
     @tag :tmp_dir
     test "shows app if user have full access",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :app_server,
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :app_server,
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -90,9 +74,9 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
-      slugs = ~w(mkt-app sales-app opt-app)
+      slugs = ~w(mkt-livebook-app eng-livebook-app ops-livebook-app)
 
       for slug <- slugs do
         pid = deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
@@ -107,22 +91,21 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
     test "renders unauthorized if loses the access in real-time",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
       {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["mkt-"],
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["mkt-"],
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -130,7 +113,7 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slug = "mkt-analytics"
       pid = deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
@@ -140,7 +123,8 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
       {:ok, view, _html} = live(conn, path)
       assert render(view) =~ "LivebookApp:#{slug}"
 
-      erpc_call(node, :update_authorization_group, [authorization_group, %{prefixes: ["ops-"]}])
+      {:ok, %{prefixes: ["ops-"]}} =
+        TeamsRPC.update_authorization_group(node, authorization_group, %{prefixes: ["ops-"]})
 
       id = to_string(deployment_group.id)
 
@@ -156,22 +140,21 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
     test "shows app if disable the authentication in real-time",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
       {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["mkt-"],
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["mkt-"],
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -179,7 +162,7 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slug = "analytics-app"
       pid = deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
@@ -190,7 +173,7 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
       assert render(view) =~ "Not authorized"
 
       {:ok, %{teams_auth: false} = deployment_group} =
-        erpc_call(node, :toggle_teams_authentication, [deployment_group])
+        TeamsRPC.toggle_teams_authentication(node, deployment_group)
 
       id = to_string(deployment_group.id)
       assert_receive {:server_authorization_updated, %{id: ^id, teams_auth: false}}
@@ -222,14 +205,15 @@ defmodule LivebookWeb.Integration.AppSessionLiveTest do
     encrypted_content = Livebook.Teams.encrypt(zip_content, secret_key)
 
     app_deployment_id =
-      erpc_call(node, :upload_app_deployment, [
+      TeamsRPC.upload_app_deployment(
+        node,
         org,
         deployment_group,
         app_deployment,
         encrypted_content,
         # broadcast?
         true
-      ]).id
+      ).id
 
     app_deployment_id = to_string(app_deployment_id)
     assert_receive {:app_deployment_started, %{id: ^app_deployment_id}}

--- a/test/livebook_teams/web/apps_live_test.exs
+++ b/test/livebook_teams/web/apps_live_test.exs
@@ -1,52 +1,45 @@
 defmodule LivebookWeb.Integration.AppsLiveTest do
   use Livebook.TeamsIntegrationCase, async: false
 
+  import Phoenix.LiveViewTest
+
+  @moduletag workspace_for: :agent
+  setup :workspace
+
+  @moduletag subscribe_to_hubs_topics: [:connection]
+  @moduletag subscribe_to_teams_topics: [
+               :clients,
+               :agents,
+               :deployment_groups,
+               :app_deployments,
+               :app_server
+             ]
+
+  setup do
+    Livebook.Apps.subscribe()
+    :ok
+  end
+
   describe "authorized apps" do
-    setup %{conn: conn, node: node} do
-      Livebook.Teams.Broadcasts.subscribe([:agents, :app_deployments, :app_server])
-      Livebook.Apps.subscribe()
-
-      {_agent_key, org, deployment_group, team} = create_agent_team_hub(node)
-
-      # we wait until the agent_connected is received by livebook
-      hub_id = team.id
-      deployment_group_id = to_string(deployment_group.id)
-      org_id = to_string(org.id)
-
-      assert_receive {:agent_joined,
-                      %{
-                        hub_id: ^hub_id,
-                        org_id: ^org_id,
-                        deployment_group_id: ^deployment_group_id
-                      }}
-
-      start_supervised!(
-        {Livebook.ZTA.LivebookTeams, name: LivebookWeb.ZTA, identity_key: team.id}
-      )
-
-      {conn, code} = authenticate_user_on_teams(conn, node, team)
-
-      {:ok, conn: conn, code: code, deployment_group: deployment_group, org: org, team: team}
-    end
+    setup :livebook_teams_auth
 
     @tag :tmp_dir
     test "shows one app if user doesn't have full access",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["dev-"],
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["dev-"],
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -54,7 +47,7 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slug = "dev-app"
 
@@ -72,20 +65,19 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
     @tag :tmp_dir
     test "shows all apps if user have full access",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :app_server,
-            oidc_provider: oidc_provider,
-            deployment_group: context.deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :app_server,
+          oidc_provider: oidc_provider,
+          deployment_group: context.deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -93,7 +85,7 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slugs = ~w(mkt-app sales-app opt-app)
 
@@ -116,23 +108,25 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
     @tag :tmp_dir
     test "updates the apps list in real-time",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+      {:ok, %{groups_auth: true} = deployment_group} =
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      id = to_string(deployment_group.id)
+      assert_receive {:deployment_group_updated, %{id: ^id, groups_auth: true}}
+
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["mkt-"],
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["mkt-"],
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -140,47 +134,43 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
-      slug = "marketing-app"
-
+      slug = "marketing-report"
       deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
 
-      assert conn
-             |> get(~p"/apps")
-             |> html_response(200) =~ "No apps running."
+      {:ok, view, _} = live(conn, ~p"/apps")
+      refute render(view) =~ slug
 
-      {:ok, %{groups_auth: false} = deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [deployment_group])
+      {:ok, %{groups_auth: false}} = TeamsRPC.toggle_groups_authorization(node, deployment_group)
+      assert_receive {:server_authorization_updated, %{id: ^id, groups_auth: false}}, 3_000
 
-      id = to_string(deployment_group.id)
-      assert_receive {:server_authorization_updated, %{id: ^id, groups_auth: false}}
-
-      assert conn
-             |> get(~p"/apps")
-             |> html_response(200) =~ slug
+      {:ok, view, _} = live(conn, ~p"/apps")
+      assert render(view) =~ slug
     end
 
     @tag :tmp_dir
     test "shows all apps if disable the authentication in real-time",
          %{conn: conn, node: node, code: code, tmp_dir: tmp_dir} = context do
-      {:ok, deployment_group} =
-        erpc_call(node, :toggle_groups_authorization, [context.deployment_group])
+      {:ok, %{groups_auth: true} = deployment_group} =
+        TeamsRPC.toggle_groups_authorization(node, context.deployment_group)
 
-      oidc_provider = erpc_call(node, :create_oidc_provider, [context.org])
+      id = to_string(deployment_group.id)
+      assert_receive {:deployment_group_updated, %{id: ^id, groups_auth: true}}
+
+      oidc_provider = TeamsRPC.create_oidc_provider(node, context.org)
 
       authorization_group =
-        erpc_call(node, :create_authorization_group, [
-          %{
-            group_name: "marketing",
-            access_type: :apps,
-            prefixes: ["mkt-"],
-            oidc_provider: oidc_provider,
-            deployment_group: deployment_group
-          }
-        ])
+        TeamsRPC.create_authorization_group(node,
+          group_name: "marketing",
+          access_type: :apps,
+          prefixes: ["mkt-"],
+          oidc_provider: oidc_provider,
+          deployment_group: deployment_group
+        )
 
-      erpc_call(node, :update_user_info_groups, [
+      TeamsRPC.update_user_info_groups(
+        node,
         code,
         [
           %{
@@ -188,25 +178,19 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
             "group_name" => authorization_group.group_name
           }
         ]
-      ])
+      )
 
       slug = "marketing-app"
-
       deploy_app(slug, context.team, context.org, context.deployment_group, tmp_dir, node)
 
-      assert conn
-             |> get(~p"/apps")
-             |> html_response(200) =~ "No apps running."
+      {:ok, view, _} = live(conn, ~p"/apps")
+      refute render(view) =~ slug
 
-      {:ok, %{teams_auth: false} = deployment_group} =
-        erpc_call(node, :toggle_teams_authentication, [deployment_group])
+      {:ok, %{teams_auth: false}} = TeamsRPC.toggle_teams_authentication(node, deployment_group)
+      assert_receive {:server_authorization_updated, %{id: ^id, teams_auth: false}}, 3_000
 
-      id = to_string(deployment_group.id)
-      assert_receive {:server_authorization_updated, %{id: ^id, teams_auth: false}}
-
-      assert conn
-             |> get(~p"/apps")
-             |> html_response(200) =~ slug
+      {:ok, view, _} = live(conn, ~p"/apps")
+      assert render(view) =~ slug
     end
   end
 
@@ -230,26 +214,28 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
     secret_key = Livebook.Teams.derive_key(team.teams_key)
     encrypted_content = Livebook.Teams.encrypt(zip_content, secret_key)
 
-    app_deployment_id =
-      erpc_call(node, :upload_app_deployment, [
+    app_deployment =
+      TeamsRPC.upload_app_deployment(
+        node,
         org,
         deployment_group,
         app_deployment,
         encrypted_content,
         # broadcast?
         true
-      ]).id
+      )
 
-    app_deployment_id = to_string(app_deployment_id)
+    app_deployment_id = to_string(app_deployment.id)
     assert_receive {:app_deployment_started, %{id: ^app_deployment_id}}
 
-    assert_receive {:app_created, %{pid: pid, slug: ^slug}}
+    assert_receive {:app_created, %{pid: pid, slug: ^slug}}, 50000
 
     assert_receive {:app_updated,
                     %{
                       slug: ^slug,
                       sessions: [%{app_status: %{execution: :executed, lifecycle: :active}}]
-                    }}
+                    }},
+                   5000
 
     on_exit(fn ->
       if Process.alive?(pid) do

--- a/test/livebook_teams/web/apps_live_test.exs
+++ b/test/livebook_teams/web/apps_live_test.exs
@@ -3,8 +3,8 @@ defmodule LivebookWeb.Integration.AppsLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @moduletag workspace_for: :agent
-  setup :workspace
+  @moduletag teams_for: :agent
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [

--- a/test/livebook_teams/web/hub/deployment_group_test.exs
+++ b/test/livebook_teams/web/hub/deployment_group_test.exs
@@ -1,26 +1,24 @@
 defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
   use Livebook.TeamsIntegrationCase, async: true
 
-  import Phoenix.LiveViewTest
   import Livebook.TestHelpers
+  import Phoenix.LiveViewTest
 
   alias Livebook.Teams.DeploymentGroup
 
-  setup %{user: user, node: node} do
-    Livebook.Hubs.Broadcasts.subscribe([:crud, :connection, :secrets, :file_systems])
-    Livebook.Teams.Broadcasts.subscribe([:clients, :app_deployments, :deployment_groups, :agents])
-    hub = create_team_hub(user, node)
-    id = hub.id
+  @moduletag workspace_for: :user
+  setup :workspace
 
-    assert_receive {:hub_connected, ^id}
-    assert_receive {:client_connected, ^id}
+  @moduletag subscribe_to_hubs_topics: [:crud, :connection, :secrets, :file_systems]
+  @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :deployment_groups]
 
-    {:ok, hub: hub}
-  end
-
-  test "creates a deployment group", %{conn: conn, hub: hub} do
+  test "creates a deployment group", %{conn: conn, team: team} do
     deployment_group =
-      build(:deployment_group, mode: :offline, hub_id: hub.id, url: "http://example.com")
+      build(:deployment_group,
+        mode: :offline,
+        hub_id: team.id,
+        url: "http://example.com"
+      )
 
     name = deployment_group.name
     url = deployment_group.url
@@ -30,12 +28,11 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
         name: deployment_group.name,
         value: deployment_group.mode,
         hub_id: deployment_group.hub_id,
-        url: url,
-        teams_auth: true
+        url: url
       }
     }
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     assert view
            |> element("#add-deployment-group")
@@ -56,12 +53,12 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
     assert_receive {:deployment_group_created,
                     %DeploymentGroup{name: ^name, url: ^url} = deployment_group}
 
-    assert_patch(view, "/hub/#{hub.id}")
+    assert_patch(view, "/hub/#{team.id}")
     assert render(view) =~ "Deployment group added successfully"
-    assert deployment_group in Livebook.Teams.get_deployment_groups(hub)
+    assert deployment_group in Livebook.Teams.get_deployment_groups(team)
 
     # Guarantee it shows the error from API
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     assert view
            |> element("#add-deployment-group")
@@ -99,11 +96,14 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
              "must start with &quot;http://&quot; or &quot;https://&quot;"
   end
 
-  test "creates a secret", %{conn: conn, hub: hub} do
-    %{id: id} = insert_deployment_group(mode: :online, hub_id: hub.id)
-    secret = build(:secret, hub_id: hub.id, deployment_group_id: id)
+  test "creates a secret", %{conn: conn, team: team, node: node, org: org} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
+    id = to_string(deployment_group.id)
+    assert_receive {:deployment_group_created, %{id: ^id}}
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    secret = build(:secret, hub_id: team.id, deployment_group_id: id)
+
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     attrs = %{
       secret: %{
@@ -120,7 +120,7 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
     |> element("#hub-deployment-group-#{id} [aria-label=\"add secret\"]", "Add secret")
     |> render_click(%{})
 
-    assert_patch(view, ~p"/hub/#{hub.id}/groups/#{id}/secrets/new")
+    assert_patch(view, ~p"/hub/#{team.id}/groups/#{id}/secrets/new")
     assert render(view) =~ "Add secret"
 
     view
@@ -139,33 +139,35 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
                     %Livebook.Teams.DeploymentGroup{id: ^id, secrets: [^secret]} =
                       deployment_group}
 
-    assert_patch(view, ~p"/hub/#{hub.id}")
+    assert_patch(view, ~p"/hub/#{team.id}")
     assert render(view) =~ "Secret #{secret.name} added successfully"
     assert render(element(view, "#hub-deployment-group-#{id}")) =~ secret.name
     assert secret in deployment_group.secrets
 
     # Guarantee it shows the error from API
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}/groups/#{id}/secrets/new")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}/groups/#{id}/secrets/new")
 
     assert view
            |> element("#deployment-group-secrets-form")
            |> render_submit(attrs) =~ "has already been taken"
   end
 
-  test "updates an existing secret", %{conn: conn, hub: hub} do
-    %{id: id} = insert_deployment_group(mode: :online, hub_id: hub.id)
-    secret = insert_secret(hub_id: hub.id, deployment_group_id: id)
+  test "updates an existing secret",
+       %{conn: conn, team: team, node: node, org: org, org_key: org_key} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
+    secret = TeamsRPC.create_deployment_group_secret(node, team, org_key, deployment_group)
+    id = to_string(deployment_group.id)
 
     assert_receive {:deployment_group_updated,
                     %Livebook.Teams.DeploymentGroup{id: ^id, secrets: [^secret]}}
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     assert view
            |> element("#hub-deployment-group-#{id} [aria-label=\"edit #{secret.name}\"]")
            |> render_click() =~ "Edit secret"
 
-    assert_patch(view, ~p"/hub/#{hub.id}/groups/#{id}/secrets/edit/#{secret.name}")
+    assert_patch(view, ~p"/hub/#{team.id}/groups/#{id}/secrets/edit/#{secret.name}")
 
     attrs = %{
       secret: %{
@@ -195,17 +197,19 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
                     %Livebook.Teams.DeploymentGroup{id: ^id, secrets: [^updated_secret]} =
                       deployment_group}
 
-    assert_patch(view, "/hub/#{hub.id}")
+    assert_patch(view, "/hub/#{team.id}")
     assert render(view) =~ "Secret #{secret.name} updated successfully"
     assert render(element(view, "#hub-deployment-group-#{id}")) =~ secret.name
     assert updated_secret in deployment_group.secrets
   end
 
-  test "deletes an existing secret", %{conn: conn, hub: hub} do
-    %{id: id} = insert_deployment_group(mode: :online, hub_id: hub.id)
-    secret = insert_secret(hub_id: hub.id, deployment_group_id: id)
+  test "deletes an existing secret",
+       %{conn: conn, team: team, node: node, org: org, org_key: org_key} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
+    secret = TeamsRPC.create_deployment_group_secret(node, team, org_key, deployment_group)
+    id = to_string(deployment_group.id)
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     view
     |> element("#hub-deployment-group-#{id} [aria-label=\"delete #{secret.name}\"]")
@@ -216,15 +220,15 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
     assert_receive {:deployment_group_updated,
                     %Livebook.Teams.DeploymentGroup{id: ^id, secrets: []}}
 
-    assert_patch(view, ~p"/hub/#{hub.id}")
+    assert_patch(view, ~p"/hub/#{team.id}")
     assert render(view) =~ "Secret #{secret.name} deleted successfully"
     refute render(element(view, "#hub-deployment-group-#{id}")) =~ secret.name
   end
 
-  test "shows the agent count", %{conn: conn, hub: hub} do
-    %{id: id} = deployment_group = insert_deployment_group(mode: :online, hub_id: hub.id)
-
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+  test "shows the agent count", %{conn: conn, team: team, node: node, org: org} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
+    id = to_string(deployment_group.id)
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     assert view
            |> element("#hub-deployment-group-#{id} [aria-label=\"app servers\"]")
@@ -233,7 +237,7 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
            |> LazyHTML.text()
            |> String.trim() == "0"
 
-    simulate_agent_join(hub, deployment_group)
+    simulate_agent_join(team, deployment_group)
 
     assert view
            |> element("#hub-deployment-group-#{id} [aria-label=\"app servers\"]")
@@ -244,12 +248,13 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
   end
 
   @tag :tmp_dir
-  test "shows the app deployed count", %{conn: conn, hub: hub, tmp_dir: tmp_dir} do
-    %{id: id} = insert_deployment_group(mode: :online, hub_id: hub.id)
-    id = to_string(id)
-    hub_id = hub.id
+  test "shows the app deployed count",
+       %{conn: conn, team: team, node: node, org: org, tmp_dir: tmp_dir} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
+    id = to_string(deployment_group.id)
+    hub_id = team.id
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     refute_received {:app_deployment_started, %{deployment_group_id: ^id, hub_id: ^hub_id}}
 
@@ -266,14 +271,14 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
       Livebook.Notebook.new()
       | app_settings: app_settings,
         name: "MyNotebook",
-        hub_id: hub.id,
+        hub_id: team.id,
         deployment_group_id: id
     }
 
     files_dir = Livebook.FileSystem.File.local(tmp_dir)
 
     {:ok, app_deployment} = Livebook.Teams.AppDeployment.new(notebook, files_dir)
-    :ok = Livebook.Teams.deploy_app(hub, app_deployment)
+    :ok = Livebook.Teams.deploy_app(team, app_deployment)
 
     assert_receive {:app_deployment_started, %{deployment_group_id: ^id}}, 2_000
 
@@ -285,14 +290,13 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
            |> String.trim() == "1"
   end
 
-  test "shows the environment variables count", %{conn: conn, node: node, hub: hub} do
-    %{id: id} = insert_deployment_group(mode: :online, hub_id: hub.id)
-    deployment_group = erpc_call(node, :get_deployment_group!, [id])
+  test "shows the environment variables count", %{conn: conn, team: team, node: node, org: org} do
+    deployment_group = TeamsRPC.create_deployment_group(node, org: org)
     id = to_string(deployment_group.id)
 
     assert_receive {:deployment_group_created, %{id: ^id, environment_variables: []}}
 
-    {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")
+    {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
 
     assert view
            |> element("#hub-deployment-group-#{id} [aria-label=\"environment variables\"]")
@@ -301,7 +305,7 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
            |> LazyHTML.text()
            |> String.trim() == "0"
 
-    erpc_call(node, :create_environment_variable, [[deployment_group: deployment_group]])
+    TeamsRPC.create_environment_variable(node, deployment_group: deployment_group)
     assert_receive {:deployment_group_updated, %{id: ^id, environment_variables: [_]}}
 
     assert view

--- a/test/livebook_teams/web/hub/deployment_group_test.exs
+++ b/test/livebook_teams/web/hub/deployment_group_test.exs
@@ -6,8 +6,8 @@ defmodule LivebookWeb.Integration.Hub.DeploymentGroupTest do
 
   alias Livebook.Teams.DeploymentGroup
 
-  @moduletag workspace_for: :user
-  setup :workspace
+  @moduletag teams_for: :user
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:crud, :connection, :secrets, :file_systems]
   @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :deployment_groups]

--- a/test/livebook_teams/web/hub/edit_live_test.exs
+++ b/test/livebook_teams/web/hub/edit_live_test.exs
@@ -6,13 +6,13 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
   import Livebook.TestHelpers
   import Phoenix.LiveViewTest
 
-  setup :workspace
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:crud, :connection, :secrets, :file_systems]
   @moduletag subscribe_to_teams_topics: [:clients]
 
   describe "user" do
-    @describetag workspace_for: :user
+    @describetag teams_for: :user
 
     test "updates the hub", %{conn: conn, team: team} do
       {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
@@ -285,7 +285,7 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
   end
 
   describe "agent" do
-    @describetag workspace_for: :agent
+    @describetag teams_for: :agent
     @describetag subscribe_to_teams_topics: [:clients, :agents]
 
     test "shows an error when creating a secret", %{conn: conn, team: team} do
@@ -359,8 +359,8 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
     # Not async, because we alter global config (default hub)
     use Livebook.TeamsIntegrationCase, async: false
 
-    @moduletag workspace_for: :user
-    setup :workspace
+    @moduletag teams_for: :user
+    setup :teams
 
     @moduletag subscribe_to_hubs_topics: [:crud, :connection, :secrets, :file_systems]
     @moduletag subscribe_to_teams_topics: [:clients]

--- a/test/livebook_teams/web/hub/new_live_test.exs
+++ b/test/livebook_teams/web/hub/new_live_test.exs
@@ -5,6 +5,12 @@ defmodule LivebookWeb.Hub.NewLiveTest do
 
   import Phoenix.LiveViewTest
 
+  @moduletag workspace_for: :user
+  setup :workspace
+
+  @moduletag subscribe_to_hubs_topics: [:connection]
+  @moduletag subscribe_to_teams_topics: [:clients]
+
   test "render hub selection cards", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/hub")
 
@@ -35,14 +41,14 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       render_submit(form, attrs)
 
       # gets the org request by name
-      org_request = :erpc.call(node, TeamsRPC, :get_org_request_by!, [[name: name]])
+      org_request = TeamsRPC.get_org_request_by!(node, name: name)
 
       # check if the form has the url to confirm
       link_element = element(view, "#new-org-form a")
       assert render(link_element) =~ "/org-request/#{org_request.id}/confirm"
 
       # force org request confirmation
-      :erpc.call(node, TeamsRPC, :confirm_org_request, [org_request, user])
+      TeamsRPC.confirm_org_request(node, org_request, user)
 
       # wait for the c:handle_info/2 cycle
       # check if the page redirected to edit hub page
@@ -76,10 +82,10 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       {:ok, view, _html} = live(conn, ~p"/hub")
 
       # previously create the org and associate user with org
-      org = :erpc.call(node, TeamsRPC, :create_org, [[name: name]])
-      :erpc.call(node, TeamsRPC, :create_org_key, [[org: org, key_hash: key_hash]])
-      :erpc.call(node, TeamsRPC, :create_org_key_pair, [[org: org]])
-      :erpc.call(node, TeamsRPC, :create_user_org, [[org: org, user: user]])
+      org = TeamsRPC.create_org(node, name: name)
+      TeamsRPC.create_org_key(node, org: org, key_hash: key_hash)
+      TeamsRPC.create_org_key_pair(node, org: org)
+      TeamsRPC.create_user_org(node, org: org, user: user)
 
       # select the new org option
       view
@@ -97,17 +103,14 @@ defmodule LivebookWeb.Hub.NewLiveTest do
       render_submit(form, attrs)
 
       # gets the org request by name and key hash
-      org_request =
-        :erpc.call(node, TeamsRPC, :get_org_request_by!, [
-          [name: name, key_hash: key_hash]
-        ])
+      org_request = TeamsRPC.get_org_request_by!(node, name: name, key_hash: key_hash)
 
       # check if the form has the url to confirm
       link_element = element(view, "#join-org-form a")
       assert render(link_element) =~ "/org-request/#{org_request.id}/confirm"
 
       # force org request confirmation
-      :erpc.call(node, TeamsRPC, :confirm_org_request, [org_request, user])
+      TeamsRPC.confirm_org_request(node, org_request, user)
 
       # wait for the c:handle_info/2 cycle
       # check if the page redirected to edit hub page

--- a/test/livebook_teams/web/hub/new_live_test.exs
+++ b/test/livebook_teams/web/hub/new_live_test.exs
@@ -5,8 +5,8 @@ defmodule LivebookWeb.Hub.NewLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @moduletag workspace_for: :user
-  setup :workspace
+  @moduletag teams_for: :user
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [:clients]

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -4,6 +4,12 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
   import Phoenix.LiveViewTest
   import Livebook.SessionHelpers
 
+  @moduletag workspace_for: :user
+  setup :workspace
+
+  @moduletag subscribe_to_hubs_topics: [:connection]
+  @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]
+
   alias Livebook.FileSystem
   alias Livebook.Sessions
   alias Livebook.Session
@@ -58,7 +64,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       assert has_element?(view, ~s/#select-hub-#{id}/)
 
       # force user to be deleted from org
-      erpc_call(node, :delete_user_org, [user.id, hub.org_id])
+      TeamsRPC.delete_user_org(node, user.id, hub.org_id)
       reason = "#{hub.hub_name}: you were removed from the org"
 
       # checks if the hub received the `user_deleted` event and deleted the hub

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -4,8 +4,8 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
   import Phoenix.LiveViewTest
   import Livebook.SessionHelpers
 
-  @moduletag workspace_for: :user
-  setup :workspace
+  @moduletag teams_for: :user
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [:clients, :agents, :app_deployments, :app_server]

--- a/test/livebook_teams/zta/livebook_teams_test.exs
+++ b/test/livebook_teams/zta/livebook_teams_test.exs
@@ -3,8 +3,8 @@ defmodule Livebook.ZTA.LivebookTeamsTest do
 
   alias Livebook.ZTA.LivebookTeams
 
-  @moduletag workspace_for: :agent
-  setup :workspace
+  @moduletag teams_for: :agent
+  setup :teams
 
   @moduletag subscribe_to_hubs_topics: [:connection]
   @moduletag subscribe_to_teams_topics: [:clients, :agents]

--- a/test/support/integration/teams_rpc.ex
+++ b/test/support/integration/teams_rpc.ex
@@ -1,0 +1,206 @@
+defmodule Livebook.TeamsRPC do
+  alias Livebook.Factory
+
+  def subscribe(node, parent, deployment_group, org) do
+    :erpc.call(node, TeamsRPC, :subscribe, [parent, deployment_group, org])
+  end
+
+  # Read resource
+
+  def get_org_request!(node, id) do
+    :erpc.call(node, TeamsRPC, :get_org_request!, [id])
+  end
+
+  def get_org_request_by!(node, opts) do
+    :erpc.call(node, TeamsRPC, :get_org_request_by!, [opts])
+  end
+
+  def get_org_key!(node, id) do
+    :erpc.call(node, TeamsRPC, :get_org_key!, [id])
+  end
+
+  def get_deployment_group!(node, id) do
+    :erpc.call(node, TeamsRPC, :get_deployment_group!, [id])
+  end
+
+  def get_auth_request_by_code!(node, code) do
+    :erpc.call(node, TeamsRPC, :get_auth_request_by_code!, [code])
+  end
+
+  def get_apps_metadatas(node, id) do
+    :erpc.call(node, TeamsRPC, :get_apps_metadatas, [id])
+  end
+
+  # Create resource
+
+  def create_user(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_user, [attrs])
+  end
+
+  def create_secret(node, team, org_key, attrs \\ []) do
+    attrs = Keyword.merge(attrs, hub_id: team.id)
+    secret = Factory.build(:secret, attrs)
+
+    derived_key = Livebook.Teams.derive_key(team.teams_key)
+    value = Livebook.Teams.encrypt(secret.value, derived_key)
+
+    attrs =
+      %{
+        name: secret.name,
+        value: value,
+        org_key: org_key
+      }
+
+    :erpc.call(node, TeamsRPC, :create_secret, [attrs])
+    secret
+  end
+
+  def create_org(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_org, [attrs])
+  end
+
+  def create_org_key(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_org_key, [attrs])
+  end
+
+  def create_org_key_pair(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_org_key_pair, [attrs])
+  end
+
+  def create_org_request(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_org_request, [attrs])
+  end
+
+  def create_user_org(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_user_org, [attrs])
+  end
+
+  def create_file_system(node, team, org_key, file_system \\ nil) do
+    file_system = if file_system, do: file_system, else: Factory.build(:fs_s3)
+    derived_key = Livebook.Teams.derive_key(team.teams_key)
+    name = Livebook.FileSystem.external_metadata(file_system).name
+    type = Livebook.FileSystems.type(file_system)
+    attrs = Livebook.FileSystem.dump(file_system)
+    json = JSON.encode!(attrs)
+    value = Livebook.Teams.encrypt(json, derived_key)
+
+    attrs = %{name: name, type: String.to_atom(type), value: value, org_key: org_key}
+    external_id = :erpc.call(node, TeamsRPC, :create_file_system, [attrs]).id
+    Map.replace!(file_system, :external_id, external_id)
+  end
+
+  def create_deployment_group(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_deployment_group, [attrs])
+  end
+
+  def create_deployment_group_secret(node, team, org_key, deployment_group, attrs \\ []) do
+    attrs =
+      Keyword.merge(attrs,
+        deployment_group_id: to_string(deployment_group.id),
+        hub_id: team.id
+      )
+
+    secret = Factory.build(:secret, attrs)
+
+    derived_key = Livebook.Teams.derive_key(team.teams_key)
+    value = Livebook.Teams.encrypt(secret.value, derived_key)
+
+    attrs =
+      %{
+        name: secret.name,
+        value: value,
+        org_key: org_key,
+        deployment_group: deployment_group
+      }
+
+    :erpc.call(node, TeamsRPC, :create_deployment_group_secret, [attrs])
+    secret
+  end
+
+  def create_agent_key(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_agent_key, [attrs])
+  end
+
+  def create_environment_variable(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_environment_variable, [attrs])
+  end
+
+  def create_billing_subscription(node, org) do
+    :erpc.call(node, TeamsRPC, :create_billing_subscription, [org])
+  end
+
+  def create_oidc_provider(node, org) do
+    :erpc.call(node, TeamsRPC, :create_oidc_provider, [org])
+  end
+
+  def create_authorization_group(node, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :create_authorization_group, [attrs])
+  end
+
+  # Update resource
+
+  def update_authorization_group(node, authorization_group, attrs) do
+    :erpc.call(node, TeamsRPC, :update_authorization_group, [authorization_group, attrs])
+  end
+
+  def update_user_info_groups(node, code, groups) do
+    :erpc.call(node, TeamsRPC, :update_user_info_groups, [code, groups])
+  end
+
+  def update_deployment_group(node, deployment_group, attrs) do
+    :erpc.call(node, TeamsRPC, :update_deployment_group, [deployment_group, attrs])
+  end
+
+  # Delete resource
+
+  def delete_user_org(node, user_id, org_id) do
+    :erpc.call(node, TeamsRPC, :delete_user_org, [user_id, org_id])
+  end
+
+  def delete_deployment_group(node, deployment_group) do
+    :erpc.call(node, TeamsRPC, :delete_deployment_group, [deployment_group])
+  end
+
+  # Actions
+
+  def upload_app_deployment(
+        node,
+        org,
+        deployment_group,
+        livebook_app_deployment,
+        encrypted_content,
+        broadast? \\ false
+      ) do
+    :erpc.call(node, TeamsRPC, :upload_app_deployment, [
+      org,
+      deployment_group,
+      livebook_app_deployment,
+      encrypted_content,
+      broadast?
+    ])
+  end
+
+  def confirm_org_request(node, org_request, user) do
+    :erpc.call(node, TeamsRPC, :confirm_org_request, [org_request, user])
+  end
+
+  def associate_user_with_org(node, user, org) do
+    :erpc.call(node, TeamsRPC, :associate_user_with_org, [user, org])
+  end
+
+  def toggle_app_deployment(node, id, org_id) do
+    :erpc.call(node, TeamsRPC, :toggle_app_deployment, [id, org_id])
+  end
+
+  def allow_auth_request(node, token) do
+    :erpc.call(node, TeamsRPC, :allow_auth_request, [token])
+  end
+
+  def toggle_teams_authentication(node, deployment_group) do
+    :erpc.call(node, TeamsRPC, :toggle_teams_authentication, [deployment_group])
+  end
+
+  def toggle_groups_authorization(node, deployment_group) do
+    :erpc.call(node, TeamsRPC, :toggle_groups_authorization, [deployment_group])
+  end
+end

--- a/test/support/integration/teams_server.ex
+++ b/test/support/integration/teams_server.ex
@@ -1,9 +1,7 @@
 defmodule Livebook.TeamsServer do
   use GenServer
 
-  alias Livebook.TeamsRPC
-
-  defstruct [:node, :token, :user, :org, :teams_key, :port, :app_port, :url, :env]
+  defstruct [:node, :port, :app_port, :url, :env]
 
   @name __MODULE__
   @timeout 10_000

--- a/test/support/integration/teams_server.ex
+++ b/test/support/integration/teams_server.ex
@@ -217,7 +217,7 @@ defmodule Livebook.TeamsServer do
   defp wait_on_start(state, port) do
     url = state.url || fetch_url(state)
 
-    case :httpc.request(:get, {~c"#{url}/public/health", []}, [], []) do
+    case :httpc.request(:get, {~c"#{url}/healthz", []}, [], []) do
       {:ok, _} ->
         port
 

--- a/test/support/integration/teams_tests.ex
+++ b/test/support/integration/teams_tests.ex
@@ -1,0 +1,177 @@
+defmodule Livebook.TeamsIntegrationHelper do
+  alias Livebook.{Factory, Hubs, Teams, TeamsRPC}
+
+  import ExUnit.Assertions
+  import Phoenix.ConnTest
+
+  @endpoint LivebookWeb.Endpoint
+
+  def workspace(context) do
+    case {context[:workspace_for], context[:workspace_persisted]} do
+      {:user, false} -> Map.merge(context, new_user_hub(context.node))
+      {:user, _} -> Map.merge(context, create_user_hub(context.node))
+      {:agent, false} -> Map.merge(context, new_agent_hub(context.node))
+      {:agent, _} -> Map.merge(context, create_agent_hub(context.node))
+      _otherwise -> context
+    end
+  end
+
+  def livebook_teams_auth(%{conn: conn, node: node, team: team, workspace_for: :agent} = context) do
+    ExUnit.Callbacks.start_supervised!(
+      {Livebook.ZTA.LivebookTeams, name: LivebookWeb.ZTA, identity_key: team.id}
+    )
+
+    {conn, code} = authenticate_user_on_teams(conn, node, team)
+    Map.merge(context, %{conn: conn, code: code})
+  end
+
+  @doc false
+  def create_user_hub(node) do
+    context = new_user_hub(node)
+    id = context.team.id
+    Hubs.save_hub(context.team)
+    pid = Hubs.TeamClient.get_pid(id)
+
+    assert Process.alive?(pid)
+    assert Hubs.hub_exists?(id)
+    assert_receive {:hub_connected, ^id}, 3_000
+    assert_receive {:client_connected, ^id}, 3_000
+
+    ExUnit.Callbacks.on_exit(fn -> Hubs.delete_hub(id) end)
+    context
+  end
+
+  @doc false
+  def new_user_hub(node) do
+    {teams_key, key_hash} = generate_key_hash()
+
+    org = TeamsRPC.create_org(node)
+    user = TeamsRPC.create_user(node)
+    org_key = TeamsRPC.create_org_key(node, org: org, key_hash: key_hash)
+    org_key_pair = TeamsRPC.create_org_key_pair(node, org: org)
+    token = TeamsRPC.associate_user_with_org(node, user, org)
+    TeamsRPC.create_billing_subscription(node, org)
+
+    team =
+      Factory.build(:team,
+        id: "team-#{org.name}",
+        hub_name: org.name,
+        user_id: user.id,
+        org_id: org.id,
+        org_key_id: org_key.id,
+        org_public_key: org_key_pair.public_key,
+        session_token: token,
+        teams_key: teams_key,
+        billing_status: %{disabled: false, type: nil}
+      )
+
+    %{
+      org: org,
+      user: user,
+      org_key: org_key,
+      org_key_pair: org_key_pair,
+      team: team
+    }
+  end
+
+  @doc false
+  def create_agent_hub(node, opts \\ []) do
+    context = new_agent_hub(node, opts)
+    id = context.team.id
+    Hubs.save_hub(context.team)
+
+    deployment_group_id = to_string(context.deployment_group.id)
+    org_id = to_string(context.org.id)
+    pid = Hubs.TeamClient.get_pid(id)
+
+    assert Process.alive?(pid)
+    assert Hubs.hub_exists?(id)
+    assert_receive {:hub_connected, ^id}, 3_000
+    assert_receive {:client_connected, ^id}, 3_000
+
+    assert_receive {:agent_joined,
+                    %{hub_id: ^id, deployment_group_id: ^deployment_group_id, org_id: ^org_id} =
+                      agent},
+                   3_000
+
+    ExUnit.Callbacks.on_exit(fn -> Hubs.delete_hub(id) end)
+    Map.put_new(%{context | team: Hubs.fetch_hub!(id)}, :agent, agent)
+  end
+
+  @doc false
+  def new_agent_hub(node, opts \\ []) do
+    {teams_key, key_hash} = generate_key_hash()
+
+    org = TeamsRPC.create_org(node)
+    org_key = TeamsRPC.create_org_key(node, org: org, key_hash: key_hash)
+    org_key_pair = TeamsRPC.create_org_key_pair(node, org: org)
+
+    attrs =
+      opts
+      |> Keyword.get(:deployment_group, [])
+      |> Keyword.merge(
+        name: "sleepy-cat-#{Ecto.UUID.generate()}",
+        mode: :online,
+        org: org
+      )
+
+    deployment_group = TeamsRPC.create_deployment_group(node, attrs)
+    agent_key = TeamsRPC.create_agent_key(node, deployment_group: deployment_group)
+
+    TeamsRPC.create_billing_subscription(node, org)
+
+    team =
+      Factory.build(:team,
+        id: "team-#{org.name}",
+        hub_name: org.name,
+        user_id: nil,
+        org_id: org.id,
+        org_key_id: org_key.id,
+        org_public_key: org_key_pair.public_key,
+        session_token: agent_key.key,
+        teams_key: teams_key
+      )
+
+    %{
+      agent_key: agent_key,
+      deployment_group: deployment_group,
+      org: org,
+      org_key: org_key,
+      org_key_pair: org_key_pair,
+      team: team
+    }
+  end
+
+  @doc false
+  def authenticate_user_on_teams(conn, node, team) do
+    response =
+      conn
+      |> LivebookWeb.ConnCase.with_authorization(team.id)
+      |> get("/")
+      |> html_response(200)
+
+    [_, location] = Regex.run(~r/URL\("(.*?)"\)/, response)
+    uri = URI.parse(location)
+    %{"token" => token} = URI.decode_query(uri.query)
+
+    %{code: code} = Livebook.TeamsRPC.allow_auth_request(node, token)
+
+    session =
+      conn
+      |> LivebookWeb.ConnCase.with_authorization(team.id)
+      |> get("/", %{teams_identity: "", code: code})
+      |> Plug.Conn.get_session()
+
+    conn = Plug.Test.init_test_session(conn, session)
+    authenticated_conn = get(conn, "/")
+    assigns = Map.take(authenticated_conn.assigns, [:current_user])
+
+    {%Plug.Conn{conn | assigns: Map.merge(conn.assigns, assigns)}, code}
+  end
+
+  # Private
+
+  defp generate_key_hash(teams_key \\ Teams.Org.teams_key()) do
+    {teams_key, Teams.Org.key_hash(%Teams.Org{teams_key: teams_key})}
+  end
+end

--- a/test/support/integration/teams_tests.ex
+++ b/test/support/integration/teams_tests.ex
@@ -6,8 +6,8 @@ defmodule Livebook.TeamsIntegrationHelper do
 
   @endpoint LivebookWeb.Endpoint
 
-  def workspace(context) do
-    case {context[:workspace_for], context[:workspace_persisted]} do
+  def teams(context) do
+    case {context[:teams_for], context[:teams_persisted]} do
       {:user, false} -> Map.merge(context, new_user_hub(context.node))
       {:user, _} -> Map.merge(context, create_user_hub(context.node))
       {:agent, false} -> Map.merge(context, new_agent_hub(context.node))
@@ -16,7 +16,7 @@ defmodule Livebook.TeamsIntegrationHelper do
     end
   end
 
-  def livebook_teams_auth(%{conn: conn, node: node, team: team, workspace_for: :agent} = context) do
+  def livebook_teams_auth(%{conn: conn, node: node, team: team, teams_for: :agent} = context) do
     ExUnit.Callbacks.start_supervised!(
       {Livebook.ZTA.LivebookTeams, name: LivebookWeb.ZTA, identity_key: team.id}
     )


### PR DESCRIPTION
This PR will reduce the amount of errors that `mix test` was generating when you run integration tests with Teams. It also removes redundant tests.

Some test suites are `async: false` until the bug with `async: true` is fixed