### PR TITLE
(Desktop) Fix livebook stdout closed on non-utf8 bytes

### DIFF
--- a/rel/app/src-tauri/src/lib.rs
+++ b/rel/app/src-tauri/src/lib.rs
@@ -336,14 +336,17 @@ impl AppState {
 fn spawn_output_thread(reader: impl Read + Send + 'static, is_stderr: bool) {
     std::thread::spawn(move || {
         let mut reader = BufReader::new(reader);
-        let mut line = String::new();
+        let mut buf = Vec::new();
         loop {
-            line.clear();
-            let bytes = reader.read_line(&mut line).unwrap_or(0);
+            buf.clear();
+            // Note that we should not assume the output is valid UTF-8,
+            // so we read raw bytes and interpret as lossy UTF-8.
+            let bytes = reader.read_until(b'\n', &mut buf).unwrap_or(0);
             if bytes == 0 {
                 break;
             }
 
+            let line = String::from_utf8_lossy(&buf);
             let line = line.trim_end_matches(&['\r', '\n'][..]);
             if is_stderr {
                 if tracing::enabled!(Level::ERROR) {


### PR DESCRIPTION
Closes #3200.

The desktop app spawns the Livebook Elixir node and reads stdout. If an invalid UTF-8 byte appears in the stdout, the reader finishes and effectively closes the pipe for writing. Once the pipe is closed, trying to log to stdout crashes the `:user` process, causing the reported issue. Elixir/Erlang code should not produce a byte like this, however a NIF might print anything.

The error can be reproduced by writing invalid byte directly to stdout descriptor:

```elixir
File.write("/dev/fd/1", <<0xFF>>)
require Logger
Logger.error("Hello")
Logger.error("Hello")
```

Once the stdout is closed, it is corrupted as long as the app is running. When a runtime is restarted, any logging triggers the same `:user` crash.