### PR TITLE
Mounter needs to susbcribe to hub connection events

### DIFF
--- a/lib/livebook/file_system/mounter.ex
+++ b/lib/livebook/file_system/mounter.ex
@@ -27,7 +27,7 @@ defmodule Livebook.FileSystem.Mounter do
 
   @impl GenServer
   def handle_continue(:boot, state) do
-    Hubs.Broadcasts.subscribe([:crud, :file_systems])
+    Hubs.Broadcasts.subscribe([:crud, :file_systems, :connection])
     Process.send_after(self(), :remount, state.loop_delay)
 
     {:noreply, mount_file_systems(state, Hubs.Personal.id())}


### PR DESCRIPTION
Mounter was handling hub-connected events:

https://github.com/livebook-dev/livebook/blob/871a0a0c679c5f19708d754d94bdd0bc2739b640/lib/livebook/file_system/mounter.ex#L36-L39

But it was not subscribing to them.