### PR TITLE
Show topbar notifications with WebSocket events

### DIFF
--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -741,13 +741,27 @@ defmodule Livebook.Hubs.TeamClient do
   end
 
   defp build_notification(notification) do
+    kind =
+      if notification.kind in ~w[warning error info],
+        do: notification.kind,
+        else: "info"
+
     %Teams.Notification{
       id: notification.id,
-      kind: notification.kind,
-      type: atomize(notification.type),
+      kind: kind,
       message: nullify(notification.message),
       min_version: nullify(notification.min_version)
     }
+  end
+
+  defp put_notification(state, notification) do
+    state = remove_notification(state, notification)
+
+    %{state | notifications: [notification | state.notifications]}
+  end
+
+  defp remove_notification(state, notification) do
+    %{state | notifications: Enum.reject(state.notifications, &(&1.id == notification.id))}
   end
 
   defp handle_event(:secret_created, %Secrets.Secret{} = secret, state) do
@@ -1009,14 +1023,21 @@ defmodule Livebook.Hubs.TeamClient do
 
   defp handle_event(:notification_sent, %Teams.Notification{} = notification, state) do
     Teams.Broadcasts.notification_sent(notification)
-    notifications = filter_notifications([notification | state.notifications])
+    put_notification(state, notification)
+  end
 
-    %{state | notifications: notifications}
+  defp handle_event(:notification_updated, %Teams.Notification{} = notification, state) do
+    Teams.Broadcasts.notification_updated(notification)
+    put_notification(state, notification)
+  end
+
+  defp handle_event(:notification_deleted, %Teams.Notification{} = notification, state) do
+    Teams.Broadcasts.notification_deleted(notification)
+    remove_notification(state, notification)
   end
 
   defp dispatch_common_connected_events(state, connected) do
-    # Clear all the notifications before handling the new ones from Teams
-    %{state | notifications: []}
+    state
     |> update_hub(connected)
     |> dispatch_secrets(connected)
     |> dispatch_file_systems(connected)
@@ -1105,12 +1126,16 @@ defmodule Livebook.Hubs.TeamClient do
   end
 
   defp dispatch_notifications(state, %{notifications: notifications}) do
-    notifications =
-      notifications
-      |> Enum.map(&build_notification/1)
-      |> filter_notifications()
+    notifications = Enum.map(notifications, &build_notification/1)
 
-    dispatch_events(state, notification_sent: notifications)
+    {created, deleted, updated} =
+      diff(state.notifications, notifications, &(&1.id == &2.id))
+
+    dispatch_events(state,
+      notification_deleted: deleted,
+      notification_sent: created,
+      notification_updated: updated
+    )
   end
 
   defp dispatch_connection(%{hub: %{id: id}} = state) do
@@ -1279,15 +1304,6 @@ defmodule Livebook.Hubs.TeamClient do
   defp authorized_group?(authorization_groups, groups) do
     Enum.any?(authorization_groups, fn %{provider_id: id, group_name: name} ->
       %{"provider_id" => id, "group_name" => name} in groups
-    end)
-  end
-
-  defp filter_notifications(notifications) do
-    # To ensure Livebook doesn't show both version-related notifications,
-    # it must prioritize the unsupported version message.
-    Enum.filter(notifications, fn notification ->
-      not (notification.type == :deprecation) or
-        not Enum.any?(notifications, &(&1.type == :unsupported_version))
     end)
   end
 

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -749,8 +749,7 @@ defmodule Livebook.Hubs.TeamClient do
     %Teams.Notification{
       id: notification.id,
       kind: kind,
-      message: nullify(notification.message),
-      min_version: nullify(notification.min_version)
+      message: nullify(notification.message)
     }
   end
 

--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -25,6 +25,7 @@ defmodule Livebook.Hubs.TeamClient do
     app_deployments: [],
     agents: [],
     app_folders: [],
+    notifications: [],
     app_deployment_statuses: nil
   ]
 
@@ -190,6 +191,16 @@ defmodule Livebook.Hubs.TeamClient do
   @spec get_app_folders(String.t()) :: list(Teams.AppFolder.t())
   def get_app_folders(id) do
     GenServer.call(registry_name(id), :get_app_folders)
+  catch
+    :exit, _ -> []
+  end
+
+  @doc """
+  Returns a list of cached notifications related to this instance.
+  """
+  @spec get_notifications(String.t()) :: list(Teams.Notification.t())
+  def get_notifications(id) do
+    GenServer.call(registry_name(id), :get_notifications)
   catch
     :exit, _ -> []
   end
