### PR TITLE
Fix deploy via CLI when notebooks path is relative

### DIFF
--- a/lib/livebook_cli/deploy.ex
+++ b/lib/livebook_cli/deploy.ex
@@ -135,7 +135,9 @@ defmodule LivebookCLI.Deploy do
     deploy_results =
       for path <- config.paths do
         log_info(" * Preparing to deploy notebook #{Path.basename(path)}")
-        files_dir = Livebook.FileSystem.File.local(path)
+
+        absolute_path = Path.expand(path)
+        files_dir = Livebook.FileSystem.File.local(absolute_path)
 
         with {:ok, content} <- File.read(path),
              {:ok, app_deployment} <- prepare_app_deployment(path, content, files_dir) do


### PR DESCRIPTION
Before, when running a command like this:

```shell
livebook deploy --deploy-key="lb_dk_***" --teams-key="lb_tk_***" --deployment-group-id="3" notebooks/*.livemd
```

I was getting an output with an error:

```
Validating config from options...
Authenticating CLI...
Found 1 notebook
Deploying notebooks:
 * Preparing to deploy notebook hello.livemd
** (ArgumentError) expected an expanded absolute path, got: "notebooks/hello.livemd"
    (livebook 0.17.0-dev) lib/livebook/file_system/file.ex:37: Livebook.FileSystem.File.new/2
    (livebook 0.17.0-dev) lib/livebook_cli/deploy.ex:138: anonymous fn/3 in LivebookCLI.Deploy.deploy_to_teams/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (livebook 0.17.0-dev) lib/livebook_cli/deploy.ex:136: LivebookCLI.Deploy.deploy_to_teams/2
    (livebook 0.17.0-dev) lib/livebook_cli/task.ex:20: LivebookCLI.Task.call/2
    (elixir 1.18.4) lib/kernel/cli.ex:137: anonymous fn/3 in Kernel.CLI.exec_fun/2
```