### PR TITLE
Set the pool_timeout to 10s for kubereq

### DIFF
--- a/lib/livebook/k8s_api.ex
+++ b/lib/livebook/k8s_api.ex
@@ -313,6 +313,6 @@ defmodule Livebook.K8sAPI do
   end
 
   defp build_req() do
-    Req.new() |> Livebook.Utils.req_attach_defaults()
+    Req.new(pool_timeout: 10_000) |> Livebook.Utils.req_attach_defaults()
   end
 end


### PR DESCRIPTION
After bumping kubereq, I ran some tests. They failed with Finch being unable unable to provide a connection. Raising the `pool_timeout` fixes this.