### PR TITLE
Version compatibility enforcement between Livebook and Livebook Teams

### DIFF
--- a/lib/livebook/hubs/team_client.ex
+++ b/lib/livebook/hubs/team_client.ex
@@ -18,6 +18,7 @@ defmodule Livebook.Hubs.TeamClient do
     :connection_status,
     :derived_key,
     :deployment_group_id,
+    version_enforcement: nil,
     connected?: false,
     secrets: [],
     file_systems: [],
@@ -203,6 +204,16 @@ defmodule Livebook.Hubs.TeamClient do
     GenServer.call(registry_name(id), :get_notifications)
   catch
     :exit, _ -> []
+  end
+
+  @doc """
+  Returns the Team client version enforcement.
+  """
+  @spec version_enforcement(String.t()) :: String.t() | nil
+  def version_enforcement(id) do
+    GenServer.call(registry_name(id), :version_enforcement)
+  catch
+    :exit, _ -> nil
   end
 
   @doc """
@@ -416,6 +427,10 @@ defmodule Livebook.Hubs.TeamClient do
 
   def handle_call(:get_notifications, _caller, state) do
     {:reply, state.notifications, state}
+  end
+
+  def handle_call(:version_enforcement, _, state) do
+    {:reply, state.version_enforcement, state}
   end
 
   @impl true
@@ -1036,7 +1051,7 @@ defmodule Livebook.Hubs.TeamClient do
   end
 
   defp dispatch_common_connected_events(state, connected) do
-    state
+    %{state | version_enforcement: nullify(connected.min_version_enforcement)}
     |> update_hub(connected)
     |> dispatch_secrets(connected)
     |> dispatch_file_systems(connected)

--- a/lib/livebook/zta/livebook_teams.ex
+++ b/lib/livebook/zta/livebook_teams.ex
@@ -1,6 +1,7 @@
 defmodule Livebook.ZTA.LivebookTeams do
   use LivebookWeb, :verified_routes
 
+  alias Livebook.Hubs
   alias Livebook.Teams
 
   import Plug.Conn
@@ -28,24 +29,32 @@ defmodule Livebook.ZTA.LivebookTeams do
   def authenticate(name, conn, _opts) do
     team = NimbleZTA.get(name)
 
-    case Livebook.Hubs.TeamClient.identity_status(team.id) do
-      :enabled ->
-        handle_request(name, conn, team, conn.params)
+    if version = Hubs.TeamClient.version_enforcement(team.id) do
+      {conn
+       |> put_status(:service_unavailable)
+       |> put_view(LivebookWeb.ErrorHTML)
+       |> render("unsupported_version.html", %{min_version: version})
+       |> halt(), nil}
+    else
+      case Hubs.TeamClient.identity_status(team.id) do
+        :enabled ->
+          handle_request(name, conn, team, conn.params)
 
-      :disabled ->
-        {conn, %{}}
+        :disabled ->
+          {conn, %{}}
 
-      :pending ->
-        {conn
-         |> put_status(:service_unavailable)
-         |> put_view(LivebookWeb.ErrorHTML)
-         |> render("error.html", %{
-           status: 503,
-           details:
-             "This Livebook instance cannot be accessed because it has not yet" <>
-               " established a connection to Livebook Teams."
-         })
-         |> halt(), nil}
+        :pending ->
+          {conn
+           |> put_status(:service_unavailable)
+           |> put_view(LivebookWeb.ErrorHTML)
+           |> render("error.html", %{
+             status: 503,
+             details:
+               "This Livebook instance cannot be accessed because it has not yet" <>
+                 " established a connection to Livebook Teams."
+           })
+           |> halt(), nil}
+      end
     end
   end
 
@@ -240,7 +249,7 @@ defmodule Livebook.ZTA.LivebookTeams do
     } = payload
 
     access_type =
-      if Livebook.Hubs.TeamClient.user_full_access?(hub_id, groups),
+      if Hubs.TeamClient.user_full_access?(hub_id, groups),
         do: :full,
         else: :apps
 

--- a/lib/livebook_web/controllers/error_html.ex
+++ b/lib/livebook_web/controllers/error_html.ex
@@ -35,6 +35,16 @@ defmodule LivebookWeb.ErrorHTML do
     """
   end
 
