### PR TITLE
Fix test failing because of concurrent compilation

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -32,15 +32,8 @@ config :livebook,
   check_completion_data_interval: 300,
   iframe_port: 4003
 
-data_path = Path.expand("tmp/livebook_data/test")
-
-# Clear data path for tests
-if File.exists?(data_path) do
-  File.rm_rf!(data_path)
-end
-
 config :livebook,
-  data_path: data_path,
+  data_path: Path.expand("tmp/livebook_data/test"),
   agent_name: "chonky-cat",
   k8s_kubeconfig_pipeline:
     {Kubereq.Kubeconfig.Stub,

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -4,6 +4,8 @@ defmodule Livebook.Application do
   require Logger
 
   def start(_type, _args) do
+    setup_tests()
+
     Logger.add_handlers(:livebook)
     Livebook.ZTA.init()
     create_teams_hub = parse_teams_hub()
@@ -431,5 +433,17 @@ defmodule Livebook.Application do
 
   defp serverless?() do
     Application.get_env(:livebook, :serverless, false)
+  end
+
+  if Mix.env() == :test do
+    defp setup_tests() do
+      data_path = Livebook.Config.data_path()
+      # Clear data path for tests
+      if File.exists?(data_path) do
+        File.rm_rf!(data_path)
+      end
+    end
+  else
+    defp setup_tets(), do: :ok
   end
 end


### PR DESCRIPTION
Currently we remove Livebook storage file in `config/test.exs`, so that it is fresh for every tests run and happens before the app boots.

The issue with this approach is that while the tests are running, a concurrent compilation removes the files and makes all the tests fail. Most commonly it happens when you save a file during tests run, which causes the language server to recompile.

Doing this in `test_helpers.exs` is too late because the app is started, and the startup uses the storage. I think a reasonable middle ground is doing it conditionally on `Application.start`.