### PR TITLE
Fix fly runtime proxy auth

### DIFF
--- a/lib/livebook/runtime/fly.ex
+++ b/lib/livebook/runtime/fly.ex
@@ -291,12 +291,10 @@ defmodule Livebook.Runtime.Fly do
         app_name,
         "--bind-addr",
         bind_addr,
-        "--access-token",
-        token,
         "--watch-stdin"
       ]
 
-      env = [{~c"FLY_NO_UPDATE_CHECK", ~c"1"}]
+      env = [{~c"FLY_NO_UPDATE_CHECK", ~c"1"}, {~c"FLY_ACCESS_TOKEN", ~c"#{token}"}]
 
       port =
         Port.open(

--- a/lib/livebook_web/live/session_live/fly_runtime_component.ex
+++ b/lib/livebook_web/live/session_live/fly_runtime_component.ex
@@ -440,7 +440,7 @@ defmodule LivebookWeb.SessionLive.FlyRuntimeComponent do
 
   @impl true
   def handle_event("set_token", %{"token" => token}, socket) do
-    {:noreply, socket |> assign(token: nullify(token)) |> load_org_and_regions()}
+    {:noreply, socket |> assign(token: nullify(token)) |> load_org_and_regions() |> load_app()}
   end
 
   def handle_event("set_app_name", %{"app_name" => app_name}, socket) do

--- a/test/livebook/runtime/fly_test.exs
+++ b/test/livebook/runtime/fly_test.exs
@@ -7,7 +7,7 @@ defmodule Livebook.Runtime.FlyTest do
 
   alias Livebook.Runtime
 
-  @assert_receive_timeout 10_000
+  @assert_receive_timeout 20_000
 
   setup do
     Livebook.FlyAPI.passthrough()


### PR DESCRIPTION
I noticed that passing `--access-token` flyctl proxy no longer works for me on latest cli version. Perhaps this is another instance of https://github.com/superfly/flyctl/issues/1506. Passing `FLY_ACCESS_TOKEN` env var works, so I updated to that.