@@ -401,6 +412,10 @@ defmodule Livebook.Hubs.TeamClient do
 
   def handle_call(:get_app_folders, _caller, state) do
     {:reply, state.app_folders, state}
+  end
+
+  def handle_call(:get_notifications, _caller, state) do
+    {:reply, state.notifications, state}
   end
 
   @impl true
@@ -725,6 +740,16 @@ defmodule Livebook.Hubs.TeamClient do
     }
   end
 
+  defp build_notification(notification) do
+    %Teams.Notification{
+      id: notification.id,
+      kind: notification.kind,
+      type: atomize(notification.type),
+      message: nullify(notification.message),
+      min_version: nullify(notification.min_version)
+    }
+  end
+
   defp handle_event(:secret_created, %Secrets.Secret{} = secret, state) do
     Hubs.Broadcasts.secret_created(secret)
 
@@ -982,8 +1007,16 @@ defmodule Livebook.Hubs.TeamClient do
     end
   end
 
+  defp handle_event(:notification_sent, %Teams.Notification{} = notification, state) do
+    Teams.Broadcasts.notification_sent(notification)
+    notifications = filter_notifications([notification | state.notifications])
+
+    %{state | notifications: notifications}
+  end
+
   defp dispatch_common_connected_events(state, connected) do
-    state
+    # Clear all the notifications before handling the new ones from Teams
+    %{state | notifications: []}
     |> update_hub(connected)
     |> dispatch_secrets(connected)
     |> dispatch_file_systems(connected)
@@ -991,6 +1024,7 @@ defmodule Livebook.Hubs.TeamClient do
     |> dispatch_app_deployments(connected)
     |> dispatch_agents(connected)
     |> dispatch_app_folders(connected)
+    |> dispatch_notifications(connected)
     |> dispatch_connection()
   end
 
@@ -1068,6 +1102,15 @@ defmodule Livebook.Hubs.TeamClient do
       app_folder_created: created,
       app_folder_updated: updated
     )
+  end
+
+  defp dispatch_notifications(state, %{notifications: notifications}) do
+    notifications =
+      notifications
+      |> Enum.map(&build_notification/1)
+      |> filter_notifications()
+
+    dispatch_events(state, notification_sent: notifications)
   end
 
   defp dispatch_connection(%{hub: %{id: id}} = state) do
@@ -1236,6 +1279,15 @@ defmodule Livebook.Hubs.TeamClient do
   defp authorized_group?(authorization_groups, groups) do
     Enum.any?(authorization_groups, fn %{provider_id: id, group_name: name} ->
       %{"provider_id" => id, "group_name" => name} in groups
+    end)
+  end
+
+  defp filter_notifications(notifications) do
+    # To ensure Livebook doesn't show both version-related notifications,
+    # it must prioritize the unsupported version message.
+    Enum.filter(notifications, fn notification ->
+      not (notification.type == :deprecation) or
+        not Enum.any?(notifications, &(&1.type == :unsupported_version))
     end)
   end
 

--- a/lib/livebook/teams.ex
+++ b/lib/livebook/teams.ex
@@ -321,4 +321,20 @@ defmodule Livebook.Teams do
   def get_app_folders(team) do
     Hubs.Provider.get_app_folders(team)
   end
+
+  @doc """
+  Gets a list of notifications from Livebook Teams.
+  """
+  @spec get_notifications() :: list(Teams.Notification.t())
+  def get_notifications do
+    hubs = Hubs.get_hubs()
+
+    if team = Enum.find(hubs, &match?(%Team{}, &1)) do
+      team.id
+      |> TeamClient.get_notifications()
+      |> Enum.sort_by(& &1.id)
+    else
+      []
+    end
+  end
 end

--- a/lib/livebook/teams/broadcasts.ex
+++ b/lib/livebook/teams/broadcasts.ex
@@ -29,6 +29,7 @@ defmodule Livebook.Teams.Broadcasts do
   Topic `#{@clients_topic}`:
 
     * `{:client_connected, id}`
+    * `{:notification_sent, Notification.t()}`
 
   Topic `#{@deployment_groups_topic}`:
 
@@ -65,6 +66,14 @@ defmodule Livebook.Teams.Broadcasts do
   @spec client_connected(String.t()) :: broadcast()
   def client_connected(id) do
     broadcast(@clients_topic, {:client_connected, id})
