### PR TITLE
Fix typos in Dockerfile and env script comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG CUDA_VERSION_MAJOR
 ARG CUDA_VERSION_MINOR
 
 RUN distro="ubuntu$(. /etc/lsb-release; echo "$DISTRIB_RELEASE" | tr -d '.')" && \
-  # Official Docker images use the sbsa packages when targetting arm64.
+  # Official Docker images use the sbsa packages when targeting arm64.
   # See https://gitlab.com/nvidia/container-images/cuda/-/blob/85f465ea3343a2d7f7753a0a838701999ed58a01/dist/12.5.1/ubuntu2204/base/Dockerfile#L12
   arch="$(if [ "$(uname -m)" = "aarch64" ]; then echo "sbsa"; else echo "x86_64"; fi)" && \
   apt-get update && apt-get install -y ca-certificates wget && \
@@ -106,7 +106,7 @@ RUN mix local.hex --force && \
 
 # By default Livebook binds to loopback, but in order to make the app
 # accessible outside of the container (by binding ports), we need to
-# bind to any address. Also note that we specify IPv6 address, becuase
+# bind to any address. Also note that we specify IPv6 address, because
 # we want to accept IPv6 connections. This is actually the default in
 # usual Phoenix deployments.
 ENV LIVEBOOK_IP="::"

--- a/rel/server/env.sh.eex
+++ b/rel/server/env.sh.eex
@@ -41,7 +41,7 @@ else
   # we need to set it here. Also there is a very tiny time gap between we
   # start distribution and set the cookie during application boot, so we
   # specifically want the temporary node cookie to be random, rather than
-  # a fixed value. Note that this value is overriden on boot, so other
+  # a fixed value. Note that this value is overridden on boot, so other
   # than being the initial node cookie, we don't really use it.
   export RELEASE_COOKIE="${RELEASE_COOKIE:-$(head -c 512 /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)}"
 


### PR DESCRIPTION
Fixes small comment typos: "targetting" → "targeting" and "becuase" → "because" (`Dockerfile`), "overriden" → "overridden" (`rel/server/env.sh.eex`).