### PR TITLE
fix: lock app server when Livebook Teams connection is pending

### DIFF
--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -334,9 +334,8 @@ defmodule Livebook.Hubs.TeamClient do
 
   def handle_call(:identity_status, _caller, %{deployment_group_id: id} = state) do
     case fetch_deployment_group(id, state) do
-      {:ok, deployment_group} ->
-        auth_via_teams_config = if(deployment_group.teams_auth, do: :enabled, else: :disabled)
-        {:reply, auth_via_teams_config, state}
+      {:ok, %{teams_auth: true}} ->
+        {:reply, :enabled, state}
 
       _ ->
         {:reply, :disabled, state}

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -142,11 +142,14 @@ defmodule Livebook.Hubs.TeamClient do
   end
 
   @doc """
-  Returns if the Team client uses Livebook Teams identity provider.
+  Returns the identity status for the Team client.
+
+  Returns `:pending` when the Teams connection has not been established yet,
+  `:enabled` when Teams authentication is enabled, and `:disabled` otherwise.
   """
-  @spec identity_enabled?(String.t()) :: boolean()
-  def identity_enabled?(id) do
-    GenServer.call(registry_name(id), :identity_enabled?)
+  @spec identity_status(String.t()) :: :pending | :enabled | :disabled
+  def identity_status(id) do
+    GenServer.call(registry_name(id), :identity_status)
   end
 
   @doc """
@@ -325,14 +328,18 @@ defmodule Livebook.Hubs.TeamClient do
     {:reply, environment_variables, state}
   end
 
-  def handle_call(:identity_enabled?, _caller, %{deployment_group_id: nil} = state) do
-    {:reply, false, state}
+  def handle_call(:identity_status, _caller, %{deployment_group_id: nil} = state) do
+    {:reply, :pending, state}
   end
 
-  def handle_call(:identity_enabled?, _caller, %{deployment_group_id: id} = state) do
+  def handle_call(:identity_status, _caller, %{deployment_group_id: id} = state) do
     case fetch_deployment_group(id, state) do
-      {:ok, deployment_group} -> {:reply, deployment_group.teams_auth, state}
-      _ -> {:reply, false, state}
+      {:ok, deployment_group} ->
+        auth_via_teams_config = if(deployment_group.teams_auth, do: :enabled, else: :disabled)
+        {:reply, auth_via_teams_config, state}
+
+      _ ->
+        {:reply, :disabled, state}
     end
   end
 

--- a/lib/livebook/zta/livebook_teams.ex
+++ b/lib/livebook/zta/livebook_teams.ex
@@ -28,10 +28,24 @@ defmodule Livebook.ZTA.LivebookTeams do
   def authenticate(name, conn, _opts) do
     team = NimbleZTA.get(name)
 
-    if Livebook.Hubs.TeamClient.identity_enabled?(team.id) do
-      handle_request(name, conn, team, conn.params)
-    else
-      {conn, %{}}
+    case Livebook.Hubs.TeamClient.identity_status(team.id) do
+      :enabled ->
+        handle_request(name, conn, team, conn.params)
+
+      :disabled ->
+        {conn, %{}}
+
+      :pending ->
+        {conn
+         |> put_status(:service_unavailable)
+         |> put_view(LivebookWeb.ErrorHTML)
+         |> render("error.html", %{
+           status: 503,
+           details:
+             "This Livebook instance cannot be accessed because it has not yet" <>
+               " established a connection to Livebook Teams."
+         })
+         |> halt(), nil}
     end
   end
 

--- a/test/livebook_teams/zta/livebook_teams_test.exs
+++ b/test/livebook_teams/zta/livebook_teams_test.exs
@@ -179,4 +179,31 @@ defmodule Livebook.ZTA.LivebookTeamsTest do
       assert {_conn, %{id: ^id, groups: ^groups}} = LivebookTeams.authenticate(test, conn, [])
     end
   end
+
+  defmodule PendingConnection do
+    # No TeamsIntegrationCase needed — we test the scenario where
+    # the TeamClient has never connected to Teams
+    use LivebookWeb.ConnCase, async: true
+
+    alias Livebook.ZTA.LivebookTeams
+
+    setup %{conn: conn, test: test} do
+      team = build(:team, user_id: nil)
+      Livebook.Hubs.save_hub(team)
+      on_exit(fn -> Livebook.Hubs.delete_hub(team.id) end)
+
+      start_supervised!({LivebookTeams, name: test, identity_key: team.id})
+
+      {:ok, conn: conn, team: team}
+    end
+
+    test "returns 503 when Teams connection is pending", %{conn: conn, test: test} do
+      conn = init_test_session(conn, %{})
+
+      assert {conn, nil} = LivebookTeams.authenticate(test, conn, [])
+      assert conn.halted
+      assert conn.status == 503
+      assert conn.resp_body =~ "it has not yet established a connection to Livebook Teams"
+    end
+  end
 end


### PR DESCRIPTION
When an app server boots and cannot reach Livebook Teams, there could be a problem with instance-level authentication.

This PR fixes this.