### PR TITLE
Allow local network access within iframes

### DIFF
--- a/assets/js/hooks/js_view/iframe.js
+++ b/assets/js/hooks/js_view/iframe.js
@@ -35,7 +35,7 @@ export function initializeIframeSource(iframe, iframePort, iframeUrl) {
     iframe.sandbox =
       "allow-scripts allow-same-origin allow-downloads allow-forms allow-modals allow-popups allow-top-navigation";
     iframe.allow =
-      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; fullscreen; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write; bluetooth; serial";
+      "accelerometer; ambient-light-sensor; camera; display-capture; encrypted-media; fullscreen; geolocation; gyroscope; microphone; midi; usb; xr-spatial-tracking; clipboard-read; clipboard-write; bluetooth; serial; local-network-access";
     iframe.src = url;
   });
 }


### PR DESCRIPTION
## Context

We use livebook apps for some internal tools, so I have an instance deployed on prem which can only be accessed through VPN or locally in our offices and it was working great until Google decided to block local network access in public websites and iframes by default.

And since livebook uses iframes to run js served from our private deployment, users started to see errors like this one when they updated their browsers:

```
Failed to load the widget JS module, got the following error:

    Failed to fetch dynamically imported module: https://<our-private-domain>/public/sessions/45tr2u36pbqjkbvjsdwad3pacgwpbqbr47r2uzytrey45cyh/assets/3jj7uljc2ssyxy7g627axv7idu/main.js

See the browser console for more details. If running behind an authentication proxy, make sure the /public/* routes are publicly accessible.
```

And in console:

```
Access to script at 'https://<our-private-domain>/public/sessions/45tr2u36pbqjkbvjsdwad3pacgwpbqbr47r2uzytrey45cyh/assets/3jj7uljc2ssyxy7g627axv7idu/main.js' from origin 'https://livebookusercontent.com' has been blocked by CORS policy: Permission was denied for this request to access the `unknown` address space.
```

For more context https://docs.google.com/document/d/1QQkqehw8umtAgz5z0um7THx-aoU251p705FbIQjDuGs/edit?tab=t.0#heading=h.denb9idl4lm0

