### PR TITLE
Change formatting shortcut

### DIFF
--- a/assets/js/hooks/cell_editor/live_editor/codemirror/formatter.js
+++ b/assets/js/hooks/cell_editor/live_editor/codemirror/formatter.js
@@ -91,9 +91,8 @@ function startFormat(view) {
 
 const formatterKeymap = [
   {
-    key: "Ctrl-Shift-i",
-    mac: "Alt-Shift-f",
-    win: "Alt-Shift-f",
+    key: "Ctrl-Shift-f",
+    mac: "Cmd-Shift-f",
     run: startFormat,
   },
 ];

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -18,9 +18,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
         desc: "Show signature help"
       },
       %{
-        seq: ["ctrl", "shift", "i"],
-        seq_mac: ["⌥", "⇧", "f"],
-        seq_windows: ["alt", "shift", "f"],
+        seq: ["ctrl", "shift", "f"],
+        seq_mac: ["⌘", "⇧", "f"],
         press_all: true,
         desc: "Format Elixir code",
         basic: true


### PR DESCRIPTION
So `Alt-Shift-f` no longer dispatches correctly in CodeMirror (I updated dependencies as part of #3137). The reasoning is that shift and alt alone (or together) are used to type actual characters, so generally such shortcuts should be avoided. The corresponding change in [CodeMirror changelog](https://codemirror.net/docs/changelog#%40codemirror%2Fview-6.38.1-(2025-07-15)).

I changed the shortcut to be `ctrl + shift + f` on Linux/Windows and `cmd + shift + f` on macOS.