### PR TITLE
Fix some git file storage issues

### DIFF
--- a/lib/livebook/file_system/git.ex
+++ b/lib/livebook/file_system/git.ex
@@ -38,17 +38,6 @@ defmodule Livebook.FileSystem.Git do
       message: "must be a valid repo URL"
     )
     |> validate_required([:repo_url, :branch, :key, :hub_id])
-    |> update_change(:key, fn key ->
-      if key =~ "\n" do
-        key
-      else
-        String.replace(
-          key,
-          ~r/ (?!(?:OPENSSH |RSA |EC |DSA |PRIVATE )?(?:PRIVATE )?KEY-----)/,
-          "\n"
-        )
-      end
-    end)
     |> put_id()
   end
 

--- a/lib/livebook/file_system/git/client.ex
+++ b/lib/livebook/file_system/git/client.ex
@@ -151,10 +151,16 @@ defmodule Livebook.FileSystem.Git.Client do
 
   defp with_ssh_key_file(file_system, fun) when is_function(fun, 1) do
     File.mkdir_p!(Livebook.Config.tmp_path())
-
     key_path = FileSystem.Git.key_path(file_system)
-    pem_entry = :public_key.pem_decode(file_system.key)
-    ssh_key = :public_key.pem_encode(pem_entry)
+
+    ssh_key =
+      file_system.key
+      |> String.replace(
+        ~r/ (?!(?:OPENSSH |RSA |EC |DSA |PRIVATE )?(?:PRIVATE )?KEY-----)/,
+        "\n"
+      )
+      |> :public_key.pem_decode()
+      |> :public_key.pem_encode()
 
     File.write!(key_path, ssh_key)
     File.chmod!(key_path, 0o600)

--- a/lib/livebook/file_system/git/client.ex
+++ b/lib/livebook/file_system/git/client.ex
@@ -136,7 +136,7 @@ defmodule Livebook.FileSystem.Git.Client do
   end
 
   defp env_opts(key_path) do
-    [env: %{"GIT_SSH_COMMAND" => "ssh -i '#{key_path}'"}]
+    [env: %{"GIT_SSH_COMMAND" => "ssh -o StrictHostKeyChecking=no -i '#{key_path}'"}]
   end
 
   defp fetch_repository(file_system) do

--- a/lib/livebook/file_system/mounter.ex
+++ b/lib/livebook/file_system/mounter.ex
@@ -27,7 +27,7 @@ defmodule Livebook.FileSystem.Mounter do
 
   @impl GenServer
   def handle_continue(:boot, state) do
-    Hubs.Broadcasts.subscribe([:connection, :crud, :file_systems])
+    Hubs.Broadcasts.subscribe([:crud, :file_systems])
     Process.send_after(self(), :remount, state.loop_delay)
 
     {:noreply, mount_file_systems(state, Hubs.Personal.id())}
@@ -48,10 +48,6 @@ defmodule Livebook.FileSystem.Mounter do
 
   def handle_info({:file_system_deleted, file_system}, state) do
     {:noreply, unmount_file_system(state, file_system)}
-  end
-
-  def handle_info({:hub_changed, hub_id}, state) do
-    {:noreply, mount_file_systems(state, hub_id)}
   end
 
   def handle_info({:hub_deleted, hub_id}, state) do

--- a/lib/livebook/file_system/mounter.ex
+++ b/lib/livebook/file_system/mounter.ex
@@ -97,6 +97,8 @@ defmodule Livebook.FileSystem.Mounter do
 
       {:error, reason} ->
         Logger.error("[file_system=#{name(file_system)}] failed to mount: #{reason}")
+        Process.send_after(self(), {:file_system_created, file_system}, to_timeout(second: 10))
+
         state
     end
   end
@@ -109,6 +111,8 @@ defmodule Livebook.FileSystem.Mounter do
 
       {:error, reason} ->
         Logger.error("[file_system=#{name(file_system)}] failed to unmount: #{reason}")
+        Process.send_after(self(), {:file_system_deleted, file_system}, to_timeout(second: 10))
+
         state
     end
   end

--- a/test/livebook_teams/web/hub/edit_live_test.exs
+++ b/test/livebook_teams/web/hub/edit_live_test.exs
@@ -229,15 +229,6 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
     test "creates a Git file system", %{conn: conn, team: team} do
       id = Livebook.FileSystem.Utils.id("git", team.id, "git@github.com:livebook-dev/test.git")
       file_system = build(:fs_git, id: id, hub_id: team.id)
-
-      # When the user paste the ssh key to the password input, it will remove the break lines.
-      # So, the changeset need to normalize it before persisting. That said, the ssh key from
-      # factory must be "denormalized" so we can test the user scenario.
-      file_system = %{
-        file_system
-        | key: file_system.key |> String.replace("\n", "\s") |> String.trim()
-      }
-
       attrs = %{file_system: Livebook.FileSystem.dump(file_system)}
 
       {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")

--- a/test/livebook_web/live/hub/edit_live_test.exs
+++ b/test/livebook_web/live/hub/edit_live_test.exs
@@ -201,15 +201,6 @@ defmodule LivebookWeb.Hub.EditLiveTest do
     test "creates a Git file system", %{conn: conn, hub: hub} do
       file_system = build(:fs_git)
       id = file_system.id
-
-      # When the user paste the ssh key to the password input, it will remove the break lines.
-      # So, the changeset need to normalize it before persisting. That said, the ssh key from
-      # factory must be "denormalized" so we can test the user scenario.
-      file_system = %{
-        file_system
-        | key: file_system.key |> String.replace("\n", "\s") |> String.trim()
-      }
-
       attrs = %{file_system: Livebook.FileSystem.dump(file_system)}
 
       {:ok, view, _html} = live(conn, ~p"/hub/#{hub.id}")

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,7 +96,14 @@ defmodule Livebook.Factory do
   def build(:fs_git) do
     repo_url = "git@github.com:livebook-dev/test.git"
     hub_id = Livebook.Hubs.Personal.id()
-    key = System.get_env("TEST_GIT_SSH_KEY")
+
+    # When the user paste the ssh key to the password input, it will remove the break lines.
+    # So, the changeset need to normalize it before persisting. That said, the ssh key from
+    # factory must be "denormalized" so we can test the user scenario.
+    key =
+      System.get_env("TEST_GIT_SSH_KEY")
+      |> String.replace("\n", "\s")
+      |> String.trim()
 
     %Livebook.FileSystem.Git{
       id: Livebook.FileSystem.Utils.id("git", hub_id, repo_url),


### PR DESCRIPTION
* If you try to edit a git file storage that had the key normalized, it will generate an invalid ssh key format that fails to update from the UI
* If you run from Docker, the Docker will fail to clone because the git provider host isn't known by SSH
* Reduce the Mounter calls, removing `hub_changed` to be handled
* Add some logs when it fails
* Add retry when fails to mount/unmount