### PR TITLE
Exposes query string from the permalink to session

### DIFF
--- a/lib/livebook/app.ex
+++ b/lib/livebook/app.ex
@@ -347,12 +347,12 @@ defmodule Livebook.App do
     if temporary_sessions?(state.deployment_bundle.notebook.app_settings) do
       state
     else
-      {:ok, state, _app_session} = start_app_session(state)
+      {:ok, state, _app_session} = start_app_session(state, nil, nil)
       state
     end
   end
 
-  defp start_app_session(state, user \\ nil, params \\ nil) do
+  defp start_app_session(state, user, params) do
     user = if(state.deployment_bundle.notebook.teams_enabled, do: user)
 
     files_source =

--- a/lib/livebook/app.ex
+++ b/lib/livebook/app.ex
@@ -140,13 +140,17 @@ defmodule Livebook.App do
     * `:user` - the user requesting the session. In multi-session app,
       we track who starts each session
 
+    * `:session_params` - the session parameters. In multi-session app,
+      we expose the parameters used to request the session.
+
   """
   @spec get_session_id(pid(), keyword()) :: Livebook.Session.id()
   def get_session_id(pid, opts \\ []) do
-    opts = Keyword.validate!(opts, [:user])
+    opts = Keyword.validate!(opts, [:user, :session_params])
     user = opts[:user]
+    params = opts[:session_params]
 
-    GenServer.call(pid, {:get_session_id, user})
+    GenServer.call(pid, {:get_session_id, user, params})
   end
 
   @doc """
@@ -231,7 +235,7 @@ defmodule Livebook.App do
     {:reply, self_from_state(state), state}
   end
 
-  def handle_call({:get_session_id, user}, _from, state) do
+  def handle_call({:get_session_id, user, params}, _from, state) do
     {session_id, state} =
       case {state.deployment_bundle.notebook.app_settings.multi_session,
             single_session_app_session(state)} do
@@ -240,7 +244,7 @@ defmodule Livebook.App do
 
         {multi_session, _} ->
           user = if(multi_session, do: user)
-          {:ok, state, app_session} = start_app_session(state, user)
+          {:ok, state, app_session} = start_app_session(state, user, params)
           {app_session.id, notify_update(state)}
       end
 
@@ -348,7 +352,7 @@ defmodule Livebook.App do
     end
   end
 
-  defp start_app_session(state, user \\ nil) do
+  defp start_app_session(state, user \\ nil, params \\ nil) do
     user = if(state.deployment_bundle.notebook.teams_enabled, do: user)
 
     files_source =
@@ -364,6 +368,7 @@ defmodule Livebook.App do
       app_permanent: state.deployment_bundle.permanent,
       auto_shutdown_ms: state.deployment_bundle.notebook.app_settings.auto_shutdown_ms,
       started_by: user,
+      session_params: params,
       deployed_by: state.deployment_bundle.deployed_by
     ]
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -205,6 +205,9 @@ defmodule Livebook.Session do
     * `:deployed_by` - the user that deployed the app, to which this
       session belongs to. This is only relevant for app sessions
 
