### PR TITLE
Use deployment group specific LIVEBOOK_NODE for K8s clustering

### DIFF
--- a/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
@@ -368,7 +368,7 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupAgentComponent do
     if sanitized == "" do
       string
       |> Base.encode32(padding: false, case: :lower)
-      |> String.slice(0, 40)
+      |> String.slice(0, 20)
     else
       sanitized
     end


### PR DESCRIPTION
Updates the Kubernetes deployment instructions to include a deployment-group-specific prefix in the `LIVEBOOK_NODE` environment variable. This ensures that pods from different deployment groups sharing the same namespace and headless service do not accidentally cluster together.