+  end
+
+  @doc """
+  Broadcasts under `#{@clients_topic}` topic when hub receives a notification.
+  """
+  @spec notification_sent(Teams.Notification.t()) :: broadcast()
+  def notification_sent(%Teams.Notification{} = notification) do
+    broadcast(@clients_topic, {:notification_sent, notification})
   end
 
   @doc """

--- a/lib/livebook/teams/broadcasts.ex
+++ b/lib/livebook/teams/broadcasts.ex
@@ -30,6 +30,8 @@ defmodule Livebook.Teams.Broadcasts do
 
     * `{:client_connected, id}`
     * `{:notification_sent, Notification.t()}`
+    * `{:notification_updated, Notification.t()}`
+    * `{:notification_deleted, Notification.t()}`
 
   Topic `#{@deployment_groups_topic}`:
 
@@ -74,6 +76,22 @@ defmodule Livebook.Teams.Broadcasts do
   @spec notification_sent(Teams.Notification.t()) :: broadcast()
   def notification_sent(%Teams.Notification{} = notification) do
     broadcast(@clients_topic, {:notification_sent, notification})
+  end
+
+  @doc """
+  Broadcasts under `#{@clients_topic}` topic when hub receives an updated notification.
+  """
+  @spec notification_updated(Teams.Notification.t()) :: broadcast()
+  def notification_updated(%Teams.Notification{} = notification) do
+    broadcast(@clients_topic, {:notification_updated, notification})
+  end
+
+  @doc """
+  Broadcasts under `#{@clients_topic}` topic when hub receives a deleted notification.
+  """
+  @spec notification_deleted(Teams.Notification.t()) :: broadcast()
+  def notification_deleted(%Teams.Notification{} = notification) do
+    broadcast(@clients_topic, {:notification_deleted, notification})
   end
 
   @doc """

--- a/lib/livebook/teams/notification.ex
+++ b/lib/livebook/teams/notification.ex
@@ -3,12 +3,8 @@ defmodule Livebook.Teams.Notification do
           id: String.t(),
           message: String.t() | nil,
           kind: String.t(),
-          type: :deprecation | :unsupported_version | atom(),
           min_version: String.t() | nil
         }
 
-  defstruct [:id, :message, :kind, :type, :min_version]
-
-  def version_notification?(%__MODULE__{type: type}),
-    do: type in ~w[deprecation unsupported_version]a
+  defstruct [:id, :message, :kind, :min_version]
 end

--- a/lib/livebook/teams/notification.ex
+++ b/lib/livebook/teams/notification.ex
@@ -8,4 +8,7 @@ defmodule Livebook.Teams.Notification do
         }
 
   defstruct [:id, :message, :kind, :type, :min_version]
+
+  def version_notification?(%__MODULE__{type: type}),
+    do: type in ~w[deprecation unsupported_version]a
 end

--- a/lib/livebook/teams/notification.ex
+++ b/lib/livebook/teams/notification.ex
@@ -2,9 +2,8 @@ defmodule Livebook.Teams.Notification do
   @type t :: %__MODULE__{
           id: String.t(),
           message: String.t() | nil,
-          kind: String.t(),
-          min_version: String.t() | nil
+          kind: String.t()
         }
 
-  defstruct [:id, :message, :kind, :min_version]
+  defstruct [:id, :message, :kind]
 end

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -68,13 +68,7 @@ defmodule Livebook.UpdateCheck do
 
   @impl true
   def handle_call(:get_new_version, _from, state) do
-    version_notification? =
-      Enum.any?(
-        Livebook.Teams.get_notifications(),
-        &Livebook.Teams.Notification.version_notification?/1
-      )
-
-    new_version = if state.enabled and not version_notification?, do: state.new_version
+    new_version = if state.enabled, do: state.new_version
     {:reply, new_version, state}
   end
 

--- a/lib/livebook/update_check.ex
+++ b/lib/livebook/update_check.ex
@@ -68,7 +68,13 @@ defmodule Livebook.UpdateCheck do
 
   @impl true
   def handle_call(:get_new_version, _from, state) do
-    new_version = if state.enabled, do: state.new_version
+    version_notification? =
+      Enum.any?(
+        Livebook.Teams.get_notifications(),
+        &Livebook.Teams.Notification.version_notification?/1
+      )
+
+    new_version = if state.enabled and not version_notification?, do: state.new_version
     {:reply, new_version, state}
   end
 

--- a/lib/livebook_web/components/layout_components.ex
+++ b/lib/livebook_web/components/layout_components.ex
@@ -12,6 +12,7 @@ defmodule LivebookWeb.LayoutComponents do
   attr :current_user, Livebook.Users.User, required: true
   attr :teams_auth, :atom, values: [:online, :offline]
   attr :saved_hubs, :list, required: true
+  attr :notifications, :list, required: true
 
   slot :inner_block, required: true
   slot :topbar_action
