### PR TITLE
Accept a custom image registry url

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ The following environment variables can be used to configure Livebook on boot:
     By default iframes are loaded from local `LIVEBOOK_IFRAME_PORT` when accessing
     Livebook over http:// and from https://livebookusercontent.com when accessing over https://.
 
+  * `LIVEBOOK_IMAGE_REGISTRY_URL` - sets the container image registry used to fetch livebook images from.
+    By default uses `ghcr.io/livebook-dev/livebook`.
+
   * `LIVEBOOK_IP` - sets the ip address to start the web application on.
     Must be a valid IPv4 or IPv6 address.
 

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -264,6 +264,10 @@ defmodule Livebook do
       config :livebook, :agent_name, agent_name
     end
 
+    if image_registry_url = Livebook.Config.image_registry_url!("LIVEBOOK_IMAGE_REGISTRY_URL") do
+      config :livebook, :image_registry_url, image_registry_url
+    end
+
     if Livebook.Config.boolean!("LIVEBOOK_FIPS", false) do
       if :crypto.enable_fips_mode(true) do
         IO.puts("[Livebook] FIPS mode enabled")

--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -21,6 +21,16 @@ defmodule Livebook.Config do
   end
 
   @doc """
+  Returns container image registry URL.
+
+  This returns the usual container image registry URL, and allows users to specify a custom URL.
+  """
+  @spec image_registry_url() :: String.t()
+  def image_registry_url() do
+    Application.get_env(:livebook, :image_registry_url) || "ghcr.io/livebook-dev/livebook"
+  end
+
+  @doc """
   Returns docker images to be used when generating sample Dockerfiles.
   """
   @spec docker_images() ::
@@ -661,6 +671,13 @@ defmodule Livebook.Config do
 
       agent_name
     end
+  end
+
+  @doc """
+  Parses image registry from env.
+  """
+  def image_registry_url!(env) do
+    System.get_env(env)
   end
 
   @doc """

--- a/lib/livebook/hubs/dockerfile.ex
+++ b/lib/livebook/hubs/dockerfile.ex
@@ -3,6 +3,7 @@ defmodule Livebook.Hubs.Dockerfile do
 
   import Ecto.Changeset
 
+  alias Livebook.Config
   alias Livebook.Hubs
 
   @type config :: %{
@@ -82,8 +83,10 @@ defmodule Livebook.Hubs.Dockerfile do
       ) do
     base_image = Enum.find(Livebook.Config.docker_images(), &(&1.tag == config.docker_tag))
 
+    image_registry_url = Config.image_registry_url()
+
     image = """
-    FROM ghcr.io/livebook-dev/livebook:#{base_image.tag}
+    FROM #{image_registry_url}:#{base_image.tag}
     """
 
     image_envs = format_envs(base_image.env)
@@ -316,7 +319,8 @@ defmodule Livebook.Hubs.Dockerfile do
   def online_docker_info(config, %Hubs.Team{} = hub, agent_key) do
     base_image = Enum.find(Livebook.Config.docker_images(), &(&1.tag == config.docker_tag))
 
-    image = "ghcr.io/livebook-dev/livebook:#{base_image.tag}"
+    image_registry_url = Config.image_registry_url()
+    image = "#{image_registry_url}:#{base_image.tag}"
 
     env = [
       {"LIVEBOOK_AGENT_NAME", "default"},

--- a/lib/livebook/k8s/pod.ex
+++ b/lib/livebook/k8s/pod.ex
@@ -19,6 +19,8 @@ defmodule Livebook.K8s.Pod do
             memory: 1Gi\
   """
 
+  alias Livebook.Config
+
   @doc """
   Returns the default pod template.
   """
@@ -73,7 +75,8 @@ defmodule Livebook.K8s.Pod do
   """
   @spec set_docker_tag(map(), String.t()) :: map()
   def set_docker_tag(manifest, docker_tag) do
-    image = "ghcr.io/livebook-dev/livebook:#{docker_tag}"
+    image_registry_url = Config.image_registry_url()
+    image = "#{image_registry_url}:#{docker_tag}"
     put_in(manifest, ["spec", "containers", access_main_container(), "image"], image)
   end
 

--- a/lib/livebook/runtime/fly.ex
+++ b/lib/livebook/runtime/fly.ex
@@ -51,6 +51,7 @@ defmodule Livebook.Runtime.Fly do
 
   use GenServer, restart: :temporary
 
+  alias Livebook.Config
   alias Livebook.Runtime.RemoteUtils
 
   @type t :: %__MODULE__{
@@ -200,7 +201,10 @@ defmodule Livebook.Runtime.Fly do
 
   defp create_machine(config, runtime_data) do
     base_image = Enum.find(Livebook.Config.docker_images(), &(&1.tag == config.docker_tag))
-    image = "ghcr.io/livebook-dev/livebook:#{base_image.tag}"
+
+    image_registry_url = Config.image_registry_url()
+
+    image = "#{image_registry_url}:#{base_image.tag}"
 
     env =
       Map.merge(


### PR DESCRIPTION
Hi Livebook team! 👋

This PR allows configuring a different image registry URL, by default using `ghcr.io/livebook-dev/livebook`.

This is useful for controlled environments where `ghcr.io` is not available, and a mirror needs to be used instead.

I wanted this option to change the image being pulled at `lib/livebook/k8s/pod.ex`, but saw also other places were referencing it, and changed them as well to use the configured value.

What do you think?

Thank you!