### PR TITLE
Remove quotes from generic font family

### DIFF
--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -31,7 +31,7 @@ body {
 }
 
 @utility font-editor {
-  font-family: "JetBrains Mono", "Droid Sans Mono", "monospace";
+  font-family: "JetBrains Mono", "Droid Sans Mono", monospace;
   font-variant-ligatures: none;
   font-size: 14px;
 }


### PR DESCRIPTION
Generic font families cannot have quotes:

> Generic family names are keywords and must not be quoted.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family#generic-name