### PR TITLE
Use /bin/sh friendly condition in env.sh

### DIFF
--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -1,4 +1,4 @@
-if [[ "$RELEASE_COMMAND" == "rpc" || "$RELEASE_COMMAND" == "remote" ]]; then
+if [ "$RELEASE_COMMAND" = "rpc" ] || [ "$RELEASE_COMMAND" = "remote" ]; then
   export RELEASE_DISTRIBUTION="name"
   if [ ! -z "${LIVEBOOK_NODE}" ]; then export RELEASE_NODE=${LIVEBOOK_NODE}; fi
   if [ ! -z "${LIVEBOOK_COOKIE}" ]; then export RELEASE_COOKIE=${LIVEBOOK_COOKIE}; fi


### PR DESCRIPTION
The current version of Docker container uses /bin/sh as the shell and logs the following error during start:

```
> docker run -p 8080:8080 -p 8081:8081 --pull always -u $(id -u):$(id -g) -v $(pwd):/data ghcr.io/livebook-dev/livebook

latest: Pulling from livebook-dev/livebook
Digest: sha256:83dfb28b7a9a6eae14aa50a67dfc2b8e39d506e84bbce59db057ed790b544e35
Status: Image is up to date for ghcr.io/livebook-dev/livebook:latest
./livebook: 1: /app/releases/0.16.1/env.sh: [[: not found
./livebook: 1: /app/releases/0.16.1/env.sh: start: not found
[Livebook] Application running at http://localhost:8080/?token=*****************
```