@@ -30,6 +31,7 @@ defmodule LivebookWeb.LayoutComponents do
         <.topbar :if={@teams_auth == :offline} variant="warning">
           You are running an offline Workspace for deployment. You cannot modify its settings.
         </.topbar>
+        <.teams_notification :for={notification <- @notifications} notification={notification} />
 
         <div class="md:hidden sticky flex items-center justify-between h-14 px-4 top-0 left-0 z-500 bg-white border-b border-gray-200">
           <div class="pt-1 text-xl text-gray-400 hover:text-gray-600 focus:text-gray-600">
@@ -338,6 +340,34 @@ defmodule LivebookWeb.LayoutComponents do
   defp topbar_class("warning"), do: "bg-yellow-200 text-gray-900"
   defp topbar_class("info"), do: "bg-blue-200 text-gray-900"
   defp topbar_class("error"), do: "bg-red-200 text-gray-900"
+
+  attr :notification, Livebook.Teams.Notification, required: true
+
+  defp teams_notification(%{notification: %{type: :deprecation}} = assigns) do
+    ~H"""
+    <.topbar variant={@notification.kind}>
+      This Livebook version will not be compatible with a future version of Livebook Teams. Please update to
+      <strong>v{@notification.min_version}</strong>
+      or later.
+    </.topbar>
+    """
+  end
+
+  defp teams_notification(%{notification: %{type: :unsupported_version}} = assigns) do
+    ~H"""
+    <.topbar variant={@notification.kind}>
+      This Livebook version is no longer compatible with Livebook Teams. Please update to
+      <strong>v{@notification.min_version}</strong>
+      or later to keep using Teams features.
+    </.topbar>
+    """
+  end
+
+  defp teams_notification(assigns) do
+    ~H"""
+    <.topbar variant={@notification.kind}>{@notification.message}</.topbar>
+    """
+  end
 
   @doc """
   Returns an inline script to inject in dev mode.

--- a/lib/livebook_web/components/layout_components.ex
+++ b/lib/livebook_web/components/layout_components.ex
@@ -343,21 +343,11 @@ defmodule LivebookWeb.LayoutComponents do
 
   attr :notification, Livebook.Teams.Notification, required: true
 
-  defp teams_notification(%{notification: %{type: :deprecation}} = assigns) do
+  defp teams_notification(%{notification: notification} = assigns)
+       when is_binary(notification.min_version) do
     ~H"""
     <.topbar variant={@notification.kind}>
-      This Livebook version will not be compatible with a future version of Livebook Teams. Please update to
-      <strong>v{@notification.min_version}</strong>
-      or later.
-    </.topbar>
-    """
-  end
-
-  defp teams_notification(%{notification: %{type: :unsupported_version}} = assigns) do
-    ~H"""
-    <.topbar variant={@notification.kind}>
-      This Livebook version is no longer compatible with Livebook Teams. Please update to
-      <strong>v{@notification.min_version}</strong>
+      {@notification.message} Please update to <strong>v{@notification.min_version}</strong>
       or later to keep using Teams features.
     </.topbar>
     """

--- a/lib/livebook_web/components/layout_components.ex
+++ b/lib/livebook_web/components/layout_components.ex
@@ -31,7 +31,9 @@ defmodule LivebookWeb.LayoutComponents do
         <.topbar :if={@teams_auth == :offline} variant="warning">
           You are running an offline Workspace for deployment. You cannot modify its settings.
         </.topbar>
-        <.teams_notification :for={notification <- @notifications} notification={notification} />
+        <.topbar :for={notification <- @notifications} variant={notification.kind}>
+          {notification.message}
+        </.topbar>
 
         <div class="md:hidden sticky flex items-center justify-between h-14 px-4 top-0 left-0 z-500 bg-white border-b border-gray-200">
           <div class="pt-1 text-xl text-gray-400 hover:text-gray-600 focus:text-gray-600">
@@ -340,24 +342,6 @@ defmodule LivebookWeb.LayoutComponents do
   defp topbar_class("warning"), do: "bg-yellow-200 text-gray-900"
   defp topbar_class("info"), do: "bg-blue-200 text-gray-900"
   defp topbar_class("error"), do: "bg-red-200 text-gray-900"
-
-  attr :notification, Livebook.Teams.Notification, required: true
-
-  defp teams_notification(%{notification: notification} = assigns)
-       when is_binary(notification.min_version) do
-    ~H"""
-    <.topbar variant={@notification.kind}>
-      {@notification.message} Please update to <strong>v{@notification.min_version}</strong>
-      or later to keep using Teams features.
-    </.topbar>
-    """
-  end
-
-  defp teams_notification(assigns) do
-    ~H"""
-    <.topbar variant={@notification.kind}>{@notification.message}</.topbar>
-    """
-  end
 
   @doc """
   Returns an inline script to inject in dev mode.

