### PR TITLE
Add structured data in code evaluation logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,13 @@ The following environment variables can be used to configure Livebook on boot:
     logging, either of: error, warning, notice, info, debug. Defaults to warning.
 
   * `LIVEBOOK_LOG_METADATA` - a comma-separated list of metadata keys that should
-    be included in the log messages. Currently the only Livebook-spcecific key is
-    users (attached to evaluation and request logs). By default includes only
-    request_id.
+    be included in the log messages. Livebook-specific keys include:
+    - `users` (attached to evaluation and request logs)
+    - `session_mode` (attached to evaluation logs, either "default" or "app")
+    - `code` (attached to evaluation logs, the code being evaluated)
+    - `event` (attached to evaluation logs, currently always "code.evaluate")
+
+    By default includes only `request_id`.
 
   * `LIVEBOOK_LOG_FORMAT` - sets the log output format, either "text" (default)
     for human-readable logs or "json" for structured JSON.

--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -104,6 +104,8 @@ defmodule Livebook do
     log_metadata = Livebook.Config.log_metadata!("LIVEBOOK_LOG_METADATA")
     log_format = Livebook.Config.log_format!("LIVEBOOK_LOG_FORMAT") || :text
 
+    config :livebook, :log_format, log_format
+
     case {log_format, log_metadata} do
       {:json, log_metadata} ->
         config :logger, :default_handler,

--- a/lib/livebook/app.ex
+++ b/lib/livebook/app.ex
@@ -361,6 +361,7 @@ defmodule Livebook.App do
       files_source: {:dir, files_source},
       mode: :app,
       app_pid: self(),
+      app_permanent: state.deployment_bundle.permanent,
       auto_shutdown_ms: state.deployment_bundle.notebook.app_settings.auto_shutdown_ms,
       started_by: user,
       deployed_by: state.deployment_bundle.deployed_by

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -2684,7 +2684,7 @@ defmodule Livebook.Session do
     state
   end
 
-  def log_code_evaluation(cell, state) do
+  defp log_code_evaluation(cell, state) do
     inspected_code = inspect(cell.source, printable_limit: :infinity)
 
     # For metadata code, we try to use use the raw source, so it's easier to process

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -854,6 +854,9 @@ defmodule Livebook.Utils do
             into: %{}
       end
 
-    [users: inspect(list)]
+    case Application.get_env(:livebook, :log_format) do
+      :text -> [users: inspect(list)]
+      :json -> [users: list]
+    end
   end
 end

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -1,6 +1,7 @@
 defmodule Livebook.SessionTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
   import Livebook.HubHelpers
   import Livebook.AppHelpers
   import Livebook.SessionHelpers
@@ -2089,6 +2090,104 @@ defmodule Livebook.SessionTest do
 
         Livebook.Hubs.unset_default_hub()
       end
