### PR TITLE
Read fixed bytes size from /dev/urandom

### DIFF
--- a/rel/app/env.sh.eex
+++ b/rel/app/env.sh.eex
@@ -15,6 +15,6 @@ export PATH="${vendor_dir}/otp/erts-<%= @release.erts_version%>/bin:${vendor_dir
 if [ ! -z "${LIVEBOOK_NODE}" ]; then export RELEASE_NODE=${LIVEBOOK_NODE}; fi
 if [ ! -z "${LIVEBOOK_COOKIE}" ]; then export RELEASE_COOKIE=${LIVEBOOK_COOKIE}; fi
 
-export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 500 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
+export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 512 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
 
 cd $HOME

--- a/rel/app/env.sh.eex
+++ b/rel/app/env.sh.eex
@@ -15,6 +15,6 @@ export PATH="${vendor_dir}/otp/erts-<%= @release.erts_version%>/bin:${vendor_dir
 if [ ! -z "${LIVEBOOK_NODE}" ]; then export RELEASE_NODE=${LIVEBOOK_NODE}; fi
 if [ ! -z "${LIVEBOOK_COOKIE}" ]; then export RELEASE_COOKIE=${LIVEBOOK_COOKIE}; fi
 
-export RELEASE_COOKIE="${RELEASE_COOKIE:-$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
+export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 500 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
 
 cd $HOME

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -43,7 +43,7 @@ else
   # specifically want the temporary node cookie to be random, rather than
   # a fixed value. Note that this value is overriden on boot, so other
   # than being the initial node cookie, we don't really use it.
-  export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 500 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
+  export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 512 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
 
   cd $HOME
 fi

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -43,7 +43,7 @@ else
   # specifically want the temporary node cookie to be random, rather than
   # a fixed value. Note that this value is overriden on boot, so other
   # than being the initial node cookie, we don't really use it.
-  export RELEASE_COOKIE="${RELEASE_COOKIE:-$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
+  export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 500 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
 
   cd $HOME
 fi


### PR DESCRIPTION
Hi,

I have a situation where, when starting livebook as systemd service in a not too fast machine, the sequence of commands in order to read from /dev/urandom and get some random cookie goes forever.

In order to solve, it is not necessary to read many bytes in order to make a release cookie. Only 500 is enough and avoids extra processing during livebook start.

500 was an arbitrary value, just to have enough bytes.

Thanks