### PR TITLE
Remove folder warning from CLI deploy

### DIFF
--- a/lib/livebook/live_markdown/import.ex
+++ b/lib/livebook/live_markdown/import.ex
@@ -667,22 +667,6 @@ defmodule Livebook.LiveMarkdown.Import do
     # validate it against the public key).
     teams_enabled = is_struct(hub, Livebook.Hubs.Team) and (hub.offline == nil or stamp_verified?)
 
-    messages =
-      if app_folder_id = notebook.app_settings.app_folder_id do
-        app_folders = Hubs.Provider.get_app_folders(hub)
-
-        if Enum.any?(app_folders, &(&1.id == app_folder_id)) do
-          messages
-        else
-          messages ++
-            [
-              ~s/notebook is assigned to a non-existent app folder, defaulting to "No folder" app folder/
-            ]
-        end
-      else
-        messages
-      end
-
     {%{notebook | teams_enabled: teams_enabled}, stamp_verified?, messages}
   end
 

--- a/test/livebook_teams/live_markdown/import_test.exs
+++ b/test/livebook_teams/live_markdown/import_test.exs
@@ -42,9 +42,7 @@ defmodule Livebook.Integration.LiveMarkdown.ImportTest do
       assert {%Notebook{
                 name: "Deleted from folder",
                 app_settings: %{app_folder_id: ^app_folder_id}
-              }, %{warnings: warnings}} = LiveMarkdown.Import.notebook_from_livemd(markdown)
-
-      assert "notebook is assigned to a non-existent app folder, defaulting to 'No folder' app folder" in warnings
+              }, %{warnings: []}} = LiveMarkdown.Import.notebook_from_livemd(markdown)
     end
   end
 end


### PR DESCRIPTION
If it is offline, we can't verify it.

If it isn't offline, we verify the stamp, if the stamp is valid, then the folder should be valid. Therefore the warning is only helpful if someone deletes a folder from the server but arguably that should not halt a deployment.