### PR TITLE
Improve error message for unauthorized deploy

### DIFF
--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -8,7 +8,7 @@ defmodule Livebook.Teams.Requests do
   @deploy_key_prefix Teams.Constants.deploy_key_prefix()
   @error_message "Something went wrong, try again later or please file a bug if it persists"
   @unauthorized_error_message "You are not authorized to perform this action, make sure you have the access and you are not in a Livebook App Server/Offline instance"
-  @unauthorized_app_deployment_error_message "You are not authorized to perform this action, make sure you have the access to deploy apps to this deployment group"
+  @unauthorized_app_deployment_error_message "Deployment not authorized, check deploy permissions for this deployment group"
 
   @typep api_result :: {:ok, map()} | error_result()
   @typep error_result :: {:error, map() | String.t()} | {:transport_error, String.t()}

--- a/test/livebook_teams/cli/deploy_test.exs
+++ b/test/livebook_teams/cli/deploy_test.exs
@@ -152,7 +152,7 @@ defmodule LivebookCLI.Integration.DeployTest do
       assert output =~ "* Preparing to deploy notebook #{slug}.livemd"
 
       assert output =~
-               "* Test CLI Deploy App failed to deploy. Transport error: You are not authorized to perform this action, make sure you have the access to deploy apps to this deployment group"
+               "* Test CLI Deploy App failed to deploy. Transport error: Deployment not authorized, check deploy permissions for this deployment group"
 
       refute_receive {:app_deployment_started,
                       %{

--- a/test/livebook_teams/web/session_live_test.exs
+++ b/test/livebook_teams/web/session_live_test.exs
@@ -688,7 +688,7 @@ defmodule LivebookWeb.Integration.SessionLiveTest do
       |> render_click()
 
       assert render(view) =~
-               "You are not authorized to perform this action, make sure you have the access to deploy apps to this deployment group"
+               "Deployment not authorized, check deploy permissions for this deployment group"
     end
   end
 end


### PR DESCRIPTION
Before, the error message was 

> You are not authorized to perform this action, make sure you have the access to deploy apps to this deployment group

But in the context of deploying via CLI, the meaning of "you" is weird, because the "actor" unauthorized to deploy is not the person, but the deploy key (org token).

Therefore, the new message does not use language that assumes the actor deploying it is a person. It can be either a person or an automation:

