### PR TITLE
Hide terminate button if no more sessions

### DIFF
--- a/lib/livebook_web/live/session_live/app_info_component.ex
+++ b/lib/livebook_web/live/session_live/app_info_component.ex
@@ -216,7 +216,7 @@ defmodule LivebookWeb.SessionLive.AppInfoComponent do
   end
 
   defp app_has_sessions?(app) do
-    app && length(app.sessions) > 0
+    app && app.sessions != []
   end
 
   defp app_info_icon(assigns) do


### PR DESCRIPTION
## Before

- Given I launched the preview of an app
- When I terminate the last session
- The "Terminate" button does not disappear

https://github.com/user-attachments/assets/85f06978-baf5-434c-a84f-4187e0167d49

## After

- Given I launched the preview of an app
- When I terminate the last session
- The "Terminate" button disappears
- And the page shows the initial UI state

https://github.com/user-attachments/assets/70e409c6-3f57-418a-880f-5dc97f2dd1cb

