### PR TITLE
Improve boolean defaults

### DIFF
--- a/lib/livebook/teams/requests.ex
+++ b/lib/livebook/teams/requests.ex
@@ -255,7 +255,7 @@ defmodule Livebook.Teams.Requests do
         app_folder_id: app_deployment.app_folder_id,
         deployment_group_id: deployment_group_id,
         sha: app_deployment.sha,
-        redeploy: opts[:redeploy] || false
+        redeploy: Keyword.get(opts, :redeploy, false)
       }
 
     encrypted_content = Teams.encrypt(app_deployment.file, secret_key)

--- a/lib/livebook_cli/deploy.ex
+++ b/lib/livebook_cli/deploy.ex
@@ -64,8 +64,8 @@ defmodule LivebookCLI.Deploy do
       session_token: opts[:org_token],
       teams_key: opts[:teams_key],
       deployment_group_id: opts[:deployment_group_id],
-      dry_run?: opts[:dry_run] || false,
-      redeploy?: opts[:redeploy] || false
+      dry_run?: Keyword.get(opts, :dry_run, false),
+      redeploy?: Keyword.get(opts, :redeploy, false)
     }
   end
 
@@ -230,7 +230,7 @@ defmodule LivebookCLI.Deploy do
   defp ensure_skip_on_dry_run(app_deployment, dry_run?) do
     if dry_run? do
       message = """
-        * #{app_deployment.title} skipped due to --dry-run 
+        * #{app_deployment.title} skipped due to --dry-run
       """
 
       log_info(message)


### PR DESCRIPTION
Technically equivalent for `|| false`, but for boolean options it's best to avoid `||` altogether, because for `|| true` it doesn't work as expected.