### PR TITLE
Inform users that env var values in K8s instructions are base64-encoded

### DIFF
--- a/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
@@ -346,7 +346,8 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupAgentComponent do
       namespace: livebook-namespace
     type: Opaque
     data:
-      # LIVEBOOK_PASSWORD: <base64_encoded_password><%= for {k, v} <- secrets do %>
+      # LIVEBOOK_PASSWORD: <base64_encoded_password>
+      # Notice the values below are Base64 encoded<%= for {k, v} <- secrets do %>
       <%= k %>: <%= Base.encode64(v) %><% end %>
     """,
     [:image, :envs, :secrets, :replicas]

--- a/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
@@ -346,8 +346,8 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupAgentComponent do
       namespace: livebook-namespace
     type: Opaque
     data:
-      # LIVEBOOK_PASSWORD: <base64_encoded_password>
-      # Notice the values below are Base64 encoded<%= for {k, v} <- secrets do %>
+      # Notice the values below are Base64 encoded
+      # LIVEBOOK_PASSWORD: <base64_encoded_password><%= for {k, v} <- secrets do %>
       <%= k %>: <%= Base.encode64(v) %><% end %>
     """,
     [:image, :envs, :secrets, :replicas]


### PR DESCRIPTION
A user misunderstood the instructions and ended up using base64-encoded values directly in their environment variables.

This commit aims to reduce the risk of similar mistakes when setting up an app server.

## Before

<img width="877" height="331" alt="CleanShot 2025-08-04 at 13 43 24" src="https://github.com/user-attachments/assets/a040b1aa-51dc-4cac-a5b8-20428462c4c7" />


## After

<img width="863" height="337" alt="CleanShot 2025-08-04 at 14 13 29" src="https://github.com/user-attachments/assets/59dab71d-6b2a-444d-ae90-aea0c9e3edc9" />
