### PR TITLE
Fix Node.set_cookie usage in Phoenix integration docs

### DIFF
--- a/docs/teams/phoenix_integration.md
+++ b/docs/teams/phoenix_integration.md
@@ -85,11 +85,12 @@ Add this module to your notebook to handle environment-specific connections:
 ```elixir
 defmodule NodeConnection do
   def connect() do
-    Node.set_cookie(cookie())
+    node = target_node()
+    Node.set_cookie(node, cookie())
 
-    case Node.connect(target_node()) do
+    case Node.connect(node) do
       true -> :ok
-      _ -> {:error, "Failed to connect to #{inspect(target_node())}"}
+      _ -> {:error, "Failed to connect to #{inspect(node)}"}
     end
   end
 


### PR DESCRIPTION
Use per-node cookie (`Node.set_cookie(node, cookie())`) instead of changing the default cookie (`Node.set_cookie(cookie())`). The latter changes the runtime's default magic cookie, causing connection rejections ("Invalid challenge reply" errors) when other Livebook nodes try to connect.

Kino remote execution's smart cell was already doing this correctly: https://github.com/livebook-dev/kino/blob/017ef78e793df6edbd3e9e8cc3a696ea4c5c14c1/lib/kino/remote_execution_cell.ex#L214