--- a/lib/livebook_web/live/apps_dashboard_live.ex
+++ b/lib/livebook_web/live/apps_dashboard_live.ex
@@ -26,6 +26,7 @@ defmodule LivebookWeb.AppsDashboardLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <div class="space-y-2 p-4 md:px-12 md:py-7 max-w-(--breakpoint-lg) mx-auto">
         <div class="flex items-center justify-between">

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -42,6 +42,7 @@ defmodule LivebookWeb.HomeLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <:topbar_action>
         <div class="flex space-x-2">

--- a/lib/livebook_web/live/hooks/sidebar_hook.ex
+++ b/lib/livebook_web/live/hooks/sidebar_hook.ex
@@ -8,13 +8,17 @@ defmodule LivebookWeb.SidebarHook do
   def on_mount(:default, _params, _session, socket) do
     if connected?(socket) do
       Livebook.Hubs.Broadcasts.subscribe([:crud, :connection])
+      Livebook.Teams.Broadcasts.subscribe(:clients)
       LivebookWeb.SessionHelpers.subscribe_to_logout()
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sidebar")
     end
 
+    hubs = Livebook.Hubs.get_metadata()
+    notifications = Livebook.Teams.get_notifications()
+
     socket =
       socket
-      |> assign(saved_hubs: Livebook.Hubs.get_metadata())
+      |> assign(saved_hubs: hubs, notifications: notifications)
       |> attach_hook(:hubs, :handle_info, &handle_info/2)
       |> attach_hook(:shutdown, :handle_info, &handle_info/2)
       |> attach_hook(:shutdown, :handle_event, &handle_event/3)
@@ -47,6 +51,10 @@ defmodule LivebookWeb.SidebarHook do
      socket
      |> assign(saved_hubs: Livebook.Hubs.get_metadata())
      |> put_flash(:error, error)}
+  end
+
+  defp handle_info({:notification_sent, _notification}, socket) do
+    {:cont, assign(socket, notifications: Livebook.Teams.get_notifications())}
   end
 
   defp handle_info(_event, socket), do: {:cont, socket}

--- a/lib/livebook_web/live/hub/edit_live.ex
+++ b/lib/livebook_web/live/hub/edit_live.ex
@@ -42,6 +42,7 @@ defmodule LivebookWeb.Hub.EditLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <.hub_component
         type={@type}

--- a/lib/livebook_web/live/hub/new_live.ex
+++ b/lib/livebook_web/live/hub/new_live.ex
@@ -40,6 +40,7 @@ defmodule LivebookWeb.Hub.NewLive do
       current_user={@current_user}
       saved_hubs={@saved_hubs}
       teams_auth={@teams_auth}
+      notifications={@notifications}
     >
       <LayoutComponents.topbar :if={Livebook.Config.warn_on_live_teams_server?()} variant="warning">
         <strong>Beware!</strong>

--- a/lib/livebook_web/live/learn_live.ex
+++ b/lib/livebook_web/live/learn_live.ex
@@ -29,6 +29,7 @@ defmodule LivebookWeb.LearnLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <div class="p-4 md:px-12 md:py-7 max-w-(--breakpoint-lg) mx-auto space-y-4">
         <div>

--- a/lib/livebook_web/live/open_live.ex
+++ b/lib/livebook_web/live/open_live.ex
@@ -47,6 +47,7 @@ defmodule LivebookWeb.OpenLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <:topbar_action>
         <.button color="blue" navigate={~p"/new"}>

--- a/lib/livebook_web/live/settings_live.ex
+++ b/lib/livebook_web/live/settings_live.ex
@@ -34,6 +34,7 @@ defmodule LivebookWeb.SettingsLive do
       current_user={@current_user}
       teams_auth={@teams_auth}
       saved_hubs={@saved_hubs}
+      notifications={@notifications}
     >
       <div id="settings-page" class="p-4 md:px-12 md:py-7 max-w-(--breakpoint-md) mx-auto space-y-16">
         <div class="flex flex-col space-y-10">

--- a/proto/lib/livebook_proto/notification.pb.ex
+++ b/proto/lib/livebook_proto/notification.pb.ex
@@ -4,5 +4,4 @@ defmodule LivebookProto.Notification do
   field :id, 1, type: :string
   field :message, 2, type: :string
   field :kind, 3, type: :string
-  field :min_version, 4, type: :string, json_name: "minVersion"
 end

