### PR TITLE
Link Settings' Livebook version to GitHub release

### DIFF
--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -55,7 +55,7 @@ defmodule LivebookWeb.SettingsLive do
                 <.labeled_text :if={app_name = Livebook.Config.app_service_name()} label="Application">
                   <%= if app_url = Livebook.Config.app_service_url() do %>
                     <a href={app_url} class="underline hover:no-underline" target="_blank">
-                      {app_name}
+                      {app_name} <.remix_icon icon="external-link-line" />
                     </a>
                   <% else %>
                     {app_name}


### PR DESCRIPTION
Was running Livebook via the macOS app and it updated to the latest version. I wanted an easy way to see the changes from within Livebook, and thought the Livebook version can link to the GitHub Release which contains a changelog.

Note this link will 404 when running Livebook from the main branch as there is no GitHub Release for unreleased dev versions. I think that's fine though.