+  def render("unsupported_version.html", assigns) do
+    ~H"""
+    <.error_page
+      status={503}
+      title="Livebook version not compatible"
+      details={"This Livebook version is no longer compatible with Livebook Teams. Please update this app server to #{@min_version} or later to restore access."}
+    />
+    """
+  end
+
   def render(_template, assigns) do
     ~H"""
     <.error_page

--- a/lib/livebook_web/live/hub/edit/team_component.ex
+++ b/lib/livebook_web/live/hub/edit/team_component.ex
@@ -48,7 +48,8 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
        secret_name: secret_name,
        secret_value: secret_value,
        hub_metadata: Provider.to_metadata(assigns.hub),
-       default?: default?
+       default?: default?,
+       disabled?: Hubs.TeamClient.version_enforcement(assigns.hub.id) != nil
      )
      |> assign_form(changeset)}
   end
@@ -179,7 +180,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
               </.form>
             </div>
 
-            <div class="flex flex-col space-y-4">
+            <div :if={not @disabled?} class="flex flex-col space-y-4">
               <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
                 Secrets
               </h2>
@@ -210,7 +211,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
               </div>
             </div>
 
-            <div class="flex flex-col space-y-4">
+            <div :if={not @disabled?} class="flex flex-col space-y-4">
               <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
                 File storages
               </h2>
@@ -229,7 +230,7 @@ defmodule LivebookWeb.Hub.Edit.TeamComponent do
               />
             </div>
 
-            <div class="flex flex-col space-y-4">
+            <div :if={not @disabled?} class="flex flex-col space-y-4">
               <h2 class="text-xl text-gray-800 font-medium pb-2 border-b border-gray-200">
                 Deployment groups
               </h2>

--- a/proto/lib/livebook_proto/agent_connected.pb.ex
+++ b/proto/lib/livebook_proto/agent_connected.pb.ex
@@ -21,4 +21,5 @@ defmodule LivebookProto.AgentConnected do
   field :billing_status, 10, type: LivebookProto.BillingStatus, json_name: "billingStatus"
   field :app_folders, 11, repeated: true, type: LivebookProto.AppFolder, json_name: "appFolders"
   field :notifications, 12, repeated: true, type: LivebookProto.Notification
+  field :min_version_enforcement, 13, type: :string, json_name: "minVersionEnforcement"
 end

--- a/proto/lib/livebook_proto/user_connected.pb.ex
+++ b/proto/lib/livebook_proto/user_connected.pb.ex
@@ -19,4 +19,5 @@ defmodule LivebookProto.UserConnected do
   field :billing_status, 7, type: LivebookProto.BillingStatus, json_name: "billingStatus"
   field :app_folders, 8, repeated: true, type: LivebookProto.AppFolder, json_name: "appFolders"
   field :notifications, 9, repeated: true, type: LivebookProto.Notification
+  field :min_version_enforcement, 10, type: :string, json_name: "minVersionEnforcement"
 end

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -127,6 +127,7 @@ message UserConnected {
   BillingStatus billing_status = 7;
   repeated AppFolder app_folders = 8;
   repeated Notification notifications = 9;
+  string min_version_enforcement = 10;
 }
 
 message AgentConnected {
@@ -141,6 +142,7 @@ message AgentConnected {
   BillingStatus billing_status = 10;
   repeated AppFolder app_folders = 11;
   repeated Notification notifications = 12;
+  string min_version_enforcement = 13;
 }
 
 message AppDeployment {

--- a/test/livebook_teams/web/hub/edit_live_test.exs
+++ b/test/livebook_teams/web/hub/edit_live_test.exs
@@ -437,6 +437,23 @@ defmodule LivebookWeb.Integration.Hub.EditLiveTest do
       # guarantee the folder were deleted
       refute File.exists?(repo_dir)
     end
+
+    test "hides data if has version enforcement", %{conn: conn, team: team} do
+      # forces the min version enforcement
+      pid = Livebook.Hubs.TeamClient.get_pid(team.id)
+      :sys.replace_state(pid, &Map.replace(&1, :version_enforcement, "0.15.6"))
+
+      {:ok, view, _html} = live(conn, ~p"/hub/#{team.id}")
+
+      # hides the workspace data
+      refute has_element?(view, "#hub-secrets-list")
+      refute has_element?(view, "#hub-file-systems-list")
+      refute has_element?(view, "#add-deployment-group")
+
+      # but keep the general form and danger zone
+      assert has_element?(view, "#team-form")
+      assert has_element?(view, "#delete-hub")
+    end
   end
 
   describe "agent" do

--- a/test/livebook_teams/zta/livebook_teams_test.exs
+++ b/test/livebook_teams/zta/livebook_teams_test.exs
@@ -106,6 +106,20 @@ defmodule Livebook.ZTA.LivebookTeamsTest do
       assert html_response(conn, 200) =~ "window.location.href = "
       refute :erpc.call(metadata_node, :ets, :lookup_element, [test, access_token, 2, nil])
     end
+
+    test "shows unsupported version error page with older livebook version",
+         %{test: test, node: node, team: team} do
+      {conn, _code} = authenticate_user_on_teams(test, node, team)
+
+      # forces the min version enforcement
+      pid = Livebook.Hubs.TeamClient.get_pid(team.id)
+      :sys.replace_state(pid, &Map.replace(&1, :version_enforcement, "0.15.6"))
+
+      assert {%{halted: true} = conn, nil} = LivebookTeams.authenticate(test, conn, [])
+
+      assert html_response(conn, 503) =~
+               "This Livebook version is no longer compatible with Livebook Teams. Please update this app server to 0.15.6 or later to restore access."
+    end
   end
 
   describe "logout/2" do


### PR DESCRIPTION
For users, it will show the notification topbar and will disable the workspace. But for app servers, it will disable the instance entirely regardless of the deployment group configuration.

### App servers

<img width="1450" height="589" alt="image" src="https://github.com/user-attachments/assets/87952da3-ece9-4468-abae-4f0b1d6908df" />


### Workspace for users

<img width="840" height="486" alt="image" src="https://github.com/user-attachments/assets/7ec5cf28-b7e1-4614-a70b-47b0edac6b53" />
