### PR TITLE
Improve error message when deploy via CLI and inactive teams subscription

### DIFF
--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -346,6 +346,9 @@ defmodule Livebook.Teams.Requests do
       {:ok, %{status: status} = response} when status in 200..299 ->
         {:ok, response.body}
 
+      {:ok, %{status: status} = response} when status == 403 ->
+        return_error(response)
+
       {:ok, %{status: status} = response} when status in [410, 422] ->
         return_error(response)
 

--- a/lib/livebook_cli/deploy.ex
+++ b/lib/livebook_cli/deploy.ex
@@ -121,9 +121,15 @@ defmodule LivebookCLI.Deploy do
     log_debug("Authenticating CLI...")
 
     case Teams.fetch_cli_session(config) do
-      {:ok, team} -> team
-      {:error, error} -> raise LivebookCLI.Error, error
-      {:transport_error, error} -> raise LivebookCLI.Error, error
+      {:ok, team} ->
+        team
+
+      {:error, error} ->
+        %{"errors" => %{"detail" => error_message}} = error
+        raise LivebookCLI.Error, error_message
+
+      {:transport_error, error} ->
+        raise LivebookCLI.Error, error
     end
   end
 

--- a/test/support/integration/teams_rpc.ex
+++ b/test/support/integration/teams_rpc.ex
@@ -59,6 +59,14 @@ defmodule Livebook.TeamsRPC do
     :erpc.call(node, TeamsRPC, :create_org, [attrs])
   end
 
+  def update_org(node, org, attrs \\ []) do
+    :erpc.call(node, TeamsRPC, :update_org, [org, attrs])
+  end
+
+  def delete_subscription(node, org) do
+    :erpc.call(node, TeamsRPC, :delete_subscription, [org])
+  end
+
   def create_org_key(node, attrs \\ []) do
     :erpc.call(node, TeamsRPC, :create_org_key, [attrs])
   end


### PR DESCRIPTION
This PR aims to improve the error message for the following scenario.

- Given a Teams organization does not have an active subscription
  - it could be because the trial has ended and they didn't subscribe
  - or because they had a subscription but are no longer paying.
- When they try to deploy via CLI in this situation
- We want to display a specific error message