+    end
+  end
+
+  describe "code evaluation logging" do
+    test "logs code evaluation for regular sessions" do
+      session = start_session()
+      Session.subscribe(session.id)
+
+      {_section_id, cell_id} = insert_section_and_cell(session.pid)
+
+      unique_id = Utils.random_short_id()
+      # Use random ID to uniquely identify the source code of this cell
+      Session.set_cell_attributes(session.pid, cell_id, %{source: "# #{unique_id}"})
+
+      log =
+        capture_log(fn ->
+          Session.queue_cell_evaluation(session.pid, cell_id)
+          assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _, _}}
+        end)
+
+      # Logs from other test might be captured, so we're using an unique_id
+      assert log =~ ~s(Evaluating code\n  Session mode: default\n  Code: "# #{unique_id}")
+    end
+
+    test "logs code evaluation for preview apps" do
+      session = start_session()
+      Session.subscribe(session.id)
+
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug}
+      Session.set_app_settings(session.pid, app_settings)
+
+      {section_id, _cell_id} = insert_section_and_cell(session.pid)
+
+      Apps.subscribe()
+      Session.deploy_app(session.pid)
+      assert_receive {:app_created, %{slug: ^slug, pid: app_pid}}
+
+      session_id = App.get_session_id(app_pid)
+      {:ok, app_session} = Livebook.Sessions.fetch_session(session_id)
+
+      Session.subscribe(app_session.id)
+
+      unique_id = Utils.random_short_id()
+      # Use random ID to uniquely identify the source code of this cell
+      Session.insert_cell(app_session.pid, section_id, 0, :code, %{source: "# #{unique_id}"})
+      assert_receive {:operation, {:insert_cell, _, ^section_id, 0, :code, cell_id, _}}
+
+      log =
+        capture_log(fn ->
+          Session.queue_cell_evaluation(app_session.pid, cell_id)
+          assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _, _}}
+        end)
+
+      # Logs from other test might be captured, so we're using an unique_id
+      assert log =~ ~s(Evaluating code\n  Session mode: app\n  Code: "# #{unique_id}")
+
+      App.close(app_pid)
+    end
+
+    test "does not log code evaluation for permanent apps" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug}
+
+      unique_id = Utils.random_short_id()
+      # Use random ID to uniquely identify the source code of this cell
+      code_cell = %{Notebook.Cell.new(:code) | source: "# #{unique_id}"}
+      section = %{Notebook.Section.new() | cells: [code_cell]}
+      notebook = %{Notebook.new() | sections: [section], app_settings: app_settings}
+
+      # Deploy as a permanent app
+      app_spec = Livebook.Apps.NotebookAppSpec.new(notebook)
+      deployer_pid = Livebook.Apps.Deployer.local_deployer()
+      ref = Livebook.Apps.Deployer.deploy_monitor(deployer_pid, app_spec, permanent: true)
+
+      app_pid =
+        receive do
+          {:deploy_result, ^ref, {:ok, pid}} ->
+            Process.demonitor(ref, [:flush])
+            pid
+        end
+
+      session_id = App.get_session_id(app_pid)
+      {:ok, app_session} = Livebook.Sessions.fetch_session(session_id)
+
+      Session.subscribe(app_session.id)
+      cell_id = code_cell.id
+
+      log =
+        capture_log(fn ->
+          Session.queue_cell_evaluation(app_session.pid, cell_id)
+          assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _, _}}
+        end)
+
+      # Logs from other test might be captured, so we're using an unique_id
+      refute log =~ unique_id
+
+      App.close(app_pid)
     end
   end
 


### PR DESCRIPTION
I started working on docs for our "audit logs" feature, and I noticed we could make some improvements.


## Structured log messages when evaluating code

The goal is to emit structured data instead of strings whenever possible, making it easier to filter code evaluation log entries and parse its data in an external log aggregator.

With that PR in place, one could run Livebook with those env vars:

```sh
MIX_ENV=prod LIVEBOOK_LOG_LEVEL=info \
LIVEBOOK_LOG_METADATA="users,session_mode,code,event" \
LIVEBOOK_LOG_FORMAT=json \
mix phx.server
```

To get a nice structured log message when a code is evaluated:

```console
{"message":"Evaluating code\n  Session mode: default\n  Code: \"7 + 13\"","time":"2025-10-03T17:48:22.238Z","metadata":{"code":"7 + 13","session_mode":"default","event":"code.evaluate","users":[{"id":"1","name":"Hugo Baraúna"}]},"severity":"info"}
```

## Conditionally log code evaluation

Another change is that code evaluation is now only logged when the code is being evaluated in the context of a regular notebook session or an app preview session.

The rationale is that the purpose of logging code evaluation is to have a way to see who ran what code and when. This is relevant when someone is running code in a Livebook app server against a production environment.

However, logging code evaluation is arguably not relevant when the code is inside a deployed Livebook used by an internal user, since that user is not choosing which code to run—they are using an app or code deployed by someone else.