--- a/proto/lib/livebook_proto/notification.pb.ex
+++ b/proto/lib/livebook_proto/notification.pb.ex
@@ -4,6 +4,5 @@ defmodule LivebookProto.Notification do
   field :id, 1, type: :string
   field :message, 2, type: :string
   field :kind, 3, type: :string
-  field :type, 4, type: :string
-  field :min_version, 5, type: :string, json_name: "minVersion"
+  field :min_version, 4, type: :string, json_name: "minVersion"
 end

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -255,7 +255,6 @@ message Notification {
   string id = 1;
   string message = 2;
   string kind = 3;
-  string min_version = 4;
 }
 
 message Event {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -255,8 +255,7 @@ message Notification {
   string id = 1;
   string message = 2;
   string kind = 3;
-  string type = 4;
-  string min_version = 5;
+  string min_version = 4;
 }
 
 message Event {

--- a/test/livebook_teams/hubs/team_client_test.exs
+++ b/test/livebook_teams/hubs/team_client_test.exs
@@ -400,6 +400,47 @@ defmodule Livebook.Hubs.TeamClientTest do
       assert_receive {:app_folder_deleted, ^updated_app_folder}
       refute updated_app_folder in TeamClient.get_app_folders(team.id)
     end
+
+    test "dispatches the notifications list",
+         %{team: team, pid: pid, user_connected: user_connected} do
+      notification = build(:notification)
+
+      livebook_proto_notification =
+        %LivebookProto.Notification{
+          id: notification.id,
+          kind: notification.kind,
+          type: to_string(notification.type),
+          message: to_string(notification.message),
+          min_version: to_string(notification.min_version)
+        }
+
+      # appends the notification
+      user_connected = %{user_connected | notifications: [livebook_proto_notification]}
+      refute_received {:notification_sent, ^notification}
+      send(pid, {:event, :user_connected, user_connected})
+      assert_receive {:notification_sent, ^notification}
+      assert notification in TeamClient.get_notifications(team.id)
+
+      # updates the notification
+      updated_notification = %{notification | min_version: "0.19.0"}
+
+      updated_livebook_proto_notification = %{
+        livebook_proto_notification
+        | min_version: updated_notification.min_version
+      }
+
+      user_connected = %{user_connected | notifications: [updated_livebook_proto_notification]}
+      send(pid, {:event, :user_connected, user_connected})
+      assert_receive {:notification_sent, ^updated_notification}
+      refute notification in TeamClient.get_notifications(team.id)
+      assert updated_notification in TeamClient.get_notifications(team.id)
+
+      # deletes the notification
+      user_connected = %{user_connected | notifications: []}
+      send(pid, {:event, :user_connected, user_connected})
+      refute_receive {:notification_sent, ^updated_notification}
+      refute notification in TeamClient.get_notifications(team.id)
+    end
   end
 
   describe "handle agent_connected event" do
@@ -844,6 +885,47 @@ defmodule Livebook.Hubs.TeamClientTest do
       send(pid, {:event, :agent_connected, agent_connected})
       assert_receive {:app_folder_deleted, ^updated_app_folder}
       refute updated_app_folder in TeamClient.get_app_folders(team.id)
+    end
+
+    test "dispatches the notifications list",
+         %{team: team, pid: pid, agent_connected: agent_connected} do
+      notification = build(:notification)
+
+      livebook_proto_notification =
+        %LivebookProto.Notification{
+          id: notification.id,
+          kind: notification.kind,
+          type: to_string(notification.type),
+          message: to_string(notification.message),
+          min_version: to_string(notification.min_version)
+        }
+
+      # appends the notification
+      agent_connected = %{agent_connected | notifications: [livebook_proto_notification]}
+      refute_received {:notification_sent, ^notification}
+      send(pid, {:event, :agent_connected, agent_connected})
+      assert_receive {:notification_sent, ^notification}
+      assert notification in TeamClient.get_notifications(team.id)
+
+      # updates the notification
+      updated_notification = %{notification | min_version: "0.19.0"}
+
+      updated_livebook_proto_notification = %{
+        livebook_proto_notification
+        | min_version: updated_notification.min_version
+      }
+
+      agent_connected = %{agent_connected | notifications: [updated_livebook_proto_notification]}
+      send(pid, {:event, :agent_connected, agent_connected})
+      assert_receive {:notification_sent, ^updated_notification}
+      refute notification in TeamClient.get_notifications(team.id)
+      assert updated_notification in TeamClient.get_notifications(team.id)
+
+      # deletes the notification
+      agent_connected = %{agent_connected | notifications: []}
+      send(pid, {:event, :agent_connected, agent_connected})
+      refute_receive {:notification_sent, ^updated_notification}
+      refute notification in TeamClient.get_notifications(team.id)
     end
   end
 end

--- a/test/livebook_teams/hubs/team_client_test.exs
+++ b/test/livebook_teams/hubs/team_client_test.exs
@@ -409,7 +409,6 @@ defmodule Livebook.Hubs.TeamClientTest do
         %LivebookProto.Notification{
           id: notification.id,
           kind: notification.kind,
-          type: to_string(notification.type),
           message: to_string(notification.message),
           min_version: to_string(notification.min_version)
         }
@@ -431,14 +430,14 @@ defmodule Livebook.Hubs.TeamClientTest do
 
       user_connected = %{user_connected | notifications: [updated_livebook_proto_notification]}
       send(pid, {:event, :user_connected, user_connected})
-      assert_receive {:notification_sent, ^updated_notification}
+      assert_receive {:notification_updated, ^updated_notification}
       refute notification in TeamClient.get_notifications(team.id)
       assert updated_notification in TeamClient.get_notifications(team.id)
 
       # deletes the notification
       user_connected = %{user_connected | notifications: []}
       send(pid, {:event, :user_connected, user_connected})
-      refute_receive {:notification_sent, ^updated_notification}
+      assert_receive {:notification_deleted, ^updated_notification}
       refute notification in TeamClient.get_notifications(team.id)
     end
   end
@@ -895,7 +894,6 @@ defmodule Livebook.Hubs.TeamClientTest do
         %LivebookProto.Notification{
           id: notification.id,
           kind: notification.kind,
-          type: to_string(notification.type),
           message: to_string(notification.message),
           min_version: to_string(notification.min_version)
         }
@@ -917,14 +915,14 @@ defmodule Livebook.Hubs.TeamClientTest do
 
       agent_connected = %{agent_connected | notifications: [updated_livebook_proto_notification]}
       send(pid, {:event, :agent_connected, agent_connected})
-      assert_receive {:notification_sent, ^updated_notification}
+      assert_receive {:notification_updated, ^updated_notification}
       refute notification in TeamClient.get_notifications(team.id)
       assert updated_notification in TeamClient.get_notifications(team.id)
 
       # deletes the notification
       agent_connected = %{agent_connected | notifications: []}
       send(pid, {:event, :agent_connected, agent_connected})
-      refute_receive {:notification_sent, ^updated_notification}
+      assert_receive {:notification_deleted, ^updated_notification}
       refute notification in TeamClient.get_notifications(team.id)
     end
   end

--- a/test/livebook_teams/hubs/team_client_test.exs
+++ b/test/livebook_teams/hubs/team_client_test.exs
@@ -409,8 +409,7 @@ defmodule Livebook.Hubs.TeamClientTest do
         %LivebookProto.Notification{
           id: notification.id,
           kind: notification.kind,
-          message: to_string(notification.message),
-          min_version: to_string(notification.min_version)
+          message: to_string(notification.message)
         }
 
       # appends the notification
@@ -421,11 +420,11 @@ defmodule Livebook.Hubs.TeamClientTest do
       assert notification in TeamClient.get_notifications(team.id)
 
       # updates the notification
-      updated_notification = %{notification | min_version: "0.19.0"}
+      updated_notification = %{notification | message: "Update to 0.19.0"}
 
       updated_livebook_proto_notification = %{
         livebook_proto_notification
-        | min_version: updated_notification.min_version
+        | message: updated_notification.message
       }
 
       user_connected = %{user_connected | notifications: [updated_livebook_proto_notification]}
@@ -894,8 +893,7 @@ defmodule Livebook.Hubs.TeamClientTest do
         %LivebookProto.Notification{
           id: notification.id,
           kind: notification.kind,
-          message: to_string(notification.message),
-          min_version: to_string(notification.min_version)
+          message: to_string(notification.message)
         }
 
       # appends the notification
@@ -906,11 +904,11 @@ defmodule Livebook.Hubs.TeamClientTest do
       assert notification in TeamClient.get_notifications(team.id)
 
       # updates the notification
-      updated_notification = %{notification | min_version: "0.19.0"}
+      updated_notification = %{notification | message: "Update to 0.19.0"}
 
       updated_livebook_proto_notification = %{
         livebook_proto_notification
-        | min_version: updated_notification.min_version
+        | message: updated_notification.message
       }
 
       agent_connected = %{agent_connected | notifications: [updated_livebook_proto_notification]}

--- a/test/livebook_teams/web/admin_live_test.exs
+++ b/test/livebook_teams/web/admin_live_test.exs
@@ -167,19 +167,47 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
     for page <- ["/", "/open", "/settings", "/learn", "/hub", "/apps-dashboard"] do
       @tag page: page, teams_auth: :online
       test "GET #{page} shows the app server instance topbar warning", %{conn: conn, page: page} do
-        {:ok, view, _} = live(conn, page)
+        {:ok, _view, html} = live(conn, page)
 
-        assert render(view) =~
+        assert html =~
                  "This Livebook instance has been configured for notebook deployment and is in read-only mode."
       end
 
       @tag page: page, teams_auth: :offline
       test "GET #{page} shows the offline hub topbar warning", %{conn: conn, page: page} do
-        {:ok, view, _} = live(conn, page)
+        {:ok, _view, html} = live(conn, page)
 
-        assert render(view) =~
+        assert html =~
                  "You are running an offline Workspace for deployment. You cannot modify its settings."
       end
+    end
+  end
+
+  describe "notifications" do
+    setup %{notification_type: type, test: test, team: team} do
+      pid = Livebook.Hubs.TeamClient.get_pid(team.id)
+      notification = build(:notification, id: to_string(test), type: type)
+
+      send(pid, {:event, :notification_sent, notification})
+      assert_receive {:notification_sent, ^notification}
+
+      :ok
+    end
+
+    @tag notification_type: :deprecation
+    test "shows the deprecated version notification", %{conn: conn} do
+      {:ok, view, _} = live(conn, ~p"/")
+
+      assert render(view) =~
+               "This Livebook version will not be compatible with a future version of Livebook Teams."
+    end
+
+    @tag notification_type: :unsupported_version
+    test "shows the unsupported version notification", %{conn: conn} do
+      {:ok, view, _} = live(conn, ~p"/")
+
+      assert render(view) =~
+               "This Livebook version is no longer compatible with Livebook Teams."
     end
   end
 end

--- a/test/livebook_teams/web/admin_live_test.exs
+++ b/test/livebook_teams/web/admin_live_test.exs
@@ -183,31 +183,16 @@ defmodule LivebookWeb.Integration.AdminLiveTest do
     end
   end
 
-  describe "notifications" do
-    setup %{notification_type: type, test: test, team: team} do
-      pid = Livebook.Hubs.TeamClient.get_pid(team.id)
-      notification = build(:notification, id: to_string(test), type: type)
+  test "shows the deprecated version notification", %{conn: conn, team: team} do
+    pid = Livebook.Hubs.TeamClient.get_pid(team.id)
+    notification = build(:notification)
 
-      send(pid, {:event, :notification_sent, notification})
-      assert_receive {:notification_sent, ^notification}
+    send(pid, {:event, :notification_sent, notification})
+    assert_receive {:notification_sent, ^notification}
 
-      :ok
-    end
+    {:ok, view, _} = live(conn, ~p"/")
 
-    @tag notification_type: :deprecation
-    test "shows the deprecated version notification", %{conn: conn} do
-      {:ok, view, _} = live(conn, ~p"/")
-
-      assert render(view) =~
-               "This Livebook version will not be compatible with a future version of Livebook Teams."
-    end
-
-    @tag notification_type: :unsupported_version
-    test "shows the unsupported version notification", %{conn: conn} do
-      {:ok, view, _} = live(conn, ~p"/")
-
-      assert render(view) =~
-               "This Livebook version is no longer compatible with Livebook Teams."
-    end
+    assert render(view) =~
+             "This Livebook version will not be compatible with a future version of Livebook Teams."
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -173,9 +173,9 @@ defmodule Livebook.Factory do
     %Livebook.Teams.Notification{
       id: "1",
       kind: "warning",
-      message: nil,
-      min_version: "0.18.0",
-      type: :deprecation
+      message:
+        "This Livebook version will not be compatible with a future version of Livebook Teams.",
+      min_version: "0.18.0"
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -174,8 +174,7 @@ defmodule Livebook.Factory do
       id: "1",
       kind: "warning",
       message:
-        "This Livebook version will not be compatible with a future version of Livebook Teams.",
-      min_version: "0.18.0"
+        "This Livebook version will not be compatible with a future version of Livebook Teams."
     }
   end
 


### PR DESCRIPTION
This PR aims to implement a way to send notifications to users when they connect to Teams.

These notifications are defined during the Teams deployment; that is, they are not notifications sent while clients are already connected to Teams.

<img width="1327" height="601" alt="image" src="https://github.com/user-attachments/assets/098369c3-a9f3-46a5-b073-d0690c18eadb" />