+    * `:session_params` - the user parameters from query string, used to
+      start the session. This is only relevant to multi-session apps.
+
   """
   @spec start_link(keyword()) :: {:ok, pid, t()} | {:error, any()}
   def start_link(opts) do
@@ -1001,7 +1004,8 @@ defmodule Livebook.Session do
         auto_shutdown_ms: opts[:auto_shutdown_ms],
         auto_shutdown_timer_ref: nil,
         started_by: opts[:started_by],
-        deployed_by: opts[:deployed_by]
+        deployed_by: opts[:deployed_by],
+        session_params: opts[:session_params]
       }
 
       {:ok, state}
@@ -3185,6 +3189,13 @@ defmodule Livebook.Session do
     case state.data do
       %{mode: :app, notebook: %{app_settings: %{multi_session: true}}} ->
         info = %{type: :multi_session}
+
+        info =
+          if params = state.session_params do
+            Map.put(info, :session_params, params)
+          else
+            info
+          end
 
         if user = state.started_by do
           started_by = user_info(user)

--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -21,7 +21,7 @@ defmodule LivebookWeb.AppLive do
     {:ok, assign(socket, app: app), layout: false}
   end
 
-  def mount(%{"slug" => slug}, _session, socket) do
+  def mount(%{"slug" => slug} = params, _session, socket) do
     if socket.assigns.app_settings.multi_session do
       {:ok, app} = Livebook.Apps.fetch_app(slug)
 
@@ -30,7 +30,8 @@ defmodule LivebookWeb.AppLive do
         Livebook.Teams.Broadcasts.subscribe(:app_deployments)
       end
 
-      {:ok, assign(socket, app: app, apps_banner: Livebook.Config.apps_banner())}
+      {:ok,
+       assign(socket, app: app, query_params: params, apps_banner: Livebook.Config.apps_banner())}
     else
       {:ok, pid} = Livebook.Apps.fetch_pid(slug)
       session_id = Livebook.App.get_session_id(pid, user: socket.assigns.current_user)
@@ -113,11 +114,26 @@ defmodule LivebookWeb.AppLive do
 
   @impl true
   def handle_params(_params, _url, socket) when socket.assigns.live_action == :new_session do
-    session_id =
-      Livebook.App.get_session_id(socket.assigns.app.pid, user: socket.assigns.current_user)
+    app = socket.assigns.app
+    opts = [user: socket.assigns.current_user]
 
-    {:noreply,
-     push_navigate(socket, to: ~p"/apps/#{socket.assigns.app.slug}/sessions/#{session_id}")}
+    opts =
+      if socket.assigns.app_settings.multi_session do
+        params =
+          Enum.reduce(socket.assigns.query_params, %{}, fn {key, value}, acc ->
+            case Regex.run(~r/^[Ll][Bb]_(.*)$/, key) do
+              [_, key] -> Map.put(acc, key, value)
+              _otherwise -> acc
+            end
+          end)
+
+        Keyword.put(opts, :session_params, params)
+      else
+        opts
+      end
+
+    session_id = Livebook.App.get_session_id(app.pid, opts)
+    {:noreply, push_navigate(socket, to: ~p"/apps/#{app.slug}/sessions/#{session_id}")}
   end
 
   def handle_params(_params, _url, socket), do: {:noreply, socket}

--- a/lib/livebook_web/live/app_live.ex
+++ b/lib/livebook_web/live/app_live.ex
@@ -120,12 +120,10 @@ defmodule LivebookWeb.AppLive do
     opts =
       if socket.assigns.app_settings.multi_session do
         params =
-          Enum.reduce(socket.assigns.query_params, %{}, fn {key, value}, acc ->
-            case Regex.run(~r/^[Ll][Bb]_(.*)$/, key) do
-              [_, key] -> Map.put(acc, key, value)
-              _otherwise -> acc
-            end
-          end)
+          for {key, value} <- socket.assigns.query_params,
+              key = lb_query_param(key),
+              into: %{},
+              do: {key, value}
 
         Keyword.put(opts, :session_params, params)
       else
@@ -160,4 +158,8 @@ defmodule LivebookWeb.AppLive do
   defp active_sessions(sessions) do
     Enum.filter(sessions, &(&1.app_status.lifecycle == :active))
   end
+
+  defp lb_query_param("lb_" <> param), do: param
+  defp lb_query_param("LB_" <> param), do: param
+  defp lb_query_param(_), do: nil
 end

--- a/test/livebook/app_test.exs
+++ b/test/livebook/app_test.exs
@@ -213,6 +213,41 @@ defmodule Livebook.AppTest do
 
       assert %{sessions: [%{id: ^session_id, started_by: ^user}]} = App.get_by_pid(app_pid)
     end
+
+    test "stores session creator params in multi-session mode" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings, teams_enabled: true}
+      user = %{Livebook.Users.User.new() | name: "Jake Peralta"}
+
+      app_pid = start_app(notebook)
+      assert %{sessions: []} = App.get_by_pid(app_pid)
+
+      params = %{
+        "username" => user.name,
+        "foo" => "bar"
+      }
+
+      session_id = App.get_session_id(app_pid, user: user, session_params: params)
+
+      assert %{sessions: [%{id: ^session_id, pid: pid, started_by: ^user}]} =
+               App.get_by_pid(app_pid)
+
+      send(pid, {:runtime_app_info_request, self()})
+      assert_receive {:runtime_app_info_reply, {:ok, app_info}}
+
+      assert app_info == %{
+               type: :multi_session,
+               session_params: params,
+               started_by: %{
+                 email: user.email,
+                 id: user.id,
+                 name: user.name,
+                 payload: user.payload,
+                 source: :session
+               }
+             }
+    end
   end
 
   describe "automatic shutdown" do

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -1643,6 +1643,45 @@ defmodule Livebook.SessionTest do
 
       App.close(app_pid)
     end
+
+    test "app session responds to app info request with session params" do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings, teams_enabled: true}
+
+      user = %{
+        Livebook.Users.User.new()
+        | id: "1234",
+          name: "Jake Peralta",
+          email: "jperalta@example.com"
+      }
+
+      params = %{
+        "username" => user.name,
+        "foo" => "bar"
+      }
+
+      app_pid = deploy_notebook_sync(notebook)
+      session_id = App.get_session_id(app_pid, user: user, session_params: params)
+      {:ok, session} = Livebook.Sessions.fetch_session(session_id)
+
+      send(session.pid, {:runtime_app_info_request, self()})
+      assert_receive {:runtime_app_info_reply, {:ok, app_info}}
+
+      assert app_info == %{
+               session_params: params,
+               type: :multi_session,
+               started_by: %{
+                 source: :session,
+                 id: "1234",
+                 name: "Jake Peralta",
+                 email: "jperalta@example.com",
+                 payload: nil
+               }
+             }
+
+      App.close(app_pid)
+    end
   end
 
   test "responds to app session request when not app" do

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -112,6 +112,53 @@ defmodule LivebookWeb.AppLiveTest do
       App.close(app_pid)
     end
 
+    test "creating a new session with query params", %{conn: conn} do
+      slug = Utils.random_short_id()
+      app_settings = %{Notebook.AppSettings.new() | slug: slug, multi_session: true}
+      notebook = %{Notebook.new() | app_settings: app_settings}
+
+      Apps.subscribe()
+      app_pid = deploy_notebook_sync(notebook)
+
+      assert_receive {:app_created, %{pid: ^app_pid, sessions: []}}
+
+      query_params = %{
+        "lb_username" => "Jake Peralta",
+        "Lb_UserId" => "123",
+        "lB_eMAIl" => "jake.peralta@mail.com",
+        "LB_action" => "view",
+        "password" => "chonkycat",
+        "foo" => "bar"
+      }
+
+      {:ok, view, _} = live(conn, ~p"/apps/#{slug}?#{query_params}")
+
+      {:error, {:live_redirect, %{to: to}}} =
+        view
+        |> element("a", "New session")
+        |> render_click()
+
+      assert_receive {:app_updated, %{pid: ^app_pid, sessions: [%{id: session_id, pid: pid}]}}
+      assert to == ~p"/apps/#{slug}/sessions/#{session_id}"
+
+      send(pid, {:runtime_app_info_request, self()})
+      assert_receive {:runtime_app_info_reply, app_info}
+
+      assert app_info ==
+               {:ok,
+                %{
+                  type: :multi_session,
+                  session_params: %{
+                    "username" => "Jake Peralta",
+                    "UserId" => "123",
+                    "eMAIl" => "jake.peralta@mail.com",
+                    "action" => "view"
+                  }
+                }}
+
+      App.close(app_pid)
+    end
+
     test "does not list existing session if configured not to", %{conn: conn} do
       slug = Utils.random_short_id()
 

--- a/test/livebook_web/live/app_live_test.exs
+++ b/test/livebook_web/live/app_live_test.exs
@@ -142,19 +142,12 @@ defmodule LivebookWeb.AppLiveTest do
       assert to == ~p"/apps/#{slug}/sessions/#{session_id}"
 
       send(pid, {:runtime_app_info_request, self()})
-      assert_receive {:runtime_app_info_reply, app_info}
+      assert_receive {:runtime_app_info_reply, {:ok, app_info}}
 
-      assert app_info ==
-               {:ok,
-                %{
-                  type: :multi_session,
-                  session_params: %{
-                    "username" => "Jake Peralta",
-                    "UserId" => "123",
-                    "eMAIl" => "jake.peralta@mail.com",
-                    "action" => "view"
-                  }
-                }}
+      assert app_info == %{
+               type: :multi_session,
+               session_params: %{"username" => "Jake Peralta", "action" => "view"}
+             }
 
       App.close(app_pid)
     end


### PR DESCRIPTION
You can access the query string keys if they has a `LB_`/`lb_` prefix.

```elixir
# Access /apps/my-app?lb_username=aledsz

app_info = Kino.Workspace.app_info()
Kino.Input.text("Username", default: app_info.session_params["username"]
```