### PR TITLE
Remove hardcoded namespace from Kubernetes YAML template

### DIFF
--- a/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
+++ b/lib/livebook_web/live/hub/teams/deployment_group_agent_component.ex
@@ -343,7 +343,6 @@ defmodule LivebookWeb.Hub.Teams.DeploymentGroupAgentComponent do
     kind: Secret
     metadata:
       name: livebook-secret
-      namespace: livebook-namespace
     type: Opaque
     data:
       # Notice the values below are Base64 encoded


### PR DESCRIPTION
The generated YAML now works out of the box, all resources deploy to the user's current namespace without requiring prior setup.

Users can customize the target namespace as needed.

Before this PR, when I tried to test locally per the instructions, they didn't work out of the box.