### PR TITLE
docs: fix typo "feautures" -> "features" in Teams intro

### DIFF
--- a/docs/teams/intro_to_teams.md
+++ b/docs/teams/intro_to_teams.md
@@ -4,7 +4,7 @@
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/lwLx5beXxsg?si=husANqYhTc3rXAZS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-Livebook Teams integrates with Livebook, offering the following feautures on top of it:
+Livebook Teams integrates with Livebook, offering the following features on top of it:
 
 - Deploy notebooks as internal apps to your infrastructure
   - [Deploy Livebook apps from Livebook](deploy_app.md)


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## What

Fix a typo in `docs/teams/intro_to_teams.md`: `feautures` → `features`.

Caught by `codespell`:

```
docs/teams/intro_to_teams.md:7: feautures ==> features
```

## Why

Small docs polish on the first visible sentence of the Teams intro page.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal token-burn initiative before my Cursor billing cycle ends. Opened as **draft** for review. Single-file, single-fix scope. Happy to iterate or close if not useful.

Made with [Cursor](https://